### PR TITLE
Add Codex credential manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "compile": "npm run check && node esbuild.mjs",
     "package:vsix": "vsce package",
     "test:real-backend": "node test/realBackendProbe.mjs",
-    "test:smoke": "node test/smokeResponsesClient.mjs && node test/smokeAccountUsage.mjs",
+    "test:smoke": "node test/smokeResponsesClient.mjs && node test/smokeAccountUsage.mjs && node test/smokeAuth.mjs",
     "watch": "tsc -watch -p ./",
     "vscode:prepublish": "npm run compile"
   },
@@ -73,6 +73,22 @@
       {
         "command": "codexModelProvider.refreshAccountLimits",
         "title": "Codex: Refresh Account Limits"
+      },
+      {
+        "command": "codexForCopilot.auth.importAuthJson",
+        "title": "Codex for Copilot: Import Codex auth.json"
+      },
+      {
+        "command": "codexForCopilot.auth.signOut",
+        "title": "Codex for Copilot: Sign Out"
+      },
+      {
+        "command": "codexForCopilot.auth.showStatus",
+        "title": "Codex for Copilot: Show Auth Status"
+      },
+      {
+        "command": "codexForCopilot.auth.signInWithDeviceCode",
+        "title": "Codex for Copilot: Sign in with Device Code"
       }
     ],
     "configuration": {

--- a/src/auth/codexAuthJsonImporter.ts
+++ b/src/auth/codexAuthJsonImporter.ts
@@ -1,0 +1,49 @@
+import type { CodexAuthBundle } from './codexAuthTypes';
+import { InvalidAuthJsonError } from './codexAuthTypes';
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function parseCodexAuthJson(rawJson: string): CodexAuthBundle {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson) as unknown;
+  } catch {
+    throw new InvalidAuthJsonError('Selected file is not valid JSON.');
+  }
+
+  const value = parsed as { auth_mode?: unknown; tokens?: Record<string, unknown>; last_refresh?: unknown };
+  if (!value || typeof value !== 'object') {
+    throw new InvalidAuthJsonError('auth.json must contain a JSON object.');
+  }
+
+  if (value.auth_mode !== 'chatgpt') {
+    throw new InvalidAuthJsonError('Only auth_mode "chatgpt" is supported.');
+  }
+
+  if (!value.tokens || typeof value.tokens !== 'object') {
+    throw new InvalidAuthJsonError('auth.json is missing tokens.');
+  }
+
+  if (!nonEmptyString(value.tokens.id_token)) {
+    throw new InvalidAuthJsonError('auth.json is missing tokens.id_token.');
+  }
+  if (!nonEmptyString(value.tokens.access_token)) {
+    throw new InvalidAuthJsonError('auth.json is missing tokens.access_token.');
+  }
+  if (!nonEmptyString(value.tokens.refresh_token)) {
+    throw new InvalidAuthJsonError('auth.json is missing tokens.refresh_token.');
+  }
+
+  return {
+    auth_mode: 'chatgpt',
+    tokens: {
+      id_token: value.tokens.id_token.trim(),
+      access_token: value.tokens.access_token.trim(),
+      refresh_token: value.tokens.refresh_token.trim(),
+      ...(nonEmptyString(value.tokens.account_id) ? { account_id: value.tokens.account_id.trim() } : {})
+    },
+    last_refresh: nonEmptyString(value.last_refresh) ? value.last_refresh : new Date().toISOString()
+  };
+}

--- a/src/auth/codexAuthLock.ts
+++ b/src/auth/codexAuthLock.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+
+const STALE_LOCK_MS = 60_000;
+const RETRY_DELAY_MS = 150;
+
+export class CodexAuthLock {
+  constructor(private readonly lockUri: vscode.Uri) {}
+
+  async withLock<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      try {
+        await vscode.workspace.fs.delete(this.lockUri);
+      } catch {
+        // Best effort cleanup only.
+      }
+    }
+  }
+
+  private async acquire(): Promise<void> {
+    while (true) {
+      if (!(await this.lockExists())) {
+        await vscode.workspace.fs.writeFile(this.lockUri, Buffer.from(String(Date.now())));
+        return;
+      }
+
+      if (await this.replaceIfStale()) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+    }
+  }
+
+  private async lockExists(): Promise<boolean> {
+    try {
+      await vscode.workspace.fs.stat(this.lockUri);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async replaceIfStale(): Promise<boolean> {
+    try {
+      const stat = await vscode.workspace.fs.stat(this.lockUri);
+      if (Date.now() - stat.mtime <= STALE_LOCK_MS) {
+        return false;
+      }
+      await vscode.workspace.fs.delete(this.lockUri);
+      await vscode.workspace.fs.writeFile(this.lockUri, Buffer.from(String(Date.now())));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/auth/codexAuthManager.ts
+++ b/src/auth/codexAuthManager.ts
@@ -1,0 +1,133 @@
+import * as vscode from 'vscode';
+import { parseCodexAuthJson } from './codexAuthJsonImporter';
+import { CodexAuthLock } from './codexAuthLock';
+import { getJwtExpiration, isJwtExpiringSoon, decodeJwtPayload } from './codexJwt';
+import { CodexSecretStore } from './codexSecretStore';
+import { ACCESS_TOKEN_REFRESH_WINDOW_MS, PERIODIC_REFRESH_INTERVAL_MS, refreshCodexTokens } from './codexTokenRefresh';
+import { AuthRequiredError, CodexAuthBundle, CodexAuthStatus, ReauthRequiredError, TokenRefreshError } from './codexAuthTypes';
+
+export class CodexAuthManager {
+  constructor(
+    private readonly store: CodexSecretStore,
+    private readonly lock: CodexAuthLock
+  ) {}
+
+  async getStatus(): Promise<CodexAuthStatus> {
+    const bundle = await this.store.getAuthBundle();
+    if (!bundle) {
+      return { authenticated: false };
+    }
+
+    const idPayload = safeDecode(bundle.tokens.id_token);
+    return {
+      authenticated: true,
+      email: typeof idPayload.email === 'string' ? idPayload.email : undefined,
+      accountId: bundle.tokens.account_id,
+      accessTokenExpiresAt: getJwtExpiration(bundle.tokens.access_token),
+      lastRefresh: bundle.last_refresh
+    };
+  }
+
+  async importAuthJson(rawJson: string): Promise<void> {
+    await this.store.setAuthBundle(parseCodexAuthJson(rawJson));
+  }
+
+  async getAccessToken(): Promise<string> {
+    const existing = await this.store.getAuthBundle();
+    if (!existing) {
+      throw new AuthRequiredError();
+    }
+
+    await this.refreshIfNeeded('proactive');
+    const latest = await this.store.getAuthBundle();
+    if (!latest) {
+      throw new AuthRequiredError();
+    }
+
+    return latest.tokens.access_token;
+  }
+
+  async refreshIfNeeded(reason: 'proactive' | 'unauthorized' = 'proactive'): Promise<void> {
+    const bundle = await this.store.getAuthBundle();
+    if (!bundle) {
+      throw new AuthRequiredError();
+    }
+
+    if (reason !== 'unauthorized' && !needsRefresh(bundle)) {
+      return;
+    }
+
+    await this.lock.withLock(async () => {
+      const latest = await this.store.getAuthBundle();
+      if (!latest) {
+        throw new AuthRequiredError();
+      }
+      if (reason !== 'unauthorized' && !needsRefresh(latest)) {
+        return;
+      }
+      await this.refreshBundle(latest);
+    });
+  }
+
+  async refreshAfter401(): Promise<void> {
+    try {
+      await this.refreshIfNeeded('unauthorized');
+    } catch (error) {
+      if (error instanceof TokenRefreshError && error.permanent) {
+        void vscode.window.showErrorMessage('Codex credentials expired or were revoked. Please import auth.json again.', 'Import auth.json', 'Sign out').then((action) => {
+          if (action === 'Import auth.json') {
+            void vscode.commands.executeCommand('codexForCopilot.auth.importAuthJson');
+          } else if (action === 'Sign out') {
+            void vscode.commands.executeCommand('codexForCopilot.auth.signOut');
+          }
+        });
+        throw new ReauthRequiredError();
+      }
+      throw error;
+    }
+  }
+
+  async signOut(): Promise<void> {
+    await this.store.deleteAuthBundle();
+  }
+
+  async signInWithDeviceCode(): Promise<void> {
+    await vscode.window.showInformationMessage('Device Code login is planned but not implemented yet. Please import Codex auth.json for now.');
+  }
+
+  private async refreshBundle(bundle: CodexAuthBundle): Promise<void> {
+    const refreshed = await refreshCodexTokens(bundle.tokens.refresh_token);
+    await this.store.setAuthBundle({
+      ...bundle,
+      tokens: {
+        ...bundle.tokens,
+        ...(refreshed.id_token ? { id_token: refreshed.id_token } : {}),
+        ...(refreshed.access_token ? { access_token: refreshed.access_token } : {}),
+        ...(refreshed.refresh_token ? { refresh_token: refreshed.refresh_token } : {})
+      },
+      last_refresh: new Date().toISOString()
+    });
+  }
+}
+
+export function needsRefresh(bundle: CodexAuthBundle): boolean {
+  if (isJwtExpiringSoon(bundle.tokens.access_token, ACCESS_TOKEN_REFRESH_WINDOW_MS)) {
+    return true;
+  }
+
+  if (!bundle.last_refresh) {
+    return true;
+  }
+
+  const lastRefresh = Date.parse(bundle.last_refresh);
+  return !Number.isFinite(lastRefresh) || Date.now() - lastRefresh >= PERIODIC_REFRESH_INTERVAL_MS;
+}
+
+function safeDecode(token: string): Record<string, unknown> {
+  try {
+    const payload = decodeJwtPayload(token);
+    return payload && typeof payload === 'object' && !Array.isArray(payload) ? payload as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}

--- a/src/auth/codexAuthRequest.ts
+++ b/src/auth/codexAuthRequest.ts
@@ -1,0 +1,45 @@
+import { CodexAuthManager } from './codexAuthManager';
+import { ReauthRequiredError } from './codexAuthTypes';
+
+export async function codexFetch(
+  authManager: CodexAuthManager,
+  input: Parameters<typeof fetch>[0],
+  init: RequestInit = {}
+): Promise<Response> {
+  const accessToken = await authManager.getAccessToken();
+  const first = await fetch(input, withAuthorization(init, accessToken));
+  if (first.status !== 401) {
+    return first;
+  }
+
+  await authManager.refreshAfter401();
+  const retryToken = await authManager.getAccessToken();
+  const retry = await fetch(input, withAuthorization(init, retryToken));
+  if (retry.status === 401) {
+    throw new ReauthRequiredError();
+  }
+  return retry;
+}
+
+function withAuthorization(init: RequestInit, token: string): RequestInit {
+  return {
+    ...init,
+    headers: {
+      ...headersToRecord(init.headers),
+      Authorization: `Bearer ${token}`
+    }
+  };
+}
+
+function headersToRecord(headers: RequestInit['headers'] | undefined): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+  return Object.fromEntries(Object.entries(headers).map(([key, value]) => [key, Array.isArray(value) ? value.join(', ') : String(value)]));
+}

--- a/src/auth/codexAuthTypes.ts
+++ b/src/auth/codexAuthTypes.ts
@@ -1,0 +1,63 @@
+export type CodexAuthMode = 'chatgpt';
+
+export interface CodexTokenData {
+  id_token: string;
+  access_token: string;
+  refresh_token: string;
+  account_id?: string;
+}
+
+export interface CodexAuthBundle {
+  auth_mode: CodexAuthMode;
+  tokens: CodexTokenData;
+  last_refresh?: string;
+}
+
+export interface CodexAuthStatus {
+  authenticated: boolean;
+  email?: string;
+  accountId?: string;
+  accessTokenExpiresAt?: number;
+  lastRefresh?: string;
+  reauthRequired?: boolean;
+}
+
+export type CodexAuthState =
+  | 'unauthenticated'
+  | 'authenticated'
+  | 'refreshing'
+  | 'reauthRequired'
+  | 'signingIn';
+
+export class AuthRequiredError extends Error {
+  constructor(message = 'Codex credentials are required.') {
+    super(message);
+    this.name = 'AuthRequiredError';
+  }
+}
+
+export class ReauthRequiredError extends Error {
+  constructor(message = 'Codex credentials expired. Please import auth.json again.') {
+    super(message);
+    this.name = 'ReauthRequiredError';
+  }
+}
+
+export class InvalidAuthJsonError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidAuthJsonError';
+  }
+}
+
+export class TokenRefreshError extends Error {
+  constructor(
+    message: string,
+    public readonly permanent: boolean,
+    public readonly status?: number,
+    public readonly errorCode?: string
+  ) {
+    super(message);
+    this.name = 'TokenRefreshError';
+  }
+}

--- a/src/auth/codexJwt.ts
+++ b/src/auth/codexJwt.ts
@@ -1,0 +1,24 @@
+export function decodeJwtPayload(token: string): unknown {
+  const parts = token.split('.');
+  if (parts.length < 2 || !parts[1]) {
+    throw new Error('Malformed JWT.');
+  }
+
+  const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+  const padded = payload.padEnd(Math.ceil(payload.length / 4) * 4, '=');
+  return JSON.parse(Buffer.from(padded, 'base64').toString('utf8')) as unknown;
+}
+
+export function getJwtExpiration(token: string): number | undefined {
+  try {
+    const payload = decodeJwtPayload(token) as { exp?: unknown };
+    return typeof payload.exp === 'number' && Number.isFinite(payload.exp) ? payload.exp * 1000 : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isJwtExpiringSoon(token: string, windowMs: number): boolean {
+  const expiresAt = getJwtExpiration(token);
+  return expiresAt !== undefined && expiresAt <= Date.now() + windowMs;
+}

--- a/src/auth/codexSecretStore.ts
+++ b/src/auth/codexSecretStore.ts
@@ -1,0 +1,29 @@
+import * as vscode from 'vscode';
+import type { CodexAuthBundle } from './codexAuthTypes';
+
+export const CODEX_AUTH_SECRET_KEY = 'codexForCopilot.codexAuthBundle';
+
+export class CodexSecretStore {
+  constructor(private readonly secrets: vscode.SecretStorage) {}
+
+  async getAuthBundle(): Promise<CodexAuthBundle | undefined> {
+    const raw = await this.secrets.get(CODEX_AUTH_SECRET_KEY);
+    if (!raw) {
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(raw) as CodexAuthBundle;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async setAuthBundle(bundle: CodexAuthBundle): Promise<void> {
+    await this.secrets.store(CODEX_AUTH_SECRET_KEY, JSON.stringify(bundle));
+  }
+
+  async deleteAuthBundle(): Promise<void> {
+    await this.secrets.delete(CODEX_AUTH_SECRET_KEY);
+  }
+}

--- a/src/auth/codexTokenRefresh.ts
+++ b/src/auth/codexTokenRefresh.ts
@@ -1,0 +1,60 @@
+import { TokenRefreshError } from './codexAuthTypes';
+
+export const ACCESS_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+export const PERIODIC_REFRESH_INTERVAL_MS = 8 * 24 * 60 * 60 * 1000;
+
+const REFRESH_URL = 'https://auth.openai.com/oauth/token';
+const CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+const PERMANENT_ERROR_CODES = new Set([
+  'invalid_grant',
+  'refresh_token_expired',
+  'refresh_token_reused',
+  'refresh_token_invalidated',
+  'revoked',
+  'unauthorized_client'
+]);
+
+export interface RefreshResult {
+  id_token?: string;
+  access_token?: string;
+  refresh_token?: string;
+}
+
+export async function refreshCodexTokens(refreshToken: string): Promise<RefreshResult> {
+  let response: Response;
+  try {
+    response = await fetch(REFRESH_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: CODEX_CLIENT_ID,
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken
+      })
+    });
+  } catch (error) {
+    throw new TokenRefreshError('Codex token refresh failed due to a network error.', false);
+  }
+
+  const payload = await readJsonObject(response);
+  if (!response.ok) {
+    const errorCode = typeof payload.error === 'string' ? payload.error : undefined;
+    const permanent = response.status === 400 || response.status === 401 || (errorCode ? PERMANENT_ERROR_CODES.has(errorCode) : false);
+    throw new TokenRefreshError('Codex token refresh failed.', permanent, response.status, errorCode);
+  }
+
+  return {
+    ...(typeof payload.id_token === 'string' && payload.id_token.trim() ? { id_token: payload.id_token.trim() } : {}),
+    ...(typeof payload.access_token === 'string' && payload.access_token.trim() ? { access_token: payload.access_token.trim() } : {}),
+    ...(typeof payload.refresh_token === 'string' && payload.refresh_token.trim() ? { refresh_token: payload.refresh_token.trim() } : {})
+  };
+}
+
+async function readJsonObject(response: Response): Promise<Record<string, unknown>> {
+  try {
+    const payload = (await response.json()) as unknown;
+    return payload && typeof payload === 'object' && !Array.isArray(payload) ? payload as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}

--- a/src/auth/deviceCodeAuthProvider.ts
+++ b/src/auth/deviceCodeAuthProvider.ts
@@ -1,0 +1,12 @@
+export interface DeviceCodeAuthResult {
+  id_token: string;
+  access_token: string;
+  refresh_token: string;
+  account_id?: string;
+}
+
+export class DeviceCodeAuthProvider {
+  async signIn(): Promise<DeviceCodeAuthResult> {
+    throw new Error('Device Code login is not implemented yet.');
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,21 @@
 import * as vscode from 'vscode';
 import { CodexAccountUsageStatusBar } from './accountUsageStatusBar';
 import { CodexModelProvider } from './provider';
+import { CodexAuthLock } from './auth/codexAuthLock';
+import { CodexAuthManager } from './auth/codexAuthManager';
+import { CodexSecretStore } from './auth/codexSecretStore';
+import { InvalidAuthJsonError } from './auth/codexAuthTypes';
 import { clearApiKey, setApiKey } from './secrets';
 
 export function activate(context: vscode.ExtensionContext): void {
   const outputChannel = vscode.window.createOutputChannel('Codex Model Provider', { log: true });
   const accountUsageStatusBar = new CodexAccountUsageStatusBar(context, outputChannel);
-  const provider = new CodexModelProvider(context, outputChannel, undefined, accountUsageStatusBar, accountUsageStatusBar);
+  void vscode.workspace.fs.createDirectory(context.globalStorageUri);
+  const authManager = new CodexAuthManager(
+    new CodexSecretStore(context.secrets),
+    new CodexAuthLock(vscode.Uri.joinPath(context.globalStorageUri, 'codex-auth-refresh.lock'))
+  );
+  const provider = new CodexModelProvider(context, outputChannel, undefined, accountUsageStatusBar, accountUsageStatusBar, authManager);
 
   context.subscriptions.push(
     outputChannel,
@@ -35,17 +44,69 @@ export function activate(context: vscode.ExtensionContext): void {
       await clearApiKey(context);
       vscode.window.showInformationMessage('Responses API key cleared.');
     }),
+    vscode.commands.registerCommand('codexForCopilot.auth.importAuthJson', async () => {
+      const selected = await vscode.window.showOpenDialog({
+        title: 'Import Codex auth.json',
+        canSelectFiles: true,
+        canSelectFolders: false,
+        canSelectMany: false,
+        filters: { JSON: ['json'] }
+      });
+      const uri = selected?.[0];
+      if (!uri) {
+        return;
+      }
+      try {
+        const raw = Buffer.from(await vscode.workspace.fs.readFile(uri)).toString('utf8');
+        await authManager.importAuthJson(raw);
+        const status = await authManager.getStatus();
+        const suffix = status.email ? ` for ${status.email}` : '';
+        vscode.window.showInformationMessage(`Codex credentials imported${suffix}.`);
+      } catch (error) {
+        const message = error instanceof InvalidAuthJsonError ? error.message : 'Failed to import Codex auth.json.';
+        vscode.window.showErrorMessage(message);
+      }
+    }),
+    vscode.commands.registerCommand('codexForCopilot.auth.signOut', async () => {
+      await authManager.signOut();
+      vscode.window.showInformationMessage('Codex credentials removed.');
+    }),
+    vscode.commands.registerCommand('codexForCopilot.auth.showStatus', async () => {
+      const status = await authManager.getStatus();
+      if (!status.authenticated) {
+        vscode.window.showInformationMessage('Codex credentials are not imported.');
+        return;
+      }
+      const details = [
+        status.email ? `Email: ${status.email}` : undefined,
+        status.accountId ? `Account: ${status.accountId}` : undefined,
+        status.accessTokenExpiresAt ? `Access token expires: ${new Date(status.accessTokenExpiresAt).toLocaleString()}` : undefined,
+        status.lastRefresh ? `Last refresh: ${status.lastRefresh}` : undefined
+      ].filter(Boolean).join('\n');
+      vscode.window.showInformationMessage(details || 'Codex credentials are imported.');
+    }),
+    vscode.commands.registerCommand('codexForCopilot.auth.signInWithDeviceCode', async () => {
+      await authManager.signInWithDeviceCode();
+    }),
     vscode.commands.registerCommand('codexModelProvider.refreshAccountLimits', async () => {
       await accountUsageStatusBar.refresh();
       await accountUsageStatusBar.showDetails();
     }),
     vscode.commands.registerCommand('codexModelProvider.manage', async () => {
       const action = await vscode.window.showQuickPick(
-        ['Refresh Account Limits', 'Open Debug Logs', 'Set API Key', 'Clear API Key', 'Open Settings'],
+        ['Import Codex auth.json', 'Show Auth Status', 'Sign Out', 'Sign in with Device Code', 'Refresh Account Limits', 'Open Debug Logs', 'Set API Key', 'Clear API Key', 'Open Settings'],
         { title: 'Codex' }
       );
 
-      if (action === 'Refresh Account Limits') {
+      if (action === 'Import Codex auth.json') {
+        await vscode.commands.executeCommand('codexForCopilot.auth.importAuthJson');
+      } else if (action === 'Show Auth Status') {
+        await vscode.commands.executeCommand('codexForCopilot.auth.showStatus');
+      } else if (action === 'Sign Out') {
+        await vscode.commands.executeCommand('codexForCopilot.auth.signOut');
+      } else if (action === 'Sign in with Device Code') {
+        await vscode.commands.executeCommand('codexForCopilot.auth.signInWithDeviceCode');
+      } else if (action === 'Refresh Account Limits') {
         await vscode.commands.executeCommand('codexModelProvider.refreshAccountLimits');
       } else if (action === 'Open Debug Logs') {
         await vscode.commands.executeCommand('codexModelProvider.openDebugLogs');

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import type { ProviderConfig } from './config';
 import type { ApiCredentials } from './secrets';
 import { normalizeBaseURL } from './responsesClient';
+import { codexFetch } from './auth/codexAuthRequest';
 
 const REASONING_ID_DELIMITER = '::reasoning=';
 const PROVIDER_MODEL_ID_PREFIX = 'codex::';
@@ -110,14 +111,20 @@ export async function fetchAvailableModels(
   const modelsURL = new URL(`${normalizeBaseURL(config.baseURL)}/models`);
   modelsURL.searchParams.set('client_version', config.clientVersion);
 
-  const response = await fetch(modelsURL, {
+  const init = {
     method: 'GET',
-    headers: {
-      Authorization: `Bearer ${credentials.apiKey}`,
-      ...credentials.headers
-    },
+    headers: credentials.headers,
     signal: toAbortSignal(token)
-  });
+  };
+  const response = credentials.authManager
+    ? await codexFetch(credentials.authManager, modelsURL, init)
+    : await fetch(modelsURL, {
+        ...init,
+        headers: {
+          Authorization: `Bearer ${credentials.apiKey}`,
+          ...credentials.headers
+        }
+      });
 
   if (!response.ok) {
     throw new Error(`Model discovery failed with ${response.status} ${response.statusText}`);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -5,6 +5,7 @@ import { getProviderConfig, type ProviderConfig } from './config';
 import { buildFallbackModel, buildProviderModels, fetchAvailableModels, parseModelIdentifier, type ReasoningEffort, type ResolvedProviderModel } from './models';
 import { countInputTokens, normalizeBaseURL, streamResponseText } from './responsesClient';
 import { getApiCredentials } from './secrets';
+import type { CodexAuthManager } from './auth/codexAuthManager';
 
 type RuntimeProvideLanguageModelChatResponseOptions = vscode.ProvideLanguageModelChatResponseOptions & {
   readonly modelConfiguration?: Record<string, unknown>;
@@ -47,7 +48,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     private readonly outputChannel: vscode.LogOutputChannel,
     private readonly usageSink?: UsageSink,
     private readonly accountUsageRefreshSink?: AccountUsageRefreshSink,
-    private readonly selectedModelSink?: SelectedModelSink
+    private readonly selectedModelSink?: SelectedModelSink,
+    private readonly authManager?: CodexAuthManager
   ) {
     this.onDidChangeLanguageModelChatInformation = this.modelInfoChangedEmitter.event;
     this.context.subscriptions.push(
@@ -66,7 +68,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     token: vscode.CancellationToken
   ): Promise<vscode.LanguageModelChatInformation[]> {
     const config = getProviderConfig();
-    const credentials = await getApiCredentials(this.context);
+    const credentials = await getApiCredentials(this.context, this.authManager);
 
     this.outputChannel.debug('provideLanguageModelChatInformation start', {
       silent: options.silent,
@@ -78,15 +80,17 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     if (!credentials) {
       if (!options.silent) {
         const action = await vscode.window.showWarningMessage(
-          'Codex needs Codex credentials. Set an API key in SecretStorage or add credentials to ~/.codex/auth.json.',
-          'Set API Key',
-          'Open Settings'
+          'Codex credentials are required.',
+          { modal: true },
+          'Import auth.json',
+          'Sign in with Device Code',
+          'Cancel'
         );
 
-        if (action === 'Set API Key') {
-          await vscode.commands.executeCommand('codexModelProvider.setApiKey');
-        } else if (action === 'Open Settings') {
-          await vscode.commands.executeCommand('codexModelProvider.openSettings');
+        if (action === 'Import auth.json') {
+          await vscode.commands.executeCommand('codexForCopilot.auth.importAuthJson');
+        } else if (action === 'Sign in with Device Code') {
+          await vscode.commands.executeCommand('codexForCopilot.auth.signInWithDeviceCode');
         }
       }
 
@@ -114,10 +118,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     token: vscode.CancellationToken
   ): Promise<void> {
     const config = getProviderConfig();
-    const credentials = await getApiCredentials(this.context);
+    const credentials = await getApiCredentials(this.context, this.authManager);
 
     if (!credentials) {
-      throw new Error('Codex credentials are missing. Run "Codex: Set API Key" or configure ~/.codex/auth.json.');
+      throw new Error('Codex credentials are missing. Run "Codex for Copilot: Import Codex auth.json".');
     }
 
     const selectedModel = parseModelIdentifier(model.id || config.model);
@@ -216,7 +220,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     token: vscode.CancellationToken
   ): Promise<number> {
     const config = getProviderConfig();
-    const credentials = await getApiCredentials(this.context);
+    const credentials = await getApiCredentials(this.context, this.authManager);
 
     if (!credentials || !supportsOfficialTokenCounting(config.baseURL)) {
       const estimated = estimateTokenCount(text);
@@ -238,6 +242,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         baseURL: config.baseURL,
         apiKey: credentials.apiKey,
         headers: credentials.headers,
+        authManager: credentials.authManager,
         model: selectedModel.requestModel,
         input,
         token

--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -10,6 +10,8 @@ import type { FunctionTool, ResponseUsage, ToolChoiceOptions } from 'openai/reso
 import type { Reasoning } from 'openai/resources/shared';
 import * as vscode from 'vscode';
 import type { ResponsesInputMessage } from './convertMessages';
+import type { CodexAuthManager } from './auth/codexAuthManager';
+import { codexFetch } from './auth/codexAuthRequest';
 
 const OPENAI_DEFAULT_MAX_RETRIES = 2;
 const OPENAI_DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
@@ -18,6 +20,7 @@ export interface CountInputTokensOptions {
   baseURL: string;
   apiKey: string;
   headers?: Record<string, string>;
+  authManager?: CodexAuthManager;
   model: string;
   input: string | ResponsesInputMessage[];
   token: vscode.CancellationToken;
@@ -145,11 +148,10 @@ export async function streamResponseText(options: StreamResponseTextOptions): Pr
 }
 
 export async function countInputTokens(options: CountInputTokensOptions): Promise<number> {
-  const response = await fetch(`${normalizeBaseURL(options.baseURL)}/responses/input_tokens`, {
+  const init = {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${options.apiKey}`,
       ...options.headers
     },
     body: JSON.stringify({
@@ -157,7 +159,16 @@ export async function countInputTokens(options: CountInputTokensOptions): Promis
       input: options.input
     }),
     signal: toAbortSignal(options.token)
-  });
+  };
+  const response = options.authManager
+    ? await codexFetch(options.authManager, `${normalizeBaseURL(options.baseURL)}/responses/input_tokens`, init)
+    : await fetch(`${normalizeBaseURL(options.baseURL)}/responses/input_tokens`, {
+        ...init,
+        headers: {
+          ...init.headers,
+          Authorization: `Bearer ${options.apiKey}`
+        }
+      });
 
   if (!response.ok) {
     const body = await safeReadResponseBody(response);

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import * as vscode from 'vscode';
+import type { CodexAuthManager } from './auth/codexAuthManager';
 
 export const API_KEY_SECRET = 'codexModelProvider.apiKey';
 export const DEFAULT_USER_AGENT = 'local.codex-for-copilot/1.0.1 Codex-Extension';
@@ -10,15 +11,16 @@ export interface ApiCredentials {
   apiKey: string;
   headers: Record<string, string>;
   source: 'secretStorage' | 'codexAuth';
+  authManager?: CodexAuthManager;
   kind: 'codexAccessToken' | 'openaiApiKey';
   omitMaxOutputTokens: boolean;
 }
 
-export async function getApiKey(context: vscode.ExtensionContext): Promise<string | undefined> {
-  return (await getApiCredentials(context))?.apiKey;
+export async function getApiKey(context: vscode.ExtensionContext, authManager?: CodexAuthManager): Promise<string | undefined> {
+  return (await getApiCredentials(context, authManager))?.apiKey;
 }
 
-export async function getApiCredentials(context: vscode.ExtensionContext): Promise<ApiCredentials | undefined> {
+export async function getApiCredentials(context: vscode.ExtensionContext, authManager?: CodexAuthManager): Promise<ApiCredentials | undefined> {
   const credentialSource = vscode.workspace.getConfiguration('codexModelProvider').get<'auto' | 'codexAuth' | 'secretStorage'>('credentialsSource', 'auto');
 
   if (credentialSource === 'secretStorage') {
@@ -26,10 +28,10 @@ export async function getApiCredentials(context: vscode.ExtensionContext): Promi
   }
 
   if (credentialSource === 'codexAuth') {
-    return readCodexAuthCredentials();
+    return readCodexAuthCredentials(authManager);
   }
 
-  const codexCredentials = await readCodexAuthCredentials();
+  const codexCredentials = await readCodexAuthCredentials(authManager);
   if (codexCredentials) {
     return codexCredentials;
   }
@@ -45,7 +47,28 @@ export async function clearApiKey(context: vscode.ExtensionContext): Promise<voi
   await context.secrets.delete(API_KEY_SECRET);
 }
 
-async function readCodexAuthCredentials(): Promise<ApiCredentials | undefined> {
+async function readCodexAuthCredentials(authManager?: CodexAuthManager): Promise<ApiCredentials | undefined> {
+  if (authManager) {
+    try {
+      const status = await authManager.getStatus();
+      const accessToken = await authManager.getAccessToken();
+      const headers: Record<string, string> = { 'User-Agent': DEFAULT_USER_AGENT };
+      if (status.accountId?.trim()) {
+        headers['ChatGPT-Account-ID'] = status.accountId.trim();
+      }
+      return {
+        apiKey: accessToken,
+        headers,
+        source: 'codexAuth',
+        authManager,
+        kind: 'codexAccessToken',
+        omitMaxOutputTokens: true
+      };
+    } catch {
+      // Fall through to legacy file-based discovery for backwards compatibility.
+    }
+  }
+
   try {
     const authPath = join(homedir(), '.codex', 'auth.json');
     const raw = await readFile(authPath, 'utf8');

--- a/test/smokeAuth.mjs
+++ b/test/smokeAuth.mjs
@@ -1,0 +1,109 @@
+import { createRequire } from 'node:module';
+import Module from 'node:module';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { build } from 'esbuild';
+
+const tempDir = await mkdtemp(join(tmpdir(), 'codex-for-copilot-auth-'));
+const bundlePath = join(tempDir, 'auth.cjs');
+const entryPath = join(tempDir, 'auth-entry.ts');
+const require = createRequire(import.meta.url);
+const moduleLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'vscode') {
+    return {
+      window: { showErrorMessage: async () => undefined, showInformationMessage: async () => undefined },
+      commands: { executeCommand: async () => undefined }
+    };
+  }
+  return moduleLoad.call(this, request, parent, isMain);
+};
+await import('node:fs/promises').then(({ writeFile }) => writeFile(entryPath, `
+export * from '${process.cwd()}/src/auth/codexAuthJsonImporter';
+export * from '${process.cwd()}/src/auth/codexJwt';
+export * from '${process.cwd()}/src/auth/codexAuthManager';
+export * from '${process.cwd()}/src/auth/codexAuthRequest';
+`));
+
+await build({
+  entryPoints: [entryPath],
+  bundle: true,
+  format: 'cjs',
+  platform: 'node',
+  target: 'node20',
+  outfile: bundlePath,
+  external: ['vscode']
+});
+
+try {
+  const auth = require(bundlePath);
+  const futureToken = jwt({ exp: Math.floor(Date.now() / 1000) + 3600, email: 'user@example.com' });
+  const soonToken = jwt({ exp: Math.floor(Date.now() / 1000) + 60 });
+  const valid = auth.parseCodexAuthJson(JSON.stringify({
+    auth_mode: 'chatgpt',
+    tokens: {
+      id_token: futureToken,
+      access_token: futureToken,
+      refresh_token: 'refresh-token',
+      account_id: 'acct_1'
+    },
+    OPENAI_API_KEY: 'ignored'
+  }));
+
+  assertEqual(valid.auth_mode, 'chatgpt', 'auth mode');
+  assertEqual(valid.tokens.refresh_token, 'refresh-token', 'refresh token');
+  assertEqual('OPENAI_API_KEY' in valid, false, 'extra fields ignored');
+  assertThrows(() => auth.parseCodexAuthJson('{'), 'malformed JSON rejected');
+  assertThrows(() => auth.parseCodexAuthJson(JSON.stringify({ auth_mode: 'api', tokens: {} })), 'unsupported mode rejected');
+  assertThrows(() => auth.parseCodexAuthJson(JSON.stringify({ auth_mode: 'chatgpt', tokens: { id_token: 'a', access_token: 'b' } })), 'missing refresh token rejected');
+
+  assertEqual(auth.getJwtExpiration(futureToken), JSON.parse(Buffer.from(futureToken.split('.')[1], 'base64url').toString()).exp * 1000, 'jwt expiration');
+  assertEqual(auth.getJwtExpiration('not-a-jwt'), undefined, 'malformed jwt expiration');
+  assertEqual(auth.isJwtExpiringSoon(soonToken, 5 * 60 * 1000), true, 'expiring soon');
+  assertEqual(auth.needsRefresh({ ...valid, tokens: { ...valid.tokens, access_token: soonToken } }), true, 'refresh when access token expires soon');
+  assertEqual(auth.needsRefresh({ ...valid, last_refresh: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000).toISOString() }), true, 'refresh when last_refresh is old');
+
+  let calls = 0;
+  const manager = {
+    async getAccessToken() {
+      calls += 1;
+      return calls === 1 ? 'old-token' : 'new-token';
+    },
+    async refreshAfter401() {
+      calls += 10;
+    }
+  };
+  const seenAuth = [];
+  globalThis.fetch = async (_input, init) => {
+    seenAuth.push(init.headers.Authorization);
+    return new Response('', { status: seenAuth.length === 1 ? 401 : 200 });
+  };
+  const response = await auth.codexFetch(manager, 'http://example.test', {});
+  assertEqual(response.status, 200, '401 retry succeeds');
+  assertEqual(JSON.stringify(seenAuth), JSON.stringify(['Bearer old-token', 'Bearer new-token']), 'retry uses refreshed token');
+
+  console.log('Smoke test passed: auth import, JWT parsing, refresh decisions, and 401 retry are correct.');
+} finally {
+  Module._load = moduleLoad;
+  await rm(tempDir, { recursive: true, force: true });
+}
+
+function jwt(payload) {
+  return ['header', Buffer.from(JSON.stringify(payload)).toString('base64url'), 'signature'].join('.');
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertThrows(fn, label) {
+  try {
+    fn();
+  } catch {
+    return;
+  }
+  throw new Error(`${label}: expected throw`);
+}


### PR DESCRIPTION
### Motivation
- Provide a secure, Codex-compatible credential manager so the extension can import ChatGPT-style `auth.json`, persist tokens in VS Code `SecretStorage`, refresh tokens proactively and on 401, and leave an interface for future Device Code login.

### Description
- Add typed auth primitives and errors in `src/auth/codexAuthTypes.ts` and a SecretStorage-backed store in `src/auth/codexSecretStore.ts` to persist a normalized `CodexAuthBundle` under the key `codexForCopilot.codexAuthBundle`.
- Implement an import/validation flow in `src/auth/codexAuthJsonImporter.ts` and lightweight JWT helpers in `src/auth/codexJwt.ts` for expiry detection and metadata display.
- Implement token refresh logic against `https://auth.openai.com/oauth/token` in `src/auth/codexTokenRefresh.ts`, a cross-window refresh lock in `src/auth/codexAuthLock.ts`, and `CodexAuthManager` in `src/auth/codexAuthManager.ts` to orchestrate import, proactive refresh, forced post-401 refresh, sign-out, and the Device Code placeholder.
- Provide a request wrapper `codexFetch` in `src/auth/codexAuthRequest.ts` that attaches bearer tokens and retries once after a 401, and wire the auth manager into provider paths (`src/secrets.ts`, `src/models.ts`, `src/responsesClient.ts`, `src/provider.ts`) while preserving legacy file/API-key fallbacks.
- Add a reserved `DeviceCodeAuthProvider` stub and register commands `codexForCopilot.auth.importAuthJson`, `codexForCopilot.auth.signOut`, `codexForCopilot.auth.showStatus`, and `codexForCopilot.auth.signInWithDeviceCode`, plus a smoke test `test/smokeAuth.mjs` and package manifest updates.

### Testing
- Ran `npm run check` (TypeScript type check) and it completed successfully.
- Ran `npm run test:smoke` (existing smoke tests plus `test/smokeAuth.mjs`) and all smoke tests passed, including auth import/JWT/401-retry scenarios.
- Ran `npm run compile` (type-check + build) and the compile step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4f94e03483249c777e564ee1acec)