### PR TITLE
Recover from missing previous responses

### DIFF
--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -27,6 +27,8 @@ const MAX_REUSABLE_WEBSOCKETS = 32;
 const WEBSOCKET_OPEN = 1;
 const WEBSOCKET_CLOSING = 2;
 const WEBSOCKET_CLOSED = 3;
+const PREVIOUS_RESPONSE_NOT_FOUND_CODE = 'previous_response_not_found';
+const PREVIOUS_RESPONSE_NOT_FOUND_DEFAULT_MESSAGE = 'Responses API previous_response_id was not found.';
 
 interface ReusableResponsesWebSocketSession {
   socket: ResponsesWS;
@@ -140,6 +142,21 @@ export async function streamResponseText(options: StreamResponseTextOptions): Pr
       return;
     }
 
+    if (isResponsesContinuationMissError(error)) {
+      throw error;
+    }
+
+    if (options.previousResponseId) {
+      const continuationMissMessage = getPreviousResponseNotFoundMessage(error);
+      if (continuationMissMessage) {
+        throw new ResponsesContinuationMissError(
+          continuationMissMessage,
+          options.previousResponseId,
+          { cause: error }
+        );
+      }
+    }
+
     throw normalizeResponsesError(error, options.baseURL);
   } finally {
     cancellation.dispose();
@@ -242,10 +259,13 @@ async function streamResponseTextOverWebSocket(
           );
         }
 
-        if (options.previousResponseId && isPreviousResponseNotFoundError(streamEvent.error.error?.code, streamEvent.error.error?.message)) {
+        const continuationMissMessage = options.previousResponseId
+          ? getPreviousResponseNotFoundMessage(streamEvent.error)
+          : undefined;
+        if (options.previousResponseId && continuationMissMessage) {
           releaseReusableWebSocketSession(session, undefined, false);
           throw new ResponsesContinuationMissError(
-            streamEvent.error.error?.message ?? streamEvent.error.message,
+            continuationMissMessage,
             options.previousResponseId,
             { cause: streamEvent.error }
           );
@@ -482,9 +502,12 @@ function handleResponsesServerEvent(event: ResponsesServerEvent, options: Stream
       );
     }
 
-    if (options.previousResponseId && isPreviousResponseNotFoundError(error?.code, error?.message)) {
+    const continuationMissMessage = options.previousResponseId
+      ? getPreviousResponseNotFoundMessage(error)
+      : undefined;
+    if (options.previousResponseId && continuationMissMessage) {
       throw new ResponsesContinuationMissError(
-        error?.message ?? 'Responses API previous_response_id was not found.',
+        continuationMissMessage,
         options.previousResponseId
       );
     }
@@ -657,12 +680,58 @@ function parseToolCallInput(argumentsJson: string): object {
   }
 }
 
-function isPreviousResponseNotFoundError(code: unknown, message: unknown): boolean {
-  if (code === 'previous_response_not_found') {
-    return true;
+function getPreviousResponseNotFoundMessage(error: unknown): string | undefined {
+  const visited = new Set<object>();
+
+  const visit = (value: unknown): { matched: boolean; message?: string } => {
+    if (typeof value === 'string') {
+      const message = value.trim();
+      return message.includes(PREVIOUS_RESPONSE_NOT_FOUND_CODE)
+        ? { matched: true, message }
+        : { matched: false };
+    }
+
+    if (!value || typeof value !== 'object' || visited.has(value)) {
+      return { matched: false };
+    }
+
+    visited.add(value);
+    const record = value as Partial<Record<'code' | 'message' | 'error' | 'cause', unknown>>;
+    const message = typeof record.message === 'string' && record.message.trim()
+      ? record.message.trim()
+      : undefined;
+    const nestedError = visit(record.error);
+
+    if (nestedError.matched) {
+      return {
+        matched: true,
+        message: nestedError.message ?? message
+      };
+    }
+
+    if (record.code === PREVIOUS_RESPONSE_NOT_FOUND_CODE) {
+      return { matched: true, message };
+    }
+
+    const nestedCause = visit(record.cause);
+    if (nestedCause.matched) {
+      return {
+        matched: true,
+        message: nestedCause.message ?? message
+      };
+    }
+
+    return message?.includes(PREVIOUS_RESPONSE_NOT_FOUND_CODE)
+      ? { matched: true, message }
+      : { matched: false };
+  };
+
+  const match = visit(error);
+  if (!match.matched) {
+    return undefined;
   }
 
-  return typeof message === 'string' && message.includes('previous_response_not_found');
+  return match.message ?? PREVIOUS_RESPONSE_NOT_FOUND_DEFAULT_MESSAGE;
 }
 
 function normalizeResponsesError(error: unknown, baseURL: string): Error {

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -145,6 +145,7 @@ Module._load = function patchedLoad(request, parent, isMain) {
 const { CodexModelProvider } = require(bundlePath);
 
 try {
+  await runProviderContinuationMissRecoverySmokeTest();
   await runProviderFallbackSmokeTest();
   await runProviderCatalogVersionNeutralSmokeTest();
   await runProviderUnavailableScopeSmokeTest();
@@ -153,6 +154,144 @@ try {
 } finally {
   Module._load = moduleLoad;
   await rm(tempDir, { recursive: true, force: true });
+}
+
+async function runProviderContinuationMissRecoverySmokeTest() {
+  const responseRequests = [];
+  const warnings = [];
+  const recoveredOutput = [];
+  const staleResponseId = 'resp_stale_continuation';
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol', { multi_agent_version: 'v2' })]
+      }));
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+
+    const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    responseRequests.push(body);
+
+    if (responseRequests.length === 1) {
+      writeSseResponse(response, staleResponseId, 'seeded');
+      return;
+    }
+
+    if (responseRequests.length === 2) {
+      response.writeHead(400, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        error: {
+          type: 'invalid_request_error',
+          code: 'previous_response_not_found',
+          message: `Previous response ${staleResponseId} was not found.`,
+          param: 'previous_response_id'
+        }
+      }));
+      return;
+    }
+
+    if (responseRequests.length === 3) {
+      writeSseResponse(response, 'resp_recovered', 'recovered');
+      return;
+    }
+
+    response.writeHead(500, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ error: { message: 'unexpected extra response request' } }));
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+
+  const provider = new CodexModelProvider(
+    {
+      secrets: {
+        async get() {
+          return 'test-api-key';
+        }
+      },
+      subscriptions: []
+    },
+    {
+      debug() {},
+      info() {},
+      warn(message, payload) {
+        warnings.push({ message, payload });
+      },
+      error() {}
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected sol model for continuation recovery test.');
+    }
+
+    const firstMessage = {
+      role: vscodeMock.LanguageModelChatMessageRole.User,
+      content: [new vscodeMock.LanguageModelTextPart('First turn')]
+    };
+    const secondMessage = {
+      role: vscodeMock.LanguageModelChatMessageRole.User,
+      content: [new vscodeMock.LanguageModelTextPart('Second turn')]
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [firstMessage],
+      {},
+      { report() {} },
+      token
+    );
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [firstMessage, secondMessage],
+      {},
+      {
+        report(part) {
+          if (part instanceof vscodeMock.LanguageModelTextPart) {
+            recoveredOutput.push(part.value);
+          }
+        }
+      },
+      token
+    );
+
+    const fullInput = [
+      { role: 'user', content: 'First turn', type: 'message' },
+      { role: 'user', content: 'Second turn', type: 'message' }
+    ];
+    const continuationInput = [{ role: 'user', content: 'Second turn', type: 'message' }];
+    const resetWarnings = warnings.filter((entry) => entry.message === 'response continuation reset');
+
+    assertEqual(responseRequests.length, 3, 'continuation recovery response request count');
+    assertEqual(JSON.stringify(responseRequests[0].input), JSON.stringify(fullInput.slice(0, 1)), 'seed request full input');
+    assertEqual('previous_response_id' in responseRequests[0], false, 'seed request omits previous response id');
+    assertEqual(JSON.stringify(responseRequests[1].input), JSON.stringify(continuationInput), 'continuation request delta input');
+    assertEqual(responseRequests[1].previous_response_id, staleResponseId, 'continuation request stale response id');
+    assertEqual(JSON.stringify(responseRequests[2].input), JSON.stringify(fullInput), 'recovery request full input');
+    assertEqual('previous_response_id' in responseRequests[2], false, 'recovery request omits stale response id');
+    assertEqual(resetWarnings.length, 1, 'continuation reset warning count');
+    assertEqual(resetWarnings[0].payload.previousResponseId, staleResponseId, 'continuation reset warning response id');
+    assertEqual(recoveredOutput.join(''), 'recovered', 'continuation recovered output');
+  } finally {
+    server.close();
+  }
 }
 
 async function runProviderFallbackSmokeTest() {
@@ -545,4 +684,16 @@ function createOutputChannel() {
     warn() {},
     error() {}
   };
+}
+
+function writeSseResponse(response, responseId, delta) {
+  response.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive'
+  });
+  response.write(`data: ${JSON.stringify({ type: 'response.output_text.delta', delta })}\n\n`);
+  response.write(`data: ${JSON.stringify({ type: 'response.completed', response: { id: responseId, object: 'response', status: 'completed' } })}\n\n`);
+  response.write('data: [DONE]\n\n');
+  response.end();
 }

--- a/test/smokeResponsesClient.mjs
+++ b/test/smokeResponsesClient.mjs
@@ -34,13 +34,23 @@ Module._load = function patchedLoad(request, parent, isMain) {
   return moduleLoad.call(this, request, parent, isMain);
 };
 
-const { disposeReusableResponsesWebSockets, streamResponseText } = require(bundlePath);
+const {
+  disposeReusableResponsesWebSockets,
+  isResponsesContinuationMissError,
+  streamResponseText
+} = require(bundlePath);
 
 try {
   await runHttpTransportSmokeTest(streamResponseText);
+  await runHttpContinuationMissSmokeTest(streamResponseText, isResponsesContinuationMissError);
   await runAutoFallbackSmokeTest(streamResponseText);
   await runWebSocketTransportSmokeTest(streamResponseText);
   await runWebSocketContinuationSmokeTest(streamResponseText);
+  await runWebSocketContinuationMissSmokeTest(
+    streamResponseText,
+    isResponsesContinuationMissError,
+    disposeReusableResponsesWebSockets
+  );
   await runWebSocketSequentialReuseSmokeTest(streamResponseText);
 
   console.log('Smoke tests passed: HTTP, auto fallback, and WebSocket transports are correct.');
@@ -92,6 +102,61 @@ async function runHttpTransportSmokeTest(streamResponseText) {
 
     assertHttpRequest(capturedRequest, '/backend-api/codex/responses');
     assertEqual(deltas.join(''), 'hello world', 'HTTP streamed text');
+  } finally {
+    server.close();
+  }
+}
+
+async function runHttpContinuationMissSmokeTest(streamResponseText, isResponsesContinuationMissError) {
+  let capturedRequest;
+  const backendMessage = 'Previous response resp_missing_http was not found.';
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+
+    capturedRequest = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    response.writeHead(400, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({
+      error: {
+        type: 'invalid_request_error',
+        code: 'previous_response_not_found',
+        message: backendMessage,
+        param: 'previous_response_id'
+      }
+    }));
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const address = server.address();
+    let rejectedError;
+
+    try {
+      await streamResponseText({
+        baseURL: `http://127.0.0.1:${address.port}/backend-api/codex/responses`,
+        apiKey: 'test-api-key',
+        headers: createHeaders(),
+        transport: 'http',
+        previousResponseId: 'resp_missing_http',
+        omitMaxOutputTokens: true,
+        model: 'gpt-5.5',
+        instructions: 'Smoke test instructions',
+        input: [{ role: 'user', content: 'Only the delta' }],
+        maxOutputTokens: 32,
+        token: createCancellationToken(),
+        onTextDelta() {}
+      });
+    } catch (error) {
+      rejectedError = error;
+    }
+
+    assertEqual(capturedRequest.previous_response_id, 'resp_missing_http', 'HTTP continuation request id');
+    assertEqual(isResponsesContinuationMissError(rejectedError), true, 'HTTP continuation miss type guard');
+    assertEqual(rejectedError?.previousResponseId, 'resp_missing_http', 'HTTP rejected response id');
+    assertEqual(rejectedError?.message, backendMessage, 'HTTP continuation miss message');
   } finally {
     server.close();
   }
@@ -366,6 +431,83 @@ async function runWebSocketSequentialReuseSmokeTest(streamResponseText) {
     assertEqual(sessionEvents[0].reused, false, 'sequential reuse first session state');
     assertEqual(sessionEvents[1].reused, true, 'sequential reuse second session state');
   } finally {
+    webSocketServer.close();
+    server.close();
+  }
+}
+
+async function runWebSocketContinuationMissSmokeTest(
+  streamResponseText,
+  isResponsesContinuationMissError,
+  disposeReusableResponsesWebSockets
+) {
+  let capturedClientEvent;
+  let httpRequestCount = 0;
+  const fallbackEvents = [];
+  const backendMessage = 'Previous response resp_missing_ws was not found.';
+  const server = createServer((_request, response) => {
+    httpRequestCount += 1;
+    response.writeHead(500, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ error: { message: 'HTTP fallback must not be attempted.' } }));
+  });
+  const webSocketServer = new WebSocketServer({ noServer: true });
+
+  server.on('upgrade', (request, socket, head) => {
+    webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+      webSocketServer.emit('connection', webSocket, request);
+    });
+  });
+
+  webSocketServer.on('connection', (webSocket) => {
+    webSocket.once('message', (data) => {
+      capturedClientEvent = JSON.parse(data.toString('utf8'));
+      webSocket.send(JSON.stringify({
+        type: 'error',
+        error: {
+          type: 'invalid_request_error',
+          code: 'previous_response_not_found',
+          message: backendMessage,
+          param: 'previous_response_id'
+        },
+        status: 400
+      }));
+    });
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const address = server.address();
+    let rejectedError;
+
+    try {
+      await streamResponseText({
+        baseURL: `http://127.0.0.1:${address.port}/backend-api/codex/responses`,
+        apiKey: 'test-api-key',
+        headers: createHeaders(),
+        transport: 'auto',
+        previousResponseId: 'resp_missing_ws',
+        omitMaxOutputTokens: true,
+        model: 'gpt-5.5',
+        instructions: 'Smoke test instructions',
+        input: [{ role: 'user', content: 'Only the delta' }],
+        maxOutputTokens: 32,
+        token: createCancellationToken(),
+        onTextDelta() {},
+        onTransportFallback: (event) => fallbackEvents.push(event)
+      });
+    } catch (error) {
+      rejectedError = error;
+    }
+
+    assertEqual(capturedClientEvent.previous_response_id, 'resp_missing_ws', 'WebSocket continuation request id');
+    assertEqual(isResponsesContinuationMissError(rejectedError), true, 'WebSocket continuation miss type guard');
+    assertEqual(rejectedError?.previousResponseId, 'resp_missing_ws', 'WebSocket rejected response id');
+    assertEqual(rejectedError?.message, backendMessage, 'WebSocket continuation miss message');
+    assertEqual(fallbackEvents.length, 0, 'structured WebSocket error fallback event count');
+    assertEqual(httpRequestCount, 0, 'structured WebSocket error HTTP fallback request count');
+  } finally {
+    disposeReusableResponsesWebSockets();
     webSocketServer.close();
     server.close();
   }


### PR DESCRIPTION
## Summary

- recognize `previous_response_not_found` through OpenAI SDK HTTP and WebSocket error wrappers
- preserve structured WebSocket API errors without triggering HTTP fallback
- let the existing provider invalidate the stale branch and retry once with full input
- add transport-level and provider-level regression coverage

## Why

The backend can stop resolving a locally cached response ID, especially with `store: false` and WebSocket connection-local state. The provider already had the correct full-context recovery path, but nested SDK error wrappers could bypass its typed continuation-miss handling and surface a raw failure to VS Code.

## Validation

- `npm run check`
- `npm run compile`
- `npm run test:smoke`

Closes #7