### PR TITLE
Fix HTTP continuation recovery

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,6 @@
+failed.md
+*.log
+*.vsix
 .git/**
 .github/**
 .gitignore

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -343,16 +343,19 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         requestModel: selectedModel.requestModel,
         branchId: reusableBranch?.branchId ?? null,
         previousResponseId: initialPreviousResponseId,
-        reason: error.message
+        reason: error.message,
+        reuseDisabledUntilExpiry: error.disableReuseUntilExpiry
       });
 
-      this.outputChannel.warn('response reuse temporarily disabled until next full-input success', {
+      this.outputChannel.warn(error.disableReuseUntilExpiry
+        ? 'response reuse disabled until branch cache expiry after HTTP continuation rejection'
+        : 'response reuse temporarily disabled until next full-input success', {
         requestModel: selectedModel.requestModel,
         previousResponseId: initialPreviousResponseId,
         branchId: reusableBranch?.branchId ?? null
       });
 
-      this.responseBranchStore.disableReuse(reuseEnvelope);
+      this.responseBranchStore.disableReuse(reuseEnvelope, !error.disableReuseUntilExpiry);
       this.responseBranchStore.invalidateResponseId(initialPreviousResponseId);
 
       if (reusableBranch) {

--- a/src/responseBranchStore.ts
+++ b/src/responseBranchStore.ts
@@ -37,6 +37,11 @@ export interface ResponseBranchToolCompatibility {
   changedToolNames: string[];
 }
 
+interface DisabledResponseBranchReuse {
+  disabledAt: number;
+  enableAfterFullInputSuccess: boolean;
+}
+
 interface ResponseBranchEntry {
   id: string;
   envelope: ResponseBranchReuseEnvelope;
@@ -48,7 +53,7 @@ interface ResponseBranchEntry {
 
 export class ResponseBranchStore {
   private readonly branches = new Map<string, ResponseBranchEntry>();
-  private readonly disabledReuseKeys = new Map<string, number>();
+  private readonly disabledReuseKeys = new Map<string, DisabledResponseBranchReuse>();
   private nextBranchId = 1;
 
   constructor(
@@ -141,7 +146,9 @@ export class ResponseBranchStore {
     branchId?: string
   ): string {
     this.evictExpiredEntries();
-    this.disabledReuseKeys.delete(envelope.identityKey);
+    if (this.disabledReuseKeys.get(envelope.identityKey)?.enableAfterFullInputSuccess) {
+      this.disabledReuseKeys.delete(envelope.identityKey);
+    }
     const continuationInput = projectResponsesInputForContinuation(currentInput);
 
     if (branchId) {
@@ -197,9 +204,12 @@ export class ResponseBranchStore {
     }
   }
 
-  disableReuse(envelope: ResponseBranchReuseEnvelope): void {
+  disableReuse(envelope: ResponseBranchReuseEnvelope, enableAfterFullInputSuccess = true): void {
     this.evictExpiredEntries();
-    this.disabledReuseKeys.set(envelope.identityKey, Date.now());
+    this.disabledReuseKeys.set(envelope.identityKey, {
+      disabledAt: Date.now(),
+      enableAfterFullInputSuccess
+    });
   }
 
   private evictExpiredEntries(): void {
@@ -211,8 +221,8 @@ export class ResponseBranchStore {
       }
     }
 
-    for (const [reuseKey, disabledAt] of this.disabledReuseKeys.entries()) {
-      if (now - disabledAt > this.ttlMs) {
+    for (const [reuseKey, disabled] of this.disabledReuseKeys.entries()) {
+      if (now - disabled.disabledAt > this.ttlMs) {
         this.disabledReuseKeys.delete(reuseKey);
       }
     }

--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -53,6 +53,7 @@ export interface StreamResponseTextOptions {
   headers?: Record<string, string>;
   transport?: 'auto' | 'http' | 'websocket';
   previousResponseId?: string;
+  store?: boolean;
   omitMaxOutputTokens?: boolean;
   model: string;
   instructions: string;
@@ -138,6 +139,15 @@ export async function streamResponseText(options: StreamResponseTextOptions): Pr
   } catch (error) {
     if (options.token.isCancellationRequested || abortController.signal.aborted) {
       return;
+    }
+
+    if (options.previousResponseId && isOpaqueHttpContinuationRejection(error)) {
+      throw new ResponsesContinuationMissError(
+        'Responses API rejected previous_response_id with an opaque HTTP 400 response.',
+        options.previousResponseId,
+        { cause: error instanceof Error ? error : undefined },
+        true
+      );
     }
 
     throw normalizeResponsesError(error, options.baseURL);
@@ -423,7 +433,7 @@ function buildResponsesCreateRequest(options: StreamResponseTextOptions) {
     instructions: options.instructions,
     input: options.input,
     stream: true,
-    store: false,
+    store: options.store ?? false,
     ...(options.previousResponseId ? { previous_response_id: options.previousResponseId } : {}),
     ...(options.serviceTier ? { service_tier: options.serviceTier } : {}),
     ...(options.reasoning ? { reasoning: options.reasoning } : {}),
@@ -578,7 +588,8 @@ class ResponsesContinuationMissError extends Error {
   constructor(
     message: string,
     readonly previousResponseId: string,
-    options?: ErrorOptions
+    options?: ErrorOptions,
+    readonly disableReuseUntilExpiry = false
   ) {
     super(message, options);
     this.name = 'ResponsesContinuationMissError';
@@ -663,6 +674,12 @@ function isPreviousResponseNotFoundError(code: unknown, message: unknown): boole
   }
 
   return typeof message === 'string' && message.includes('previous_response_not_found');
+}
+
+function isOpaqueHttpContinuationRejection(error: unknown): boolean {
+  return error instanceof APIError
+    && error.status === 400
+    && /\b400 status code \(no body\)/i.test(error.message);
 }
 
 function normalizeResponsesError(error: unknown, baseURL: string): Error {

--- a/test/realBackendProbe.mjs
+++ b/test/realBackendProbe.mjs
@@ -15,6 +15,7 @@ const requestedTransport = process.env.CODEX_TEST_TRANSPORT === 'websocket'
     ? 'auto'
     : 'http';
 const runContinuationProbe = process.env.CODEX_TEST_CONTINUATION === '1';
+const requestStore = process.env.CODEX_TEST_STORE === '1';
 const requestServiceTier = requestedServiceTier === 'fast'
   ? 'priority'
   : requestedServiceTier === 'auto' || requestedServiceTier === undefined
@@ -107,6 +108,7 @@ try {
     apiKey: credentials.apiKey,
     headers: credentials.headers,
     transport: requestedTransport,
+    store: requestStore,
     omitMaxOutputTokens: credentials.omitMaxOutputTokens,
     model: requestedModel,
     instructions: 'You are a test assistant.',
@@ -149,6 +151,7 @@ try {
       headers: credentials.headers,
       transport: requestedTransport,
       previousResponseId,
+      store: requestStore,
       omitMaxOutputTokens: credentials.omitMaxOutputTokens,
       model: requestedModel,
       instructions: 'You are a test assistant.',
@@ -176,6 +179,7 @@ try {
     model: requestedModel,
     transport: requestedTransport,
     continuationProbe: runContinuationProbe,
+    requestStore,
     requestedServiceTier: requestedServiceTier ?? null,
     requestServiceTier: requestServiceTier ?? null,
     createdServiceTier,

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -146,6 +146,7 @@ const { CodexModelProvider } = require(bundlePath);
 
 try {
   await runProviderFallbackSmokeTest();
+  await runHttpContinuationRecoverySmokeTest();
   await runProviderCatalogVersionNeutralSmokeTest();
   await runProviderUnavailableScopeSmokeTest();
   await runProviderModelDiscoveryPolicySmokeTest();
@@ -262,6 +263,127 @@ async function runProviderFallbackSmokeTest() {
     assertEqual(refreshedModels.some((item) => item.id === 'codex::gpt-5.6-nova'), false, 'rejected model hidden after temporary disable');
     assertEqual(warnings.some((entry) => entry.message === 'response model unavailable'), true, 'unavailable warning emitted');
     assertEqual(thrownMessage.includes('hidden temporarily from the model picker'), true, 'clear unavailable-model error');
+  } finally {
+    server.close();
+  }
+}
+
+async function runHttpContinuationRecoverySmokeTest() {
+  const responseRequests = [];
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+
+    const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    responseRequests.push(body);
+
+    if (body.previous_response_id) {
+      response.writeHead(400);
+      response.end();
+      return;
+    }
+
+    writeSseResponse(response, responseRequests.length === 1 ? 'first reply' : 'recovered reply', responseRequests.length === 1 ? 'resp_initial' : 'resp_recovered');
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+
+  const provider = new CodexModelProvider(
+    {
+      secrets: {
+        async get() {
+          return 'test-api-key';
+        }
+      },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected sol model for HTTP continuation recovery test.');
+    }
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('First request')] }],
+      {},
+      { report() {} },
+      token
+    );
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('First request')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('first reply')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Follow up')] }
+      ],
+      {},
+      { report() {} },
+      token
+    );
+
+    assertEqual(responseRequests.length, 3, 'continuation recovery request count');
+    assertEqual(responseRequests[1].previous_response_id, 'resp_initial', 'continuation request response id');
+    assertEqual(JSON.stringify(responseRequests[1].input), JSON.stringify([{ role: 'user', content: 'Follow up', type: 'message' }]), 'continuation delta input');
+    assertEqual('previous_response_id' in responseRequests[2], false, 'recovery request omits previous response id');
+    assertEqual(
+      JSON.stringify(responseRequests[2].input),
+      JSON.stringify([
+        { role: 'user', content: 'First request', type: 'message' },
+        { role: 'assistant', content: 'first reply', type: 'message' },
+        { role: 'user', content: 'Follow up', type: 'message' }
+      ]),
+      'recovery request full input'
+    );
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('First request')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('first reply')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Follow up')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('recovered reply')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('One more request')] }
+      ],
+      {},
+      { report() {} },
+      token
+    );
+
+    assertEqual(responseRequests.length, 4, 'disabled continuation avoids another rejected request');
+    assertEqual('previous_response_id' in responseRequests[3], false, 'disabled continuation omits previous response id');
+    assertEqual(
+      JSON.stringify(responseRequests[3].input),
+      JSON.stringify([
+        { role: 'user', content: 'First request', type: 'message' },
+        { role: 'assistant', content: 'first reply', type: 'message' },
+        { role: 'user', content: 'Follow up', type: 'message' },
+        { role: 'assistant', content: 'recovered reply', type: 'message' },
+        { role: 'user', content: 'One more request', type: 'message' }
+      ]),
+      'disabled continuation full input'
+    );
   } finally {
     server.close();
   }
@@ -427,6 +549,18 @@ function createCancellationToken() {
       return { dispose() {} };
     }
   };
+}
+
+function writeSseResponse(response, text, responseId) {
+  response.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive'
+  });
+  response.write(`data: ${JSON.stringify({ type: 'response.output_text.delta', delta: text })}\n\n`);
+  response.write(`data: ${JSON.stringify({ type: 'response.completed', response: { id: responseId, object: 'response', status: 'completed' } })}\n\n`);
+  response.write('data: [DONE]\n\n');
+  response.end();
 }
 
 function assertEqual(actual, expected, label) {


### PR DESCRIPTION
Fixes HTTP conversation continuation when the Codex Responses backend rejects `previous_response_id` with an opaque 400 response.

Summary:
- Recover the current request by retrying once with the full conversation input.
- Disable response-ID reuse for the branch cache lifetime after this specific HTTP rejection, preventing later turns from issuing a known-failing continuation request.
- Keep normal continuation-miss recovery behavior for explicit backend errors.
- Add a real-backend probe switch for comparing `store` behavior; the Codex HTTP backend rejects `store: true` even for initial requests, so production requests remain `store: false`.
- Exclude local logs, failure reports, and VSIX artifacts from extension packages.

Validation:
- `npm run check`
- `npm run test:smoke`
- `npm run package:vsix`
- Real backend probe: `CODEX_TEST_TRANSPORT=http`, `CODEX_TEST_CONTINUATION=1` reproduces opaque 400 continuation rejection with `store: false`; `CODEX_TEST_STORE=1` is rejected on the initial request.