### PR TITLE
Surface known GPT-5.6 context ceilings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/models.ts whitespace=cr-at-eol

--- a/src/models.ts
+++ b/src/models.ts
@@ -14,6 +14,11 @@ const FIXED_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'gpt-5.3-codex-spark': 128000,
   'codex-auto-review': 272000
 };
+const KNOWN_CODEX_RAW_CONTEXT_CEILINGS: Readonly<Record<string, number>> = {
+  'gpt-5.6-sol': 372000,
+  'gpt-5.6-terra': 372000,
+  'gpt-5.6-luna': 372000
+};
 
 const MODEL_DESCRIPTION_FALLBACKS: Record<string, string> = {
   'gpt-5.5': 'Frontier model for complex coding, research, and real-world work.',
@@ -144,13 +149,18 @@ export async function fetchAvailableModels(
     .filter((model) => isModelVisible(model, credentials.kind));
 }
 
-export function buildProviderModels(config: ProviderConfig, upstreamModels: UpstreamModel[]): ResolvedProviderModel[] {
-  const models = upstreamModels.map((model) => buildDiscoveredModel(model, config));
-  return models.length > 0 ? models : [buildFallbackModel(config)];
+export function buildProviderModels(
+  config: ProviderConfig,
+  upstreamModels: UpstreamModel[],
+  credentialKind: ApiCredentials['kind']
+): ResolvedProviderModel[] {
+  const models = upstreamModels.map((model) => buildDiscoveredModel(model, config, credentialKind));
+  return models.length > 0 ? models : [buildFallbackModel(config, credentialKind)];
 }
 
-export function buildFallbackModel(config: ProviderConfig): ResolvedProviderModel {
+export function buildFallbackModel(config: ProviderConfig, credentialKind: ApiCredentials['kind']): ResolvedProviderModel {
   const fallbackMaxInputTokens = getFallbackContextWindow(config.model);
+  const knownRawContextCeiling = getKnownCodexRawContextCeiling(config.model, config.baseURL, credentialKind);
   const reasoningEffort = getDefaultReasoningEffort(undefined, config.model);
   const reasoningOptions = getReasoningOptions(undefined, config.model);
   return {
@@ -164,7 +174,14 @@ export function buildFallbackModel(config: ProviderConfig): ResolvedProviderMode
       maxInputTokens: fallbackMaxInputTokens,
       maxOutputTokens: config.maxOutputTokens,
       tooltip: getModelDescription(undefined, config.model),
-      detail: buildModelDetail(fallbackMaxInputTokens, reasoningOptions, reasoningEffort, config.baseURL),
+      detail: buildModelDetail(
+        fallbackMaxInputTokens,
+        reasoningOptions,
+        reasoningEffort,
+        config.baseURL,
+        undefined,
+        knownRawContextCeiling
+      ),
       capabilities: {
         imageInput: false,
         toolCalling: true
@@ -185,7 +202,11 @@ export function parseModelIdentifier(modelId: string): ParsedModelIdentifier {
   return { requestModel, reasoningEffort };
 }
 
-function buildDiscoveredModel(model: UpstreamModel, config: ProviderConfig): ResolvedProviderModel {
+function buildDiscoveredModel(
+  model: UpstreamModel,
+  config: ProviderConfig,
+  credentialKind: ApiCredentials['kind']
+): ResolvedProviderModel {
   const slug = typeof model.slug === 'string' && model.slug.trim() ? model.slug.trim() : config.model;
   const displayName = getDiscoveredDisplayName(model, config.model);
   const reasoningOptions = getReasoningOptions(model, slug);
@@ -193,6 +214,7 @@ function buildDiscoveredModel(model: UpstreamModel, config: ProviderConfig): Res
   const defaultReasoningEffort = getDefaultReasoningEffort(model, slug);
   const activeContextWindow = getModelContextWindow(slug, model.context_window);
   const maximumContextWindow = getPositiveInteger(model.max_context_window);
+  const knownRawContextCeiling = getKnownCodexRawContextCeiling(slug, config.baseURL, credentialKind);
   const imageInput = Array.isArray(model.input_modalities) && model.input_modalities.includes('image');
   const tooltip = getModelDescription(model, slug);
   const versionBase = typeof model.comp_hash === 'string' && model.comp_hash.trim() ? model.comp_hash.trim() : '1.0.0';
@@ -210,7 +232,8 @@ function buildDiscoveredModel(model: UpstreamModel, config: ProviderConfig): Res
       reasoningOptions,
       defaultReasoningEffort,
       undefined,
-      maximumContextWindow
+      maximumContextWindow,
+      knownRawContextCeiling
     ),
     capabilities: {
       imageInput,
@@ -306,6 +329,33 @@ function getFallbackContextWindow(model: string): number {
   return FIXED_MODEL_CONTEXT_WINDOWS[model] ?? DEFAULT_FALLBACK_CONTEXT_WINDOW;
 }
 
+function getKnownCodexRawContextCeiling(
+  model: string,
+  baseURL: string,
+  credentialKind: ApiCredentials['kind']
+): number | undefined {
+  if (credentialKind !== 'codexAccessToken' || !isChatGptCodexBackend(baseURL)) {
+    return undefined;
+  }
+
+  return KNOWN_CODEX_RAW_CONTEXT_CEILINGS[model];
+}
+
+function isChatGptCodexBackend(baseURL: string): boolean {
+  try {
+    const url = new URL(normalizeBaseURL(baseURL));
+    const path = url.pathname.replace(/\/+$/, '');
+    return url.origin === 'https://chatgpt.com'
+      && !url.username
+      && !url.password
+      && !url.search
+      && !url.hash
+      && path === '/backend-api/codex';
+  } catch {
+    return false;
+  }
+}
+
 function toProviderModelId(requestModel: string): string {
   return `${PROVIDER_MODEL_ID_PREFIX}${requestModel}`;
 }
@@ -321,15 +371,23 @@ function buildModelDetail(
   reasoningOptions?: readonly ReasoningOption[],
   defaultReasoningEffort?: ReasoningEffort,
   sourceHint?: string,
-  maximumContextWindow?: number
+  maximumContextWindow?: number,
+  knownRawContextCeiling?: number
 ): string {
   const hasLargerMaximum = maximumContextWindow !== undefined && maximumContextWindow > maxInputTokens;
+  const hasLargerKnownCeiling = knownRawContextCeiling !== undefined
+    && knownRawContextCeiling > maxInputTokens
+    && (maximumContextWindow === undefined || knownRawContextCeiling > maximumContextWindow);
   const parts = [hasLargerMaximum
     ? `Context: ${formatTokenCount(maxInputTokens)} (active)`
     : `Context: ${formatTokenCount(maxInputTokens)}`];
 
   if (hasLargerMaximum) {
     parts.push(`Maximum context: ${formatTokenCount(maximumContextWindow)} (opt-in)`);
+  }
+
+  if (hasLargerKnownCeiling) {
+    parts.push(`Known raw context ceiling: ${formatTokenCount(knownRawContextCeiling)}`);
   }
 
   if (reasoningOptions && reasoningOptions.length > 0) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -433,7 +433,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     token: vscode.CancellationToken
   ): Promise<ResolvedProviderModel[]> {
     const authIdentity = getCredentialIdentity(credentials);
-    const cacheKey = buildModelCacheKey(config, credentials.source, authIdentity);
+    const cacheKey = buildModelCacheKey(config, credentials.source, credentials.kind, authIdentity);
 
     if (this.cachedModels && this.cachedModels.key === cacheKey && this.cachedModels.expiresAt > Date.now()) {
       this.outputChannel.debug('getAvailableModels cache hit', {
@@ -447,7 +447,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
 
     try {
       const upstreamModels = await fetchAvailableModels(config, credentials, token);
-      models = buildProviderModels(config, upstreamModels);
+      models = buildProviderModels(config, upstreamModels, credentials.kind);
       models = this.applyModelDiscoveryPolicy(models, config, authIdentity);
       this.outputChannel.info('getAvailableModels discovery success', {
         discoveredCount: upstreamModels.length,
@@ -455,7 +455,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         requestModels: models.map((model) => model.requestModel)
       });
     } catch {
-      models = [buildFallbackModel(config)];
+      models = [buildFallbackModel(config, credentials.kind)];
       models = this.applyModelDiscoveryPolicy(models, config, authIdentity);
       this.outputChannel.warn('getAvailableModels discovery failed, using fallback model', {
         fallbackModel: config.model
@@ -686,6 +686,7 @@ function collectErrorMessages(error: unknown): string[] {
 function buildModelCacheKey(
   config: ProviderConfig,
   credentialSource: string,
+  credentialKind: string,
   authIdentity: string
 ): string {
   return [
@@ -700,6 +701,7 @@ function buildModelCacheKey(
     config.defaultReasoningEffort ?? 'auto',
     config.maxOutputTokens,
     credentialSource,
+    credentialKind,
     authIdentity
   ].join('|');
 }

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -238,7 +238,7 @@ async function runModelCatalogMetadataSmokeTest() {
       'API-key catalog filters API-ineligible models while retaining Auto Review policy'
     );
 
-    const resolvedModels = buildProviderModels(config, accountCatalog);
+    const resolvedModels = buildProviderModels(config, accountCatalog, 'codexAccessToken');
     const gpt54 = resolvedModels.find((model) => model.requestModel === 'gpt-5.4');
     const spark = resolvedModels.find((model) => model.requestModel === 'gpt-5.3-codex-spark');
     const autoReview = resolvedModels.find((model) => model.requestModel === 'codex-auto-review');
@@ -273,7 +273,7 @@ async function runModelCatalogMetadataSmokeTest() {
         context_window: 333000,
         max_context_window: 1000000
       })
-    ])[0];
+    ], 'codexAccessToken')[0];
     assertEqual(discoveredOverride.info.maxInputTokens, 333000, 'valid discovered context overrides fixed fallback');
 
     const fractionalMetadata = buildProviderModels(config, [
@@ -281,17 +281,92 @@ async function runModelCatalogMetadataSmokeTest() {
         context_window: 0.5,
         max_context_window: 0.5
       })
-    ])[0];
+    ], 'codexAccessToken')[0];
     assertEqual(fractionalMetadata.info.maxInputTokens, 272000, 'fractional context below one uses fixed fallback');
     assertEqual(fractionalMetadata.info.detail?.includes('Maximum context:'), false, 'invalid fractional maximum is omitted');
 
     const sparkFallback = buildFallbackModel({
       ...config,
       model: 'gpt-5.3-codex-spark'
-    });
+    }, 'codexAccessToken');
     assertEqual(sparkFallback.requestModel, 'gpt-5.3-codex-spark', 'Spark fallback request model');
     assertEqual(sparkFallback.info.maxInputTokens, 128000, 'Spark fixed fallback context');
     assertEqual(sparkFallback.info.capabilities?.imageInput, false, 'Spark fallback text-only capability');
+
+    const chatGptConfig = {
+      ...config,
+      baseURL: 'https://chatgpt.com/backend-api/codex/responses'
+    };
+    const rollbackCatalog = [
+      createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol', { context_window: 272000, max_context_window: 272000 }),
+      createMockModel('gpt-5.6-terra', 'GPT-5.6-Terra', { context_window: 272000, max_context_window: 272000 }),
+      createMockModel('gpt-5.6-luna', 'GPT-5.6-Luna', { context_window: 272000, max_context_window: 272000 }),
+      createMockModel('gpt-5.6-nova', 'GPT-5.6-Nova', { context_window: 272000, max_context_window: 272000 })
+    ];
+    const rollbackModels = buildProviderModels(chatGptConfig, rollbackCatalog, 'codexAccessToken');
+    const formattedKnownCeiling = (372000).toLocaleString();
+    for (const slug of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+      const model = rollbackModels.find((candidate) => candidate.requestModel === slug);
+      if (!model) {
+        throw new Error(`Expected ${slug} rollback metadata.`);
+      }
+      assertEqual(model.info.maxInputTokens, 272000, `${slug} keeps authenticated active context`);
+      assertEqual(
+        model.info.detail?.includes(`Known raw context ceiling: ${formattedKnownCeiling} tokens`),
+        true,
+        `${slug} shows known raw context ceiling`
+      );
+      assertEqual(model.info.maxOutputTokens, config.maxOutputTokens, `${slug} output metadata remains configured`);
+      assertEqual(model.info.detail?.includes('500,000'), false, `${slug} does not expose inferred total context`);
+    }
+
+    const unrelatedModel = rollbackModels.find((model) => model.requestModel === 'gpt-5.6-nova');
+    assertEqual(unrelatedModel?.info.detail?.includes('Known raw context ceiling:'), false, 'unrelated GPT-5.6 model is unchanged');
+
+    const apiKeyModels = buildProviderModels(chatGptConfig, rollbackCatalog, 'openaiApiKey');
+    assertEqual(
+      apiKeyModels.some((model) => model.info.detail?.includes('Known raw context ceiling:')),
+      false,
+      'API-key catalog omits Codex account ceilings'
+    );
+
+    const customBackendModels = buildProviderModels(config, rollbackCatalog, 'codexAccessToken');
+    assertEqual(
+      customBackendModels.some((model) => model.info.detail?.includes('Known raw context ceiling:')),
+      false,
+      'custom backend catalog omits ChatGPT Codex ceilings'
+    );
+
+    for (const baseURL of [
+      'https://chatgpt.com:444/backend-api/codex/responses',
+      'https://user@chatgpt.com/backend-api/codex/responses',
+      'https://chatgpt.com/backend-api/codex/responses?proxy=1',
+      'https://chatgpt.com/backend-api/codex/responses#proxy'
+    ]) {
+      const models = buildProviderModels({ ...chatGptConfig, baseURL }, rollbackCatalog, 'codexAccessToken');
+      assertEqual(
+        models.some((model) => model.info.detail?.includes('Known raw context ceiling:')),
+        false,
+        `noncanonical backend ${baseURL} omits known ceilings`
+      );
+    }
+
+    const promotedModel = buildProviderModels(chatGptConfig, [
+      createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol', { context_window: 372000, max_context_window: 372000 })
+    ], 'codexAccessToken')[0];
+    assertEqual(promotedModel.info.maxInputTokens, 372000, 'future 372K catalog value becomes active');
+    assertEqual(promotedModel.info.detail?.includes('Known raw context ceiling:'), false, 'active 372K omits redundant known ceiling');
+
+    const fallbackCeiling = buildFallbackModel({
+      ...chatGptConfig,
+      model: 'gpt-5.6-sol'
+    }, 'codexAccessToken');
+    assertEqual(fallbackCeiling.info.maxInputTokens, 272000, 'fallback keeps conservative active context');
+    assertEqual(
+      fallbackCeiling.info.detail?.includes(`Known raw context ceiling: ${formattedKnownCeiling} tokens`),
+      true,
+      'fallback shows known raw context ceiling'
+    );
     assertEqual(catalogRequestCount, 2, 'credential-kind catalog request count');
   } finally {
     server.close();


### PR DESCRIPTION
## Summary

- keep each authenticated remote `context_window` authoritative for VS Code `maxInputTokens`
- show a separate known 372K raw context ceiling for exact GPT-5.6 Sol, Terra, and Luna models
- scope the informational ceiling to Codex access tokens on the canonical ChatGPT Codex backend
- isolate model caches by credential kind and reject noncanonical backend URLs
- automatically remove the extra detail when discovery itself reports 372K or a larger maximum

This intentionally does not expose OpenCode’s inferred 500K total, copy its 128K output policy, or hard-override a temporary account-specific 272K rollback.

## Issue review coverage

- exact-slug 372K gating is implemented independently from generic `max_context_window` presentation
- credential kind and canonical backend eligibility are propagated into model shaping and cache keys
- regression coverage includes Sol/Terra/Luna, API-key and custom-backend isolation, unrelated names, fallback behavior, and automatic promotion when discovery reports 372K

Current delta above `master`:

- `2089ae1` Document models file whitespace convention
- `db169c2` Surface known GPT-5.6 context ceilings

Closes #14.

## Verification

- `npm run check`
- `npm run compile`
- `npm run test:smoke`
- focused model smoke under English, German, and French locales
- LSP diagnostics on all modified files
- ordinary `git diff --check`
- independent goal, QA, code-quality, security, and context reviews