### PR TITLE
Add pull request CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: Pull Request CI
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Check, compile, and smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check changed-file whitespace
+        if: github.event_name == 'pull_request'
+        run: git diff --check "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+
+      - name: Check TypeScript
+        run: npm run check
+
+      - name: Compile extension
+        run: npm run compile
+
+      - name: Run smoke tests
+        run: npm run test:smoke


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow for pull requests targeting `master`
- install dependencies with Node.js 22 and the committed npm lockfile
- check changed-file whitespace, TypeScript types, extension compilation, and smoke tests
- cancel superseded runs when additional commits are pushed to the same pull request
- allow manual runs through `workflow_dispatch`

## Security

- use the `pull_request` event rather than `pull_request_target`
- grant read-only repository contents permission
- do not expose repository secrets or run the real-backend test

## Verification

- workflow YAML parses successfully
- commands match the existing release workflow and repository scripts
- GitHub may require an explicit **Approve and run workflows** action for this initial workflow-changing PR because it was created through a GitHub integration

After merge, newly opened, updated, reopened, or marked-ready pull requests targeting `master` will run these checks automatically. Pull requests created by coding agents or first-time fork contributors may still be subject to GitHub's workflow approval security gate.