### PR TITLE
Run Codex provider locally in Remote SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ npm run compile
 
 Press F5 in VS Code to launch an Extension Development Host.
 
+The extension also works when the current workspace is opened over Remote-SSH. It is intentionally run in the local UI extension host, so it uses the credentials already stored on your local computer. Do not install a second remote copy of the extension on the SSH host; after updating, run `Developer: Show Running Extensions` and confirm that `Codex For Copilot` is running locally.
+
 ## Configuration
 
 Common settings:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "onLanguageModelChatProvider:codex-for-copilot",
     "onStartupFinished"
   ],
+  "extensionKind": [
+    "ui"
+  ],
   "main": "./out/extension.js",
   "scripts": {
     "check": "tsc -p ./ --noEmit",


### PR DESCRIPTION
## Summary\n\n- run the provider in the local UI extension host for Remote-SSH workspaces\n- allow the extension to use credentials already stored on the local computer\n- document the expected Remote-SSH behavior and verification step\n\n## Validation\n\n- npm run compile\n- npm run test:smoke