### PR TITLE
fix: allow Marketplace Entra login without subscription access

### DIFF
--- a/.github/workflows/marketplace-identity.yml
+++ b/.github/workflows/marketplace-identity.yml
@@ -21,10 +21,9 @@ jobs:
         env:
           AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         run: |
           missing=0
-          for name in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID; do
+          for name in AZURE_CLIENT_ID AZURE_TENANT_ID; do
             if [[ -z "${!name:-}" ]]; then
               echo "::error::Missing GitHub environment variable ${name} in the marketplace environment."
               missing=1
@@ -37,7 +36,7 @@ jobs:
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
 
       - name: Resolve Marketplace identity profile
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,10 +123,9 @@ jobs:
         env:
           AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         run: |
           missing=0
-          for name in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID; do
+          for name in AZURE_CLIENT_ID AZURE_TENANT_ID; do
             if [[ -z "${!name:-}" ]]; then
               echo "::error::Missing GitHub environment variable ${name} in the marketplace environment."
               missing=1
@@ -139,7 +138,7 @@ jobs:
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
 
       - name: Confirm Marketplace identity
         id: identity

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -56,12 +56,11 @@ Optionally add required reviewers so every Marketplace deployment receives a sec
 
 ### 2. Create a user-assigned managed identity
 
-Create a user-assigned managed identity in the Microsoft Entra tenant connected to the Visual Studio Marketplace publisher. The Azure CLI example below uses placeholders:
+Create a user-assigned managed identity in the Microsoft Entra tenant connected to the Visual Studio Marketplace publisher:
 
 ```bash
 RESOURCE_GROUP=<azure-resource-group>
 IDENTITY_NAME=codex-for-copilot-marketplace
-SUBSCRIPTION_ID=<azure-subscription-id>
 
 az identity create \
   --resource-group "$RESOURCE_GROUP" \
@@ -73,24 +72,10 @@ AZURE_CLIENT_ID="$(az identity show \
   --query clientId \
   --output tsv)"
 
-PRINCIPAL_ID="$(az identity show \
-  --resource-group "$RESOURCE_GROUP" \
-  --name "$IDENTITY_NAME" \
-  --query principalId \
-  --output tsv)"
-
 AZURE_TENANT_ID="$(az account show --query tenantId --output tsv)"
 ```
 
-Assign the minimum Azure role required for the identity to be usable by `azure/login`. The official VS Code publishing guide specifies `Reader`; scope it to the identity's resource group rather than the whole subscription when possible:
-
-```bash
-az role assignment create \
-  --assignee-object-id "$PRINCIPAL_ID" \
-  --assignee-principal-type ServicePrincipal \
-  --role Reader \
-  --scope "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}"
-```
+The GitHub workflows perform a tenant-scoped Entra login with `allow-no-subscriptions: true`. The managed identity therefore does not need a Reader role or any other Azure RBAC assignment merely to publish to Visual Studio Marketplace. Marketplace authorization is configured separately through the publisher membership described below.
 
 ### 3. Trust the GitHub environment through OIDC
 
@@ -116,9 +101,8 @@ In **Settings → Environments → marketplace → Environment variables**, add:
 | --- | --- |
 | `AZURE_CLIENT_ID` | Managed identity client ID |
 | `AZURE_TENANT_ID` | Microsoft Entra tenant ID |
-| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
 
-These identifiers are not credentials and do not need to be stored as secrets. No client secret is required.
+These identifiers are not credentials and do not need to be stored as secrets. No client secret or subscription ID is required.
 
 ### 5. Resolve the Marketplace identity profile ID
 


### PR DESCRIPTION
## Cause

`Marketplace Identity Check` successfully received the GitHub OIDC token and matched the configured federated subject, but `azure/login` then failed with `No subscriptions found`.

The Marketplace identity only needs a tenant-scoped Microsoft Entra login so it can request the Azure DevOps/Marketplace resource token. It does not need Azure Subscription RBAC merely to publish an extension.

## Fix

- remove `AZURE_SUBSCRIPTION_ID` from required GitHub environment variables;
- omit `subscription-id` from `azure/login`;
- set `allow-no-subscriptions: true` in both identity-check and release workflows;
- update release documentation to remove the unnecessary Reader role assignment and subscription requirement.

## Validation

The failed run showed that OIDC federation already matched:

- issuer: `https://token.actions.githubusercontent.com`
- subject: `repo:GaussianGuaicai/Codex-For-Copilot:environment:marketplace`
- audience: `api://AzureADTokenExchange`

After merging, rerun **Marketplace Identity Check**. Only `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` are required in the `marketplace` environment.