### PR TITLE
fix: match IPv6 no_proxy hosts

### DIFF
--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -13,6 +13,7 @@ import type {
   ResponseUsage
 } from 'openai/resources/responses/responses';
 import type { Reasoning } from 'openai/resources/shared';
+import { isIP } from 'node:net';
 import * as vscode from 'vscode';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import type { ResponsesInputMessage } from './convertMessages';
@@ -832,8 +833,9 @@ export function shouldBypassProxy(baseURL: string, environment: NodeJS.ProcessEn
   const noProxy = [environment.NO_PROXY, environment.no_proxy]
     .filter((value): value is string => Boolean(value?.trim()))
     .join(',');
+  const targetHostname = normalizeProxyHostname(url.hostname);
   if (!noProxy) {
-    return url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1';
+    return targetHostname === 'localhost' || targetHostname === '127.0.0.1' || targetHostname === '::1';
   }
   return noProxy.split(',').some((entry) => {
     const pattern = entry.trim().toLowerCase();
@@ -843,9 +845,52 @@ export function shouldBypassProxy(baseURL: string, environment: NodeJS.ProcessEn
     if (pattern === '*') {
       return true;
     }
-    const hostname = pattern.replace(/^https?:\/\//, '').split(':')[0].replace(/^\./, '');
-    return url.hostname.toLowerCase() === hostname || url.hostname.toLowerCase().endsWith(`.${hostname}`);
+    const hostname = parseNoProxyHostname(pattern);
+    return Boolean(hostname)
+      && (targetHostname === hostname || targetHostname.endsWith(`.${hostname}`));
   });
+}
+
+function parseNoProxyHostname(pattern: string): string | undefined {
+  if (/^https?:\/\//.test(pattern)) {
+    try {
+      return normalizeProxyHostname(new URL(pattern).hostname).replace(/^\./, '');
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (pattern.startsWith('[')) {
+    const closingBracket = pattern.indexOf(']');
+    if (closingBracket <= 1) {
+      return undefined;
+    }
+
+    const hostname = pattern.slice(1, closingBracket);
+    const suffix = pattern.slice(closingBracket + 1);
+    if (isIP(hostname) !== 6 || !isValidNoProxyPortSuffix(suffix)) {
+      return undefined;
+    }
+    return normalizeProxyHostname(hostname);
+  }
+
+  const hostname = pattern.split(':').length > 2 ? pattern : pattern.split(':', 1)[0];
+  return normalizeProxyHostname(hostname).replace(/^\./, '') || undefined;
+}
+
+function isValidNoProxyPortSuffix(suffix: string): boolean {
+  if (!suffix) {
+    return true;
+  }
+  if (!/^:\d+$/.test(suffix)) {
+    return false;
+  }
+  const port = Number(suffix.slice(1));
+  return Number.isInteger(port) && port >= 0 && port <= 65535;
+}
+
+function normalizeProxyHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().replace(/^\[|\]$/g, '');
 }
 
 function getManagedConnectionScope(options: StreamResponseTextOptions): CodexConnectionScope | undefined {

--- a/test/smokeResponsesClient.mjs
+++ b/test/smokeResponsesClient.mjs
@@ -587,6 +587,35 @@ async function runWebSocketLowercaseNoProxySmokeTest(streamResponseText, shouldB
       true,
       'lowercase no_proxy bypasses proxy when NO_PROXY is also set'
     );
+    for (const noProxy of ['::1', '[::1]', '[::1]:443', 'http://[::1]:443']) {
+      assertEqual(
+        shouldBypassProxy('http://[::1]:8080/backend-api/codex/responses', { NO_PROXY: noProxy }),
+        true,
+        `IPv6 loopback no_proxy form ${noProxy}`
+      );
+    }
+    assertEqual(
+      shouldBypassProxy('http://[::1]:8080/backend-api/codex/responses', {}),
+      true,
+      'IPv6 loopback bypasses proxy by default'
+    );
+    assertEqual(
+      shouldBypassProxy('http://[::1]:8080/backend-api/codex/responses', { NO_PROXY: '[::2]' }),
+      false,
+      'different IPv6 no_proxy host does not bypass'
+    );
+    for (const noProxy of ['[::1]junk', '[::1]:invalid', '[::1]:65536']) {
+      assertEqual(
+        shouldBypassProxy('http://[::1]:8080/backend-api/codex/responses', { NO_PROXY: noProxy }),
+        false,
+        `malformed bracketed no_proxy form ${noProxy}`
+      );
+    }
+    assertEqual(
+      shouldBypassProxy('https://example.com', { NO_PROXY: '[example.com]' }),
+      false,
+      'bracketed DNS name does not bypass proxy'
+    );
 
     await streamResponseText({
       baseURL: `http://127.0.0.1:${address.port}/backend-api/codex/responses`,


### PR DESCRIPTION
## Summary

- parse bracketed and unbracketed IPv6 `NO_PROXY` / `no_proxy` entries without splitting raw literals on `:`
- preserve URL-form, domain-suffix, wildcard, and default loopback behavior
- reject malformed bracket suffixes, invalid ports, and bracketed DNS names

This addresses the still-current IPv6 finding from PR #10: https://github.com/GaussianGuaicai/Codex-For-Copilot/pull/10#discussion_r3603513580. The issue is present in `v1.2.0`; the earlier bot completion comment did not correspond to code in the merged tree.

## Verification

- `npm run compile`
- `npm run test:smoke`
- `NODE_OPTIONS=--dns-result-order=ipv6first node test/smokeResponsesClient.mjs`
- LSP diagnostics: no findings
- `git diff --check`: clean