### PR TITLE
fix: recover wrapped continuation misses

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -819,6 +819,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     } catch (error) {
       if (shouldAttemptToolOutputContinuation && isResponsesContinuationMissError(error)) {
         if (reportedVisibleOutput) {
+          this.responseBranchStore.invalidateResponseId(error.previousResponseId);
+          if (reusableBranch) {
+            this.responseBranchStore.invalidate(reusableBranch.branchId);
+          }
           throw error;
         }
 
@@ -862,6 +866,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         }
 
         if (reportedVisibleOutput) {
+          this.responseBranchStore.invalidateResponseId(error.previousResponseId);
+          if (reusableBranch) {
+            this.responseBranchStore.invalidate(reusableBranch.branchId);
+          }
           throw error;
         }
 

--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -48,6 +48,13 @@ const WEBSOCKET_PREWARM_BUDGET_MS = 400;
 const WEBSOCKET_OPEN = 1;
 const WEBSOCKET_CLOSING = 2;
 const WEBSOCKET_CLOSED = 3;
+const PREVIOUS_RESPONSE_NOT_FOUND_CODE = 'previous_response_not_found';
+const PREVIOUS_RESPONSE_ID_PARAM = 'previous_response_id';
+const CONTINUATION_MISS_MESSAGE = 'Responses API could not find previous_response_id.';
+const MAX_ERROR_TRAVERSAL_NODES = 64;
+const MAX_ERROR_TRAVERSAL_DEPTH = 8;
+const MAX_ERROR_JSON_LENGTH = 16 * 1024;
+const UNREADABLE_ERROR_PROPERTY = Symbol('unreadableErrorProperty');
 
 interface ReusableResponsesWebSocketSession {
   socket: ResponsesWS;
@@ -146,6 +153,25 @@ export function isResponsesContinuationMissError(error: unknown): error is Respo
   return error instanceof ResponsesContinuationMissError;
 }
 
+export function isResponsesContinuationMissPayload(error: unknown): boolean {
+  let matched = false;
+  walkErrorEnvelope(error, (value) => {
+    if (typeof value !== 'object' || value === null) {
+      return true;
+    }
+
+    const code = readOwnErrorProperty(value, 'code');
+    if (code !== PREVIOUS_RESPONSE_NOT_FOUND_CODE) {
+      return true;
+    }
+
+    const param = readOwnErrorProperty(value, 'param');
+    matched = param === undefined || param === null || param === PREVIOUS_RESPONSE_ID_PARAM;
+    return !matched;
+  });
+  return matched;
+}
+
 export function disposeReusableResponsesWebSockets(): void {
   codexConnectionManager.dispose();
   const sessions = new Set(reusableWebSocketSessions.values());
@@ -226,6 +252,14 @@ export async function streamResponseText(options: StreamResponseTextOptions): Pr
     if (options.previousResponseId) {
       if (error instanceof ResponsesContinuationMissError) {
         throw error;
+      }
+
+      if (isResponsesContinuationMissPayload(error)) {
+        throw new ResponsesContinuationMissError(
+          CONTINUATION_MISS_MESSAGE,
+          options.previousResponseId,
+          { cause: error instanceof Error ? error : undefined }
+        );
       }
 
       if (isOpaqueHttpContinuationRejection(error)) {
@@ -375,11 +409,10 @@ async function streamResponseTextOverWebSocket(
           );
         }
 
-        const responseError = getResponseErrorDetails(streamEvent.error);
-        if (options.previousResponseId && isPreviousResponseNotFoundError(responseError.code, responseError.message)) {
+        if (options.previousResponseId && isResponsesContinuationMissPayload(streamEvent.error)) {
           releaseReusableWebSocketSession(session, undefined, false);
           throw new ResponsesContinuationMissError(
-            typeof responseError.message === 'string' ? responseError.message : streamEvent.error.message,
+            CONTINUATION_MISS_MESSAGE,
             options.previousResponseId,
             { cause: streamEvent.error }
           );
@@ -596,12 +629,13 @@ function reportManagedWebSocketResult(
 }
 
 function classifyManagedWebSocketError(error: unknown, options: StreamResponseTextOptions): Error {
-  const messages = collectErrorMessages(error);
-  if (options.previousResponseId && messages.some((message) => /previous_response_not_found/i.test(message))) {
-    return new ResponsesContinuationMissError(messages[0] ?? 'previous_response_not_found', options.previousResponseId, {
+  if (options.previousResponseId && isResponsesContinuationMissPayload(error)) {
+    return new ResponsesContinuationMissError(CONTINUATION_MISS_MESSAGE, options.previousResponseId, {
       cause: error instanceof Error ? error : undefined
     });
   }
+
+  const messages = collectErrorMessages(error);
   if (messages.some((message) => /connection limit|websocket_connection_limit_reached/i.test(message))) {
     return new WebSocketTransportUnavailableError('Responses WebSocket connection limit reached.', {
       cause: error instanceof Error ? error : undefined
@@ -987,9 +1021,9 @@ function handleResponsesServerEvent(
       );
     }
 
-    if (options.previousResponseId && isPreviousResponseNotFoundError(error?.code, error?.message)) {
+    if (options.previousResponseId && isResponsesContinuationMissPayload(error)) {
       throw new ResponsesContinuationMissError(
-        error?.message ?? 'Responses API previous_response_id was not found.',
+        CONTINUATION_MISS_MESSAGE,
         options.previousResponseId
       );
     }
@@ -1035,41 +1069,89 @@ function getModelNotFoundName(error: unknown): string | undefined {
 
 function collectErrorMessages(error: unknown): string[] {
   const messages: string[] = [];
-
-  const visit = (value: unknown) => {
-    if (!value) {
-      return;
-    }
-
+  walkErrorEnvelope(error, (value) => {
     if (typeof value === 'string') {
       messages.push(value);
-      return;
     }
-
-    if (value instanceof Error) {
-      messages.push(value.message);
-      visit((value as Error & { cause?: unknown }).cause);
-      return;
-    }
-
-    if (typeof value === 'object') {
-      const record = value as {
-        message?: unknown;
-        error?: unknown;
-        cause?: unknown;
-      };
-
-      if (typeof record.message === 'string') {
-        messages.push(record.message);
-      }
-
-      visit(record.error);
-      visit(record.cause);
-    }
-  };
-
-  visit(error);
+    return true;
+  });
   return messages;
+}
+
+function walkErrorEnvelope(error: unknown, visit: (value: unknown) => boolean): void {
+  const queue: Array<{ value: unknown; depth: number }> = [{ value: error, depth: 0 }];
+  const seenObjects = new WeakSet<object>();
+  let queueIndex = 0;
+  let visitedNodes = 0;
+
+  while (queueIndex < queue.length && visitedNodes < MAX_ERROR_TRAVERSAL_NODES) {
+    const current = queue[queueIndex];
+    queueIndex += 1;
+    visitedNodes += 1;
+
+    if (typeof current.value === 'object' && current.value !== null) {
+      if (seenObjects.has(current.value)) {
+        continue;
+      }
+      seenObjects.add(current.value);
+    }
+
+    if (!visit(current.value)) {
+      return;
+    }
+    if (current.depth >= MAX_ERROR_TRAVERSAL_DEPTH) {
+      continue;
+    }
+
+    if (typeof current.value === 'string') {
+      const parsed = parseBoundedErrorJson(current.value);
+      if (parsed !== undefined) {
+        queue.push({ value: parsed, depth: current.depth + 1 });
+      }
+      continue;
+    }
+    if (typeof current.value !== 'object' || current.value === null) {
+      continue;
+    }
+
+    for (const property of ['error', 'cause', 'message'] as const) {
+      const nested = readOwnErrorProperty(current.value, property);
+      if (nested !== undefined && nested !== null && nested !== UNREADABLE_ERROR_PROPERTY) {
+        queue.push({ value: nested, depth: current.depth + 1 });
+      }
+    }
+  }
+}
+
+function parseBoundedErrorJson(message: string): unknown | undefined {
+  if (message.length === 0 || message.length > MAX_ERROR_JSON_LENGTH) {
+    return undefined;
+  }
+
+  const trimmed = message.trim();
+  const looksLikeObject = trimmed.startsWith('{') && trimmed.endsWith('}');
+  const looksLikeArray = trimmed.startsWith('[') && trimmed.endsWith(']');
+  if (!looksLikeObject && !looksLikeArray) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+function readOwnErrorProperty(value: object, property: string): unknown | typeof UNREADABLE_ERROR_PROPERTY {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, property);
+    if (!descriptor) {
+      return undefined;
+    }
+    return 'value' in descriptor ? descriptor.value : UNREADABLE_ERROR_PROPERTY;
+  } catch {
+    return UNREADABLE_ERROR_PROPERTY;
+  }
 }
 
 interface WebSocketTransportUnavailableErrorOptions extends ErrorOptions {
@@ -1150,47 +1232,6 @@ function parseToolCallInput(argumentsJson: string): object {
   } catch {
     return { _raw: argumentsJson };
   }
-}
-
-function isPreviousResponseNotFoundError(code: unknown, message: unknown): boolean {
-  if (code === 'previous_response_not_found') {
-    return true;
-  }
-
-  return typeof message === 'string' && message.includes('previous_response_not_found');
-}
-
-function getResponseErrorDetails(error: unknown): {
-  code: unknown;
-  message: unknown;
-} {
-  if (typeof error !== 'object' || error === null) {
-    return {
-      code: undefined,
-      message: undefined
-    };
-  }
-
-  const record = error as {
-    code?: unknown;
-    message?: unknown;
-    error?: unknown;
-  };
-  if (record.error && typeof record.error === 'object') {
-    const nested = record.error as {
-      code?: unknown;
-      message?: unknown;
-    };
-    return {
-      code: nested.code,
-      message: nested.message ?? record.message
-    };
-  }
-
-  return {
-    code: record.code,
-    message: record.message
-  };
 }
 
 function isOpaqueHttpContinuationRejection(error: unknown): boolean {

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -175,6 +175,8 @@ try {
   await runProviderFallbackSmokeTest();
   await runInterleavedResponsePresentationSmokeTest();
   await runHttpContinuationRecoverySmokeTest();
+  await runStructuredHttpContinuationRecoverySmokeTest();
+  await runContinuationMissAfterVisibleOutputSmokeTest();
   await runRequestEnvelopeReuseInvalidationSmokeTest();
   await runToolOutputFullInputReplaySmokeTest();
   await runModelGeneratedToolLoopFullReplaySmokeTest();
@@ -723,6 +725,324 @@ async function runHttpContinuationRecoverySmokeTest() {
         { role: 'user', content: 'One more request', type: 'message' }
       ]),
       'disabled continuation full input'
+    );
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function runStructuredHttpContinuationRecoverySmokeTest() {
+  const responseRequests = [];
+  const warnings = [];
+  const infoMessages = [];
+  const failureMessages = [];
+  const remoteErrorMessage = 'Remote secret continuation detail must not be logged.';
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    responseRequests.push(body);
+
+    if (responseRequests.length === 1) {
+      writeSseResponse(response, 'first structured reply', 'resp_structured_initial');
+      return;
+    }
+
+    if (responseRequests.length === 2 && body.previous_response_id) {
+      response.writeHead(400, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        error: {
+          type: 'invalid_request_error',
+          code: 'previous_response_not_found',
+          message: remoteErrorMessage,
+          param: 'previous_response_id'
+        }
+      }));
+      return;
+    }
+
+    if (responseRequests.length === 3) {
+      writeSseResponse(response, 'structured recovered reply', 'resp_structured_recovered');
+      return;
+    }
+
+    response.writeHead(500, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ error: { message: 'Unexpected extra continuation recovery request.' } }));
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+
+  const provider = new CodexModelProvider(
+    {
+      secrets: {
+        async get() {
+          return 'test-api-key';
+        }
+      },
+      subscriptions: []
+    },
+    {
+      debug() {},
+      info(message) {
+        infoMessages.push(message);
+      },
+      warn(message, payload) {
+        warnings.push({ message, payload });
+      },
+      error(message) {
+        failureMessages.push(message);
+      }
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected sol model for structured continuation recovery test.');
+    }
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Structured first request')] }],
+      {},
+      { report() {} },
+      token
+    );
+
+    const recoveredParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Structured first request')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('first structured reply')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Structured follow up')] }
+      ],
+      {},
+      { report(part) { recoveredParts.push(part); } },
+      token
+    );
+
+    assertEqual(responseRequests.length, 3, 'structured continuation retries once with full history');
+    assertEqual(responseRequests[1].previous_response_id, 'resp_structured_initial', 'structured continuation response id');
+    assertEqual(
+      JSON.stringify(responseRequests[1].input),
+      JSON.stringify([{ role: 'user', content: 'Structured follow up', type: 'message' }]),
+      'structured continuation sends only appended input first'
+    );
+    assertEqual('previous_response_id' in responseRequests[2], false, 'structured recovery omits previous response id');
+    assertEqual(JSON.stringify(responseRequests[2].input), JSON.stringify([
+      { role: 'user', content: 'Structured first request', type: 'message' },
+      { role: 'assistant', content: 'first structured reply', type: 'message' },
+      { role: 'user', content: 'Structured follow up', type: 'message' }
+    ]), 'structured recovery replays full input');
+    assertEqual(
+      recoveredParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
+      'structured recovered reply',
+      'structured recovery reports only recovered output'
+    );
+
+    const resetWarnings = warnings.filter((entry) => entry.message === 'response continuation reset');
+    assertEqual(resetWarnings.length, 1, 'structured continuation emits one reset warning');
+    assertEqual(
+      resetWarnings[0].payload.reason,
+      'Responses API could not find previous_response_id.',
+      'structured reset warning uses the fixed classifier message'
+    );
+    assertEqual(JSON.stringify(resetWarnings).includes(remoteErrorMessage), false, 'structured reset warning omits remote error text');
+    assertEqual(infoMessages.filter((message) => message === 'response completed').length, 2, 'seed and recovered requests complete once each');
+    assertEqual(failureMessages.length, 0, 'recovered continuation emits no provider failure');
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function runContinuationMissAfterVisibleOutputSmokeTest() {
+  const responseRequests = [];
+  const warnings = [];
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    responseRequests.push(body);
+
+    if (responseRequests.length === 1) {
+      writeSseResponse(response, 'visible first reply', 'resp_visible_initial');
+      return;
+    }
+
+    if (responseRequests.length === 3) {
+      writeSseResponse(response, 'new chain reply', 'resp_visible_new_chain');
+      return;
+    }
+
+    if (responseRequests.length > 3) {
+      response.writeHead(500, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: { message: 'Visible output must prevent replay.' } }));
+      return;
+    }
+
+    response.writeHead(200, {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive'
+    });
+    response.write(`data: ${JSON.stringify({ type: 'response.output_text.delta', delta: 'partial visible output' })}\n\n`);
+    response.write(`data: ${JSON.stringify({
+      type: 'response.failed',
+      response: {
+        id: 'resp_visible_failed',
+        status: 'failed',
+        error: {
+          type: 'invalid_request_error',
+          code: 'previous_response_not_found',
+          message: 'Remote failure after visible output.',
+          param: 'previous_response_id'
+        }
+      }
+    })}\n\n`);
+    response.write('data: [DONE]\n\n');
+    response.end();
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+
+  const provider = new CodexModelProvider(
+    {
+      secrets: {
+        async get() {
+          return 'test-api-key';
+        }
+      },
+      subscriptions: []
+    },
+    {
+      debug() {},
+      info() {},
+      warn(message, payload) {
+        warnings.push({ message, payload });
+      },
+      error() {}
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected sol model for visible continuation failure test.');
+    }
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Visible first request')] }],
+      {},
+      { report() {} },
+      token
+    );
+
+    const visibleParts = [];
+    let capturedError;
+    try {
+      await provider.provideLanguageModelChatResponse(
+        model,
+        [
+          { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Visible first request')] },
+          { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('visible first reply')] },
+          { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Visible follow up')] }
+        ],
+        {},
+        { report(part) { visibleParts.push(part); } },
+        token
+      );
+    } catch (error) {
+      capturedError = error;
+    }
+
+    assertEqual(capturedError?.message, 'Responses API could not find previous_response_id.', 'visible continuation miss surfaces once');
+    assertEqual(responseRequests.length, 2, 'visible continuation miss is never replayed');
+    assertEqual(responseRequests[1].previous_response_id, 'resp_visible_initial', 'visible continuation uses prior response');
+    assertEqual(
+      visibleParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
+      'partial visible output',
+      'visible continuation output is emitted once'
+    );
+    assertEqual(
+      warnings.some((entry) => entry.message === 'response continuation reset'),
+      false,
+      'visible continuation miss emits no reset warning'
+    );
+
+    const nextParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Visible first request')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('visible first reply')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Visible follow up')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('partial visible output')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Start a new chain')] }
+      ],
+      {},
+      { report(part) { nextParts.push(part); } },
+      token
+    );
+
+    assertEqual(responseRequests.length, 3, 'next turn issues one new-chain request');
+    assertEqual('previous_response_id' in responseRequests[2], false, 'next turn does not reuse stale response id');
+    assertEqual(JSON.stringify(responseRequests[2].input), JSON.stringify([
+      { role: 'user', content: 'Visible first request', type: 'message' },
+      { role: 'assistant', content: 'visible first reply', type: 'message' },
+      { role: 'user', content: 'Visible follow up', type: 'message' },
+      { role: 'assistant', content: 'partial visible output', type: 'message' },
+      { role: 'user', content: 'Start a new chain', type: 'message' }
+    ]), 'next turn sends full input after stale branch invalidation');
+    assertEqual(
+      nextParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
+      'new chain reply',
+      'next turn reports only new-chain output'
+    );
+    assertEqual(
+      visibleParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
+      'partial visible output',
+      'visible continuation output remains unduplicated after the next turn'
+    );
+    assertEqual(
+      warnings.some((entry) => entry.message === 'response continuation reset'),
+      false,
+      'new-chain request emits no continuation reset warning'
     );
   } finally {
     await closeServer(server);

--- a/test/smokeResponsesClient.mjs
+++ b/test/smokeResponsesClient.mjs
@@ -34,10 +34,18 @@ Module._load = function patchedLoad(request, parent, isMain) {
   return moduleLoad.call(this, request, parent, isMain);
 };
 
-const { disposeReusableResponsesWebSockets, isResponsesContinuationMissError, shouldBypassProxy, streamResponseText } = require(bundlePath);
+const {
+  disposeReusableResponsesWebSockets,
+  isResponsesContinuationMissError,
+  isResponsesContinuationMissPayload,
+  shouldBypassProxy,
+  streamResponseText
+} = require(bundlePath);
 
 try {
+  runContinuationMissClassifierSmokeTest(isResponsesContinuationMissPayload);
   await runHttpTransportSmokeTest(streamResponseText);
+  await runHttpContinuationMissSmokeTest(streamResponseText, isResponsesContinuationMissError);
   await runFunctionCallArgumentsDoneSmokeTest(streamResponseText);
   await runAutoFallbackSmokeTest(streamResponseText);
   await runManagedAutoFallbackVisibilitySmokeTest(streamResponseText);
@@ -46,6 +54,7 @@ try {
   await runWebSocketLowercaseNoProxySmokeTest(streamResponseText, shouldBypassProxy);
   await runWebSocketContinuationSmokeTest(streamResponseText);
   await runWebSocketContinuationMissSmokeTest(streamResponseText, isResponsesContinuationMissError);
+  await runManagedWebSocketContinuationMissSmokeTest(streamResponseText, isResponsesContinuationMissError);
   await runWebSocketToolOutputContinuationMissSmokeTest(streamResponseText, isResponsesContinuationMissError);
   await runWebSocketSequentialReuseSmokeTest(streamResponseText);
 
@@ -54,6 +63,103 @@ try {
   disposeReusableResponsesWebSockets();
   Module._load = moduleLoad;
   await rm(tempDir, { recursive: true, force: true });
+}
+
+function runContinuationMissClassifierSmokeTest(isContinuationMissPayload) {
+  const exactPayload = {
+    code: 'previous_response_not_found',
+    param: 'previous_response_id'
+  };
+  assertEqual(isContinuationMissPayload(exactPayload), true, 'exact continuation code and param classify');
+  assertEqual(
+    isContinuationMissPayload({ code: 'previous_response_not_found' }),
+    true,
+    'missing continuation param classifies'
+  );
+  assertEqual(
+    isContinuationMissPayload({ code: 'previous_response_not_found', param: 'input' }),
+    false,
+    'conflicting continuation param does not classify'
+  );
+  assertEqual(
+    isContinuationMissPayload(new Error('Backend prose mentioned previous_response_not_found during diagnostics.')),
+    false,
+    'unstructured prose does not classify'
+  );
+  assertEqual(
+    isContinuationMissPayload(new Error(JSON.stringify({ error: exactPayload }))),
+    true,
+    'bounded JSON Error.message envelope classifies'
+  );
+  assertEqual(
+    isContinuationMissPayload(new Error(JSON.stringify({ message: 'previous_response_not_found' }))),
+    false,
+    'JSON prose without an exact code does not classify'
+  );
+
+  const customErrorWrapper = new Error('Generic SDK rejection');
+  customErrorWrapper.error = { error: exactPayload };
+  assertEqual(isContinuationMissPayload(customErrorWrapper), true, 'custom Error.error wrapper classifies');
+
+  const causedError = new Error('Outer SDK rejection', {
+    cause: Object.assign(new Error('APIError-like rejection'), {
+      status: 400,
+      error: exactPayload
+    })
+  });
+  assertEqual(isContinuationMissPayload(causedError), true, 'nested Error.cause APIError-like wrapper classifies');
+
+  const cyclic = {};
+  cyclic.cause = cyclic;
+  assertEqual(isContinuationMissPayload(cyclic), false, 'cyclic wrapper terminates without classifying');
+
+  let getterInvocationCount = 0;
+  const unreadableWrapper = new Error('Unreadable custom wrapper');
+  Object.defineProperty(unreadableWrapper, 'error', {
+    get() {
+      getterInvocationCount += 1;
+      return { error: exactPayload };
+    }
+  });
+  unreadableWrapper.cause = { error: exactPayload };
+  assertEqual(isContinuationMissPayload(unreadableWrapper), true, 'accessor is skipped while data-descriptor cause classifies');
+  assertEqual(getterInvocationCount, 0, 'error envelope getter is never invoked');
+
+  let overlyDeep = exactPayload;
+  for (let depth = 0; depth < 9; depth += 1) {
+    overlyDeep = { cause: overlyDeep };
+  }
+  assertEqual(isContinuationMissPayload(overlyDeep), false, 'payload beyond traversal depth does not classify');
+
+  const overlyWide = createErrorEnvelopeTree(4);
+  let lastLeaf = overlyWide;
+  for (let depth = 0; depth < 4; depth += 1) {
+    lastLeaf = lastLeaf.message;
+  }
+  lastLeaf.code = 'previous_response_not_found';
+  lastLeaf.param = 'previous_response_id';
+  assertEqual(isContinuationMissPayload(overlyWide), false, 'payload beyond traversal node budget does not classify');
+
+  const oversizedMessage = JSON.stringify({
+    error: exactPayload,
+    padding: 'x'.repeat(17 * 1024)
+  });
+  assertEqual(
+    isContinuationMissPayload(new Error(oversizedMessage)),
+    false,
+    'oversized JSON Error.message is not parsed'
+  );
+}
+
+function createErrorEnvelopeTree(depth) {
+  if (depth === 0) {
+    return {};
+  }
+  return {
+    error: createErrorEnvelopeTree(depth - 1),
+    cause: createErrorEnvelopeTree(depth - 1),
+    message: createErrorEnvelopeTree(depth - 1)
+  };
 }
 
 async function runHttpTransportSmokeTest(streamResponseText) {
@@ -98,6 +204,57 @@ async function runHttpTransportSmokeTest(streamResponseText) {
 
     assertHttpRequest(capturedRequest, '/backend-api/codex/responses');
     assertEqual(deltas.join(''), 'hello world', 'HTTP streamed text');
+  } finally {
+    server.close();
+  }
+}
+
+async function runHttpContinuationMissSmokeTest(streamResponseText, isResponsesContinuationMissError) {
+  let requestCount = 0;
+  const server = createServer(async (request, response) => {
+    requestCount += 1;
+    for await (const _chunk of request) {
+      // Consume the request before returning the structured SDK APIError response.
+    }
+    response.writeHead(400, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({
+      error: {
+        type: 'invalid_request_error',
+        code: 'previous_response_not_found',
+        message: 'Remote continuation details must not control classification.',
+        param: 'previous_response_id'
+      }
+    }));
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const address = server.address();
+    let capturedError;
+    try {
+      await streamResponseText({
+        baseURL: `http://127.0.0.1:${address.port}/backend-api/codex/responses`,
+        apiKey: 'test-api-key',
+        headers: createHeaders(),
+        transport: 'http',
+        previousResponseId: 'resp_http_missing',
+        omitMaxOutputTokens: true,
+        model: 'gpt-5.5',
+        instructions: 'Smoke test instructions',
+        input: [{ role: 'user', content: 'Continue.' }],
+        maxOutputTokens: 32,
+        token: createCancellationToken(),
+        onTextDelta() {}
+      });
+    } catch (error) {
+      capturedError = error;
+    }
+
+    assertEqual(isResponsesContinuationMissError(capturedError), true, 'structured HTTP APIError classifies');
+    assertEqual(capturedError.previousResponseId, 'resp_http_missing', 'structured HTTP response id');
+    assertEqual(capturedError.message, 'Responses API could not find previous_response_id.', 'structured HTTP message is fixed');
+    assertEqual(requestCount, 1, 'structured HTTP miss is not retried by the client');
   } finally {
     server.close();
   }
@@ -660,7 +817,16 @@ async function runWebSocketContinuationSmokeTest(streamResponseText) {
 }
 
 async function runWebSocketContinuationMissSmokeTest(streamResponseText, isResponsesContinuationMissError) {
-  const server = createServer();
+  let httpRequestCount = 0;
+  const fallbackEvents = [];
+  const server = createServer(async (request, response) => {
+    httpRequestCount += 1;
+    for await (const _chunk of request) {
+      // Consume any unexpected fallback request before failing the test path.
+    }
+    response.writeHead(500, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ error: { message: 'HTTP fallback must not run.' } }));
+  });
   const webSocketServer = new WebSocketServer({ noServer: true });
 
   server.on('upgrade', (request, socket, head) => {
@@ -695,7 +861,7 @@ async function runWebSocketContinuationMissSmokeTest(streamResponseText, isRespo
         baseURL: `http://127.0.0.1:${address.port}/backend-api/codex/responses`,
         apiKey: 'test-api-key',
         headers: createHeaders(),
-        transport: 'websocket',
+        transport: 'auto',
         previousResponseId: 'resp_missing',
         omitMaxOutputTokens: true,
         model: 'gpt-5.5',
@@ -703,7 +869,8 @@ async function runWebSocketContinuationMissSmokeTest(streamResponseText, isRespo
         input: [{ role: 'user', content: 'Continue.' }],
         maxOutputTokens: 32,
         token: createCancellationToken(),
-        onTextDelta() {}
+        onTextDelta() {},
+        onTransportFallback: (event) => fallbackEvents.push(event)
       });
     } catch (error) {
       capturedError = error;
@@ -711,6 +878,117 @@ async function runWebSocketContinuationMissSmokeTest(streamResponseText, isRespo
 
     assertEqual(isResponsesContinuationMissError(capturedError), true, 'continuation miss classification');
     assertEqual(capturedError.previousResponseId, 'resp_missing', 'continuation miss response id');
+    assertEqual(capturedError.cause?.error?.type, 'error', 'continuation miss retains actual SDK WebSocket wrapper');
+    assertEqual(httpRequestCount, 0, 'structured WebSocket API miss never falls back to HTTP');
+    assertEqual(fallbackEvents.length, 0, 'structured WebSocket API miss reports no fallback');
+  } finally {
+    webSocketServer.close();
+    server.close();
+  }
+}
+
+async function runManagedWebSocketContinuationMissSmokeTest(streamResponseText, isResponsesContinuationMissError) {
+  let httpRequestCount = 0;
+  const fallbackEvents = [];
+  const server = createServer(async (request, response) => {
+    httpRequestCount += 1;
+    for await (const _chunk of request) {
+      // Consume any unexpected fallback request before failing the test path.
+    }
+    response.writeHead(500, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ error: { message: 'Managed HTTP fallback must not run.' } }));
+  });
+  const webSocketServer = new WebSocketServer({ noServer: true });
+
+  server.on('upgrade', (request, socket, head) => {
+    webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+      webSocketServer.emit('connection', webSocket, request);
+    });
+  });
+
+  webSocketServer.on('connection', (webSocket, request) => {
+    webSocket.once('message', () => {
+      if (request.headers['session-id'] === 'managed-error-event') {
+        webSocket.send(JSON.stringify({
+          type: 'error',
+          error: {
+            type: 'invalid_request_error',
+            code: 'previous_response_not_found',
+            message: 'Managed WebSocket error event.',
+            param: 'previous_response_id'
+          },
+          status: 400
+        }));
+        return;
+      }
+
+      webSocket.send(JSON.stringify({
+        type: 'response.failed',
+        response: {
+          id: 'resp_managed_missing',
+          status: 'failed',
+          error: {
+            type: 'invalid_request_error',
+            message: JSON.stringify({
+              error: {
+                code: 'previous_response_not_found',
+                param: 'previous_response_id'
+              }
+            })
+          }
+        }
+      }));
+    });
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const address = server.address();
+    const baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+    const runManagedRequest = async (sessionId, previousResponseId) => {
+      try {
+        await streamResponseText({
+          baseURL,
+          apiKey: 'test-api-key',
+          headers: createHeaders(),
+          transport: 'auto',
+          compatibilityProfile: { enabled: true, endpointKey: baseURL },
+          authIdentity: 'codexAuth:acct-test',
+          identity: {
+            installationId: '11111111-1111-4111-8111-111111111111',
+            sessionId,
+            threadId: `${sessionId}-thread`,
+            turnId: `${sessionId}-turn`,
+            windowId: '55555555-5555-4555-8555-555555555555'
+          },
+          websocketPrewarm: 'disabled',
+          requestCompression: 'disabled',
+          previousResponseId,
+          omitMaxOutputTokens: true,
+          model: 'gpt-5.5',
+          instructions: 'Smoke test instructions',
+          input: [{ role: 'user', content: 'Continue managed session.' }],
+          maxOutputTokens: 32,
+          token: createCancellationToken(),
+          onTextDelta() {},
+          onTransportFallback: (event) => fallbackEvents.push(event)
+        });
+      } catch (error) {
+        return error;
+      }
+      return undefined;
+    };
+
+    const managedErrorEvent = await runManagedRequest('managed-error-event', 'resp_managed_error_previous');
+    const managedFailedEvent = await runManagedRequest('managed-failed-event', 'resp_managed_failed_previous');
+
+    assertEqual(isResponsesContinuationMissError(managedErrorEvent), true, 'managed WebSocket error miss classification');
+    assertEqual(managedErrorEvent.previousResponseId, 'resp_managed_error_previous', 'managed WebSocket error response id');
+    assertEqual(isResponsesContinuationMissError(managedFailedEvent), true, 'managed response.failed miss classification');
+    assertEqual(managedFailedEvent.previousResponseId, 'resp_managed_failed_previous', 'managed response.failed response id');
+    assertEqual(httpRequestCount, 0, 'managed structured API misses never fall back to HTTP');
+    assertEqual(fallbackEvents.length, 0, 'managed structured API misses report no fallback');
   } finally {
     webSocketServer.close();
     server.close();


### PR DESCRIPTION
## Summary

- classify exact `previous_response_not_found` codes through bounded SDK/API error wrappers across HTTP, direct WebSocket, and managed WebSocket paths
- avoid prose false positives, accessor execution, unbounded traversal, oversized JSON parsing, and HTTP fallback for structured API misses
- retry full caller history at most once before visible output; after visible output, surface the error without replay and invalidate the stale response/branch for the next turn
- use fixed sanitized diagnostics instead of backend error text

This completes the wrapped-error acceptance gap discussed in #7 without reviving the obsolete PR #8 transport branch.

## Verification

- `npm run compile`
- `npm run test:smoke`
- `node test/smokeResponsesClient.mjs`
- `node test/smokeProviderFallback.mjs`
- LSP diagnostics: no findings
- `git diff --check`: clean

Focused coverage includes Error `.error` / `.cause` wrappers, exact param validation, cycles, depth/node/string bounds, zero getter invocation, direct/managed transport parity, no HTTP fallback, one pre-output replay, no post-output replay, and subsequent full-input recovery after stale-branch invalidation.