### PR TITLE
fix: enforce model discovery policy

### DIFF
--- a/src/codexModelCache.ts
+++ b/src/codexModelCache.ts
@@ -79,6 +79,11 @@ export class CodexModelCache<T> {
     };
   }
 
+  peek(key: string): T | undefined {
+    const entry = this.entries.get(key);
+    return entry?.version === this.versionFor(key) ? entry.value : undefined;
+  }
+
   invalidate(key: string): void {
     this.entries.delete(key);
     this.invalidationVersions.set(key, (this.invalidationVersions.get(key) ?? 0) + 1);

--- a/src/models.ts
+++ b/src/models.ts
@@ -144,15 +144,20 @@ export async function fetchAvailableModels(
     throw new Error(`Model discovery failed with ${response.status} ${response.statusText}`);
   }
 
-  const payload = (await response.json()) as { models?: unknown; data?: unknown };
-  const discovered = Array.isArray(payload.models)
+  const payload = (await response.json()) as { models?: unknown; data?: unknown } | null;
+  const discovered = Array.isArray(payload?.models)
     ? payload.models
-    : Array.isArray(payload.data)
+    : Array.isArray(payload?.data)
       ? payload.data
-      : [];
+      : undefined;
+  if (!discovered) {
+    throw new Error('Model discovery returned an invalid catalog.');
+  }
+  if (!discovered.every(isUpstreamModel)) {
+    throw new Error('Model discovery returned an invalid catalog.');
+  }
 
   return discovered
-    .filter(isUpstreamModel)
     .filter((model) => isModelVisible(model, credentials.kind, config.includeHiddenModels));
 }
 
@@ -172,7 +177,7 @@ export function buildProviderModels(
       seenModelIds.add(model.info.id);
       return true;
     });
-  return models.length > 0 ? models : [buildFallbackModel(config, credentialKind)];
+  return models;
 }
 
 export function buildFallbackModel(config: ProviderConfig, credentialKind: ApiCredentials['kind']): ResolvedProviderModel {
@@ -575,7 +580,12 @@ function normalizeSentence(value: string): string {
 }
 
 function isUpstreamModel(value: unknown): value is UpstreamModel {
-  return typeof value === 'object' && value !== null;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const slug = (value as UpstreamModel).slug;
+  return typeof slug === 'string' && slug.trim().length > 0;
 }
 
 function isModelVisible(

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -81,6 +81,7 @@ type VSCodeWithThinkingPart = typeof vscode & {
 
 const USAGE_DATA_PART_MIME = 'usage';
 const MODEL_DISCOVERY_FALLBACK_TTL_MS = 60_000;
+const TEMPORARILY_UNAVAILABLE_MODEL_TTL_MS = 10 * 60_000;
 const REPORTED_TOOL_CALL_TTL_MS = 10 * 60_000;
 const MAX_PENDING_REPORTED_TOOL_CALLS = 200;
 const TOOL_OUTPUT_CONTINUATION_CAPABILITY_TTL_MS = 30 * 60_000;
@@ -1078,9 +1079,15 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     const authIdentity = getCredentialIdentity(credentials);
     const cacheKey = buildModelCacheKey(config, credentials.source, credentials.kind, authIdentity);
     try {
-      const lookup = await this.modelCache.get(
-        cacheKey,
-        () => this.discoverAvailableModels(config, credentials, token, authIdentity)
+      if (token.isCancellationRequested) {
+        throw createAbortError();
+      }
+      const lookup = await waitForPromiseWithCancellation(
+        this.modelCache.get(
+          cacheKey,
+          () => this.discoverAvailableModels(config, credentials, NON_CANCELLABLE_TOKEN, authIdentity)
+        ),
+        token
       );
       this.outputChannel.debug('getAvailableModels cache result', {
         modelDiscoveryCacheState: lookup.state,
@@ -1153,7 +1160,19 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
   ): void {
     this.runtimeAvailability.markTemporarilyUnavailable(model, config, authIdentity);
     const cacheKey = buildModelCacheKey(config, credentials.source, credentials.kind, authIdentity);
-    this.modelCache.invalidate(cacheKey);
+    const cachedCatalog = this.modelCache.peek(cacheKey);
+    if (cachedCatalog?.authoritative) {
+      this.modelCache.invalidate(cacheKey);
+      this.modelCache.set(cacheKey, {
+        models: cachedCatalog.models.filter((candidate) => candidate.requestModel !== model),
+        authoritative: true
+      }, {
+        freshTtlMs: 0,
+        staleTtlMs: TEMPORARILY_UNAVAILABLE_MODEL_TTL_MS
+      });
+    } else {
+      this.modelCache.invalidate(cacheKey);
+    }
     this.modelInfoChangedEmitter.fire();
     this.outputChannel.warn('model marked unavailable after responses rejection', {
       model,
@@ -1307,6 +1326,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       };
     }
 
+    if (authoritative) {
+      throw new Error(`Selected Codex model "${requestedModel.requestModel}" is not available in the authoritative model catalog.`);
+    }
+
     const prefixMatch = availableModels
       .filter((candidate) => requestedModel.requestModel.startsWith(`${candidate.requestModel}-`))
       .sort((left, right) => right.requestModel.length - left.requestModel.length)[0];
@@ -1322,10 +1345,6 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         reasoningEffort: requestedModel.reasoningEffort,
         effectiveInputBudget: prefixMatch.effectiveInputBudget
       };
-    }
-
-    if (authoritative) {
-      throw new Error(`Selected Codex model "${requestedModel.requestModel}" is not available in the authoritative model catalog.`);
     }
 
     const configuredModel = availableModels.find((candidate) => candidate.requestModel === config.model);
@@ -1455,7 +1474,10 @@ class RuntimeModelAvailability {
 
   markTemporarilyUnavailable(model: string, config: ProviderConfig, authIdentity: string): void {
     this.evictExpiredEntries();
-    this.temporarilyUnavailableModels.set(this.getScopeKey(model, config, authIdentity), Date.now() + 10 * 60 * 1000);
+    this.temporarilyUnavailableModels.set(
+      this.getScopeKey(model, config, authIdentity),
+      Date.now() + TEMPORARILY_UNAVAILABLE_MODEL_TTL_MS
+    );
   }
 
   getTemporarilyUnavailableModels(config: ProviderConfig, authIdentity: string): string[] {
@@ -1649,6 +1671,43 @@ function supportsOfficialTokenCounting(baseURL: string): boolean {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';
+}
+
+function waitForPromiseWithCancellation<T>(promise: Promise<T>, token: vscode.CancellationToken): Promise<T> {
+  if (token.isCancellationRequested) {
+    return Promise.reject(createAbortError());
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let cancellation: vscode.Disposable | undefined;
+    const settle = (action: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cancellation?.dispose();
+      action();
+    };
+
+    cancellation = token.onCancellationRequested(() => {
+      settle(() => reject(createAbortError()));
+    });
+    if (settled) {
+      cancellation.dispose();
+    }
+
+    void promise.then(
+      (value) => settle(() => resolve(value)),
+      (error: unknown) => settle(() => reject(error))
+    );
+  });
+}
+
+function createAbortError(): Error {
+  const error = new Error('Operation canceled.');
+  error.name = 'AbortError';
+  return error;
 }
 
 function createThinkingPart(text: string, id?: string): vscode.LanguageModelResponsePart | undefined {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -65,6 +65,11 @@ interface ResolvedRequestModel extends ParsedModelIdentifier {
   effectiveInputBudget?: number;
 }
 
+interface ProviderModelCatalog {
+  models: ResolvedProviderModel[];
+  authoritative: boolean;
+}
+
 type ModelAliasResolution =
   | { kind: 'none' }
   | { kind: 'target'; targetModel: string }
@@ -154,7 +159,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
   private readonly identityManager: CodexIdentityManager;
   private readonly pendingReportedToolCalls = new Map<string, ReportedToolCall>();
   private readonly toolOutputContinuationCapabilities = new Map<string, ToolOutputContinuationCapability>();
-  private readonly modelCache = new CodexModelCache<ResolvedProviderModel[]>({
+  private readonly modelCache = new CodexModelCache<ProviderModelCatalog>({
     freshTtlMs: MODEL_CACHE_FRESH_TTL_MS,
     staleTtlMs: MODEL_CACHE_STALE_TTL_MS
   });
@@ -222,7 +227,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       return [];
     }
 
-    const models = await this.getAvailableModels(config, credentials, token);
+    const { models } = await this.getAvailableModelCatalog(config, credentials, token);
     this.scheduleWebSocketPreconnection(config, credentials, getCredentialIdentity(credentials));
     this.outputChannel.info('provideLanguageModelChatInformation complete', {
       modelCount: models.length,
@@ -255,7 +260,11 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     const authIdentity = getCredentialIdentity(credentials);
     this.handleConnectionConfiguration(config, authIdentity);
     const compatibilityProfile = getCodexCompatibilityProfile(config.baseURL, credentials);
-    const directModel = this.resolveDirectRequestModel(model, config, authIdentity);
+    const modelCacheKey = buildModelCacheKey(config, credentials.source, credentials.kind, authIdentity);
+    const cachedCatalog = this.modelCache.peek(modelCacheKey);
+    const directModel = cachedCatalog?.authoritative
+      ? undefined
+      : this.resolveDirectRequestModel(model, config, authIdentity);
     let selectedModel: ResolvedRequestModel;
     if (directModel) {
       selectedModel = directModel;
@@ -265,10 +274,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         requestModel: selectedModel.requestModel
       });
     } else {
-      const availableModels = await this.getAvailableModels(config, credentials, token, (state) => {
+      const catalog = await this.getAvailableModelCatalog(config, credentials, token, (state) => {
         latency.recordContext({ modelDiscoveryCacheState: state });
       });
-      selectedModel = this.resolveRequestModel(model.id, config, availableModels);
+      selectedModel = this.resolveRequestModel(model.id, config, catalog.models, catalog.authoritative);
     }
     this.scheduleWebSocketPreconnection(config, credentials, authIdentity);
     latency.mark('modelResolved');
@@ -1022,12 +1031,12 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       return estimated;
     }
 
-    const availableModels = await this.getAvailableModels(config, credentials, token);
-    const selectedModel = this.resolveRequestModel(model.id, config, availableModels);
-    const input = typeof text === 'string' ? text : convertMessagesToResponsesInput([text]);
     const startedAt = Date.now();
 
     try {
+      const catalog = await this.getAvailableModelCatalog(config, credentials, token);
+      const selectedModel = this.resolveRequestModel(model.id, config, catalog.models, catalog.authoritative);
+      const input = typeof text === 'string' ? text : convertMessagesToResponsesInput([text]);
       const count = await countInputTokens({
         baseURL: config.baseURL,
         apiKey: credentials.apiKey,
@@ -1044,11 +1053,15 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         durationMs: Date.now() - startedAt
       });
       return count;
-    } catch {
+    } catch (error) {
+      if (token.isCancellationRequested || isAbortError(error)) {
+        throw error;
+      }
       const estimated = estimateTokenCount(text);
+      const requestModel = parseModelIdentifier(model.id || config.model).requestModel;
       this.outputChannel.warn('provideTokenCount fallback to local estimate', {
         modelId: model.id,
-        requestModel: selectedModel.requestModel,
+        requestModel,
         count: estimated,
         durationMs: Date.now() - startedAt
       });
@@ -1056,12 +1069,12 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     }
   }
 
-  private async getAvailableModels(
+  private async getAvailableModelCatalog(
     config: ReturnType<typeof getProviderConfig>,
     credentials: NonNullable<Awaited<ReturnType<typeof getApiCredentials>>>,
     token: vscode.CancellationToken,
     onCacheState?: (state: CodexModelCacheState | 'fallback') => void
-  ): Promise<ResolvedProviderModel[]> {
+  ): Promise<ProviderModelCatalog> {
     const authIdentity = getCredentialIdentity(credentials);
     const cacheKey = buildModelCacheKey(config, credentials.source, credentials.kind, authIdentity);
     try {
@@ -1071,7 +1084,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       );
       this.outputChannel.debug('getAvailableModels cache result', {
         modelDiscoveryCacheState: lookup.state,
-        modelCount: lookup.value.length,
+        modelCount: lookup.value.models.length,
         refreshStarted: lookup.refreshStarted
       });
       onCacheState?.(lookup.state);
@@ -1084,9 +1097,27 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         );
       }
       return lookup.value;
-    } catch {
+    } catch (error) {
+      if (token.isCancellationRequested || isAbortError(error)) {
+        throw error;
+      }
+
+      const cachedCatalog = this.modelCache.peek(cacheKey);
+      if (cachedCatalog?.authoritative) {
+        this.modelCache.set(cacheKey, cachedCatalog, {
+          freshTtlMs: MODEL_DISCOVERY_FALLBACK_TTL_MS,
+          staleTtlMs: MODEL_DISCOVERY_FALLBACK_TTL_MS
+        });
+        this.outputChannel.warn('getAvailableModels discovery failed, retaining authoritative catalog', {
+          modelCount: cachedCatalog.models.length
+        });
+        onCacheState?.('fallback');
+        return cachedCatalog;
+      }
+
       const fallbackModels = this.applyModelDiscoveryPolicy([buildFallbackModel(config, credentials.kind)], config, authIdentity);
-      this.modelCache.set(cacheKey, fallbackModels, {
+      const fallbackCatalog = { models: fallbackModels, authoritative: false };
+      this.modelCache.set(cacheKey, fallbackCatalog, {
         freshTtlMs: MODEL_DISCOVERY_FALLBACK_TTL_MS,
         staleTtlMs: MODEL_DISCOVERY_FALLBACK_TTL_MS
       });
@@ -1094,7 +1125,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         fallbackModel: config.model
       });
       onCacheState?.('fallback');
-      return fallbackModels;
+      return fallbackCatalog;
     }
   }
 
@@ -1103,7 +1134,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     credentials: NonNullable<Awaited<ReturnType<typeof getApiCredentials>>>,
     token: vscode.CancellationToken,
     authIdentity: string
-  ): Promise<ResolvedProviderModel[]> {
+  ): Promise<ProviderModelCatalog> {
     const upstreamModels = await fetchAvailableModels(config, credentials, token);
     const models = this.applyModelDiscoveryPolicy(buildProviderModels(config, upstreamModels, credentials.kind), config, authIdentity);
     this.outputChannel.info('getAvailableModels discovery success', {
@@ -1111,7 +1142,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       returnedCount: models.length,
       requestModels: models.map((model) => model.requestModel)
     });
-    return models;
+    return { models, authoritative: true };
   }
 
   private markModelUnavailable(
@@ -1130,7 +1161,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       authIdentity,
       baseURL: normalizeBaseURL(config.baseURL)
     });
-    void this.getAvailableModels(config, credentials, NON_CANCELLABLE_TOKEN).then(
+    void this.getAvailableModelCatalog(config, credentials, NON_CANCELLABLE_TOKEN).then(
       () => this.modelInfoChangedEmitter.fire(),
       () => this.outputChannel.warn('model refresh failed after responses model rejection', { model })
     );
@@ -1232,7 +1263,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
   private resolveRequestModel(
     modelId: string | undefined,
     config: ProviderConfig,
-    availableModels: readonly ResolvedProviderModel[]
+    availableModels: readonly ResolvedProviderModel[],
+    authoritative = false
   ): ResolvedRequestModel {
     if (availableModels.length === 0) {
       throw new Error('No Codex models are available after applying the configured discovery policy.');
@@ -1290,6 +1322,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         reasoningEffort: requestedModel.reasoningEffort,
         effectiveInputBudget: prefixMatch.effectiveInputBudget
       };
+    }
+
+    if (authoritative) {
+      throw new Error(`Selected Codex model "${requestedModel.requestModel}" is not available in the authoritative model catalog.`);
     }
 
     const configuredModel = availableModels.find((candidate) => candidate.requestModel === config.model);
@@ -1609,6 +1645,10 @@ function normalizeReasoningEffort(value: unknown): ReasoningEffort | undefined {
 function supportsOfficialTokenCounting(baseURL: string): boolean {
   const normalizedBaseURL = normalizeBaseURL(baseURL).toLowerCase();
   return !normalizedBaseURL.includes('chatgpt.com/backend-api/codex');
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }
 
 function createThinkingPart(text: string, id?: string): vscode.LanguageModelResponsePart | undefined {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -61,6 +61,15 @@ interface ReasoningEffortResolution {
   hasExplicitConflict: boolean;
 }
 
+interface ResolvedRequestModel extends ParsedModelIdentifier {
+  effectiveInputBudget?: number;
+}
+
+type ModelAliasResolution =
+  | { kind: 'none' }
+  | { kind: 'target'; targetModel: string }
+  | { kind: 'cycle' };
+
 type VSCodeWithThinkingPart = typeof vscode & {
   LanguageModelThinkingPart?: new (value: string | string[], id?: string, metadata?: { readonly [key: string]: any }) => unknown;
 };
@@ -246,8 +255,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     const authIdentity = getCredentialIdentity(credentials);
     this.handleConnectionConfiguration(config, authIdentity);
     const compatibilityProfile = getCodexCompatibilityProfile(config.baseURL, credentials);
-    const directModel = this.resolveDirectRequestModel(model.id, config, authIdentity);
-    let selectedModel: ParsedModelIdentifier;
+    const directModel = this.resolveDirectRequestModel(model, config, authIdentity);
+    let selectedModel: ResolvedRequestModel;
     if (directModel) {
       selectedModel = directModel;
       latency.recordContext({ modelDiscoveryCacheState: 'direct' });
@@ -302,7 +311,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       baseURL: normalizeBaseURL(config.baseURL),
       authIdentity,
       toolSignatures: toolSchemas.toolSignatures,
-      effectiveInputBudget: model.maxInputTokens,
+      effectiveInputBudget: selectedModel.effectiveInputBudget,
       ...requestOptions
     });
     latency.recordContext({ requestBuildMs: Math.max(0, performance.now() - requestBuildStartedAt) });
@@ -1224,7 +1233,11 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     modelId: string | undefined,
     config: ProviderConfig,
     availableModels: readonly ResolvedProviderModel[]
-  ): ParsedModelIdentifier {
+  ): ResolvedRequestModel {
+    if (availableModels.length === 0) {
+      throw new Error('No Codex models are available after applying the configured discovery policy.');
+    }
+
     const parsedModel = parseModelIdentifier(modelId || config.model);
     const exactAvailableModel = modelId
       ? availableModels.find((candidate) => candidate.info.id === modelId)
@@ -1233,9 +1246,13 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       requestModel: exactAvailableModel?.requestModel ?? parsedModel.requestModel,
       reasoningEffort: parsedModel.reasoningEffort
     };
-    const availableModelNames = new Set(availableModels.map((candidate) => candidate.requestModel));
-
-    const aliasedModel = this.resolveModelAlias(requestedModel.requestModel, config.modelAliases, availableModels);
+    const aliasResolution = resolveModelAliasTarget(requestedModel.requestModel, config.modelAliases);
+    if (aliasResolution.kind === 'cycle') {
+      throw new Error(`Model alias cycle detected for "${requestedModel.requestModel}".`);
+    }
+    const aliasedModel = aliasResolution.kind === 'target'
+      ? availableModels.find((candidate) => candidate.requestModel === aliasResolution.targetModel)
+      : undefined;
     if (aliasedModel) {
       this.outputChannel.warn('request model remapped from configured model alias', {
         requestedModelId: modelId ?? null,
@@ -1244,32 +1261,39 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       });
       return {
         requestModel: aliasedModel.requestModel,
-        reasoningEffort: requestedModel.reasoningEffort
+        reasoningEffort: requestedModel.reasoningEffort,
+        effectiveInputBudget: aliasedModel.effectiveInputBudget
       };
     }
 
-    if (availableModelNames.has(requestedModel.requestModel)) {
-      return requestedModel;
+    const requestedAvailableModel = exactAvailableModel
+      ?? availableModels.find((candidate) => candidate.requestModel === requestedModel.requestModel);
+    if (requestedAvailableModel) {
+      return {
+        ...requestedModel,
+        effectiveInputBudget: requestedAvailableModel.effectiveInputBudget
+      };
     }
 
     const prefixMatch = availableModels
-      .map((candidate) => candidate.requestModel)
-      .filter((candidate) => requestedModel.requestModel.startsWith(`${candidate}-`))
-      .sort((left, right) => right.length - left.length)[0];
+      .filter((candidate) => requestedModel.requestModel.startsWith(`${candidate.requestModel}-`))
+      .sort((left, right) => right.requestModel.length - left.requestModel.length)[0];
 
     if (prefixMatch) {
       this.outputChannel.warn('request model remapped from stale model identifier', {
         requestedModelId: modelId ?? null,
         requestedModel: requestedModel.requestModel,
-        resolvedModel: prefixMatch
+        resolvedModel: prefixMatch.requestModel
       });
       return {
-        requestModel: prefixMatch,
-        reasoningEffort: requestedModel.reasoningEffort
+        requestModel: prefixMatch.requestModel,
+        reasoningEffort: requestedModel.reasoningEffort,
+        effectiveInputBudget: prefixMatch.effectiveInputBudget
       };
     }
 
-    if (availableModelNames.has(config.model)) {
+    const configuredModel = availableModels.find((candidate) => candidate.requestModel === config.model);
+    if (configuredModel) {
       this.outputChannel.warn('request model fell back to configured model', {
         requestedModelId: modelId ?? null,
         requestedModel: requestedModel.requestModel,
@@ -1277,33 +1301,39 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       });
       return {
         requestModel: config.model,
-        reasoningEffort: requestedModel.reasoningEffort
+        reasoningEffort: requestedModel.reasoningEffort,
+        effectiveInputBudget: configuredModel.effectiveInputBudget
       };
     }
 
-    const fallbackModel = availableModels[0]?.requestModel ?? config.model;
+    const fallbackModel = availableModels[0];
     this.outputChannel.warn('request model fell back to first available model', {
       requestedModelId: modelId ?? null,
       requestedModel: requestedModel.requestModel,
-      resolvedModel: fallbackModel
+      resolvedModel: fallbackModel.requestModel
     });
     return {
-      requestModel: fallbackModel,
-      reasoningEffort: requestedModel.reasoningEffort
+      requestModel: fallbackModel.requestModel,
+      reasoningEffort: requestedModel.reasoningEffort,
+      effectiveInputBudget: fallbackModel.effectiveInputBudget
     };
   }
 
   private resolveDirectRequestModel(
-    modelId: string | undefined,
+    model: vscode.LanguageModelChatInformation,
     config: ProviderConfig,
     authIdentity: string
-  ): ParsedModelIdentifier | undefined {
-    if (!isProviderModelIdentifier(modelId)) {
+  ): ResolvedRequestModel | undefined {
+    if (!isProviderModelIdentifier(model.id)) {
       return undefined;
     }
 
-    const requestedModel = parseModelIdentifier(modelId);
-    const alias = config.modelAliases[requestedModel.requestModel];
+    const requestedModel = parseModelIdentifier(model.id);
+    const aliasResolution = resolveModelAliasTarget(requestedModel.requestModel, config.modelAliases);
+    if (aliasResolution.kind === 'cycle') {
+      throw new Error(`Model alias cycle detected for "${requestedModel.requestModel}".`);
+    }
+    const alias = aliasResolution.kind === 'target' ? aliasResolution.targetModel : undefined;
     const resolvedModel = alias
       ? { ...requestedModel, requestModel: alias }
       : requestedModel;
@@ -1317,12 +1347,13 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
 
     if (alias) {
       this.outputChannel.warn('request model remapped from configured model alias', {
-        requestedModelId: modelId,
+        requestedModelId: model.id,
         requestedModel: requestedModel.requestModel,
         resolvedModel: alias
       });
     }
-    return resolvedModel;
+    const effectiveInputBudget = alias ? undefined : model.maxInputTokens;
+    return { ...resolvedModel, effectiveInputBudget };
   }
 
   private applyModelDiscoveryPolicy(models: ResolvedProviderModel[], config: ProviderConfig, authIdentity: string): ResolvedProviderModel[] {
@@ -1332,18 +1363,20 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     ]);
     const availableModelNames = new Set(models.map((model) => model.requestModel));
     const aliasedSources = new Set(
-      Object.entries(config.modelAliases)
-        .filter(([, target]) => availableModelNames.has(target))
-        .map(([source]) => source)
+      Object.keys(config.modelAliases)
+        .filter((source) => {
+          const resolution = resolveModelAliasTarget(source, config.modelAliases);
+          return resolution.kind === 'cycle'
+            || (resolution.kind === 'target' && availableModelNames.has(resolution.targetModel));
+        })
     );
     const filteredModels = models.filter((model) => !disabledModels.has(model.requestModel) && !aliasedSources.has(model.requestModel));
 
-    if (filteredModels.length === 0) {
-      this.outputChannel.warn('model discovery policy kept original models because every discovered model was filtered', {
+    if (models.length > 0 && filteredModels.length === 0) {
+      this.outputChannel.warn('model discovery policy filtered every discovered model', {
         disabledModels: [...disabledModels],
         modelAliases: config.modelAliases
       });
-      return models;
     }
 
     if (filteredModels.length !== models.length) {
@@ -1357,18 +1390,27 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
 
     return filteredModels;
   }
+}
 
-  private resolveModelAlias(
-    model: string,
-    modelAliases: Record<string, string>,
-    availableModels: readonly ResolvedProviderModel[]
-  ): ResolvedProviderModel | undefined {
-    const targetModel = modelAliases[model];
-    if (!targetModel) {
-      return undefined;
+function resolveModelAliasTarget(model: string, modelAliases: Record<string, string>): ModelAliasResolution {
+  const firstTarget = modelAliases[model];
+  if (!firstTarget) {
+    return { kind: 'none' };
+  }
+
+  const visitedModels = new Set([model]);
+  let targetModel = firstTarget;
+  while (true) {
+    if (visitedModels.has(targetModel)) {
+      return { kind: 'cycle' };
     }
+    visitedModels.add(targetModel);
 
-    return availableModels.find((candidate) => candidate.requestModel === targetModel);
+    const nextTarget = modelAliases[targetModel];
+    if (!nextTarget) {
+      return { kind: 'target', targetModel };
+    }
+    targetModel = nextTarget;
   }
 }
 

--- a/test/smokeCodexModelCache.mjs
+++ b/test/smokeCodexModelCache.mjs
@@ -115,6 +115,28 @@ async function runStaleWhileRevalidateSmokeTest(CodexModelCache) {
   cache.invalidate('scope');
   assertEqual(cache.peek('scope'), undefined, 'invalidating a key removes its peek value');
 
+  const versionedCache = new CodexModelCache({
+    freshTtlMs: 100,
+    staleTtlMs: 1_000,
+    now: () => now
+  });
+  versionedCache.set('scope', ['gpt-original']);
+  now += 101;
+  let resolveSupersededRefresh;
+  const supersededRefreshValue = new Promise((resolve) => {
+    resolveSupersededRefresh = resolve;
+  });
+  const supersededRefresh = await versionedCache.get('scope', async () => supersededRefreshValue);
+  versionedCache.invalidate('scope');
+  versionedCache.set('scope', ['gpt-filtered']);
+  resolveSupersededRefresh(['gpt-original']);
+  await supersededRefresh.refresh;
+  assertEqual(
+    versionedCache.peek('scope').join(','),
+    'gpt-filtered',
+    'invalidated in-flight refresh cannot overwrite a replacement value'
+  );
+
   const boundedCache = new CodexModelCache({
     freshTtlMs: 100,
     staleTtlMs: 1_000,

--- a/test/smokeCodexModelCache.mjs
+++ b/test/smokeCodexModelCache.mjs
@@ -41,6 +41,7 @@ async function runStaleWhileRevalidateSmokeTest(CodexModelCache) {
   assertEqual(first.state, 'cold', 'cold cache state');
   assertEqual(first.value.join(','), 'gpt-first', 'cold cache value');
   assertEqual(loadCount, 1, 'cold cache load count');
+  assertEqual(cache.peek('scope').join(','), 'gpt-first', 'peek returns the cached value');
 
   now += 50;
   const fresh = await cache.get('scope', async () => {
@@ -105,10 +106,26 @@ async function runStaleWhileRevalidateSmokeTest(CodexModelCache) {
   });
   await Promise.resolve();
   assertEqual(coldSettled, false, 'expired cache waits for a cold refresh');
+  assertEqual(cache.peek('scope').join(','), 'gpt-refreshed', 'peek retains an expired value during cold refresh');
   resolveCold(['gpt-cold']);
   const coldResult = await cold;
   assertEqual(coldResult.state, 'cold', 'expired cache returns cold state');
   assertEqual(coldResult.value.join(','), 'gpt-cold', 'expired cache returns refreshed value');
+
+  cache.invalidate('scope');
+  assertEqual(cache.peek('scope'), undefined, 'invalidating a key removes its peek value');
+
+  const boundedCache = new CodexModelCache({
+    freshTtlMs: 100,
+    staleTtlMs: 1_000,
+    maxEntries: 1,
+    now: () => now
+  });
+  boundedCache.set('first', ['gpt-first']);
+  now += 1;
+  boundedCache.set('second', ['gpt-second']);
+  assertEqual(boundedCache.peek('first'), undefined, 'eviction removes the oldest peek value');
+  assertEqual(boundedCache.peek('second').join(','), 'gpt-second', 'peek retains the bounded cache entry');
 }
 
 async function assertRejects(promise, label) {

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -173,6 +173,7 @@ const { buildFallbackModel, buildProviderModels, fetchAvailableModels } = requir
 
 try {
   await runModelCatalogMetadataSmokeTest();
+  await runProviderMalformedCatalogFallbackSmokeTest();
   await runProviderLongContextSelectionSmokeTest();
   await runProviderFallbackSmokeTest();
   await runInterleavedResponsePresentationSmokeTest();
@@ -185,6 +186,7 @@ try {
   await runProviderCatalogVersionNeutralSmokeTest();
   await runProviderUnavailableScopeSmokeTest();
   await runProviderModelDiscoveryPolicySmokeTest();
+  await runProviderNestedAliasPolicySmokeTest();
   await runProviderStaleModelRefreshDoesNotBlockResponseSmokeTest();
   await runProviderModelIdDoesNotBlockColdDiscoverySmokeTest();
   console.log('Smoke test passed: provider advertises effective context profiles, sends real model slugs, and preserves runtime availability policy.');
@@ -225,12 +227,13 @@ async function runModelCatalogMetadataSmokeTest() {
       visibility: 'hidden'
     })
   ];
+  let catalogPayload = { models: catalog };
   let catalogRequestCount = 0;
   const server = createServer((request, response) => {
     if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
       catalogRequestCount += 1;
       response.writeHead(200, { 'content-type': 'application/json' });
-      response.end(JSON.stringify({ models: catalog }));
+      response.end(JSON.stringify(catalogPayload));
       return;
     }
 
@@ -267,6 +270,45 @@ async function runModelCatalogMetadataSmokeTest() {
       kind: 'openaiApiKey',
       omitMaxOutputTokens: false
     }, token);
+
+    catalogPayload = { models: [] };
+    const emptyCatalog = await fetchAvailableModels(config, {
+      ...sharedCredentials,
+      kind: 'codexAccessToken'
+    }, token);
+    assertEqual(emptyCatalog.length, 0, 'successful empty catalog remains empty');
+    assertEqual(
+      buildProviderModels(config, emptyCatalog, 'codexAccessToken').length,
+      0,
+      'successful empty catalog does not synthesize the configured fallback model'
+    );
+
+    catalogPayload = { unexpected: [] };
+    let invalidCatalogMessage = '';
+    try {
+      await fetchAvailableModels(config, {
+        ...sharedCredentials,
+        kind: 'codexAccessToken'
+      }, token);
+    } catch (error) {
+      invalidCatalogMessage = error instanceof Error ? error.message : String(error);
+    }
+    assertEqual(invalidCatalogMessage, 'Model discovery returned an invalid catalog.', 'malformed catalog is treated as discovery failure');
+
+    for (const malformedModels of [[null], [catalog[0], {}]]) {
+      catalogPayload = { models: malformedModels };
+      let malformedRowMessage = '';
+      try {
+        await fetchAvailableModels(config, {
+          ...sharedCredentials,
+          kind: 'codexAccessToken'
+        }, token);
+      } catch (error) {
+        malformedRowMessage = error instanceof Error ? error.message : String(error);
+      }
+      assertEqual(malformedRowMessage, 'Model discovery returned an invalid catalog.', 'malformed catalog row is treated as discovery failure');
+    }
+    catalogPayload = { models: catalog };
 
     assertEqual(
       defaultAccountCatalog.map((model) => model.slug).join(','),
@@ -566,9 +608,56 @@ async function runModelCatalogMetadataSmokeTest() {
       assertEqual(invalidPercentageModel.info.maxInputTokens, 258400, `invalid percentage ${String(invalidPercent)} falls back to 95`);
     }
 
-    assertEqual(catalogRequestCount, 3, 'visibility and credential-kind catalog request count');
+    assertEqual(catalogRequestCount, 7, 'visibility, credential-kind, and catalog validation request count');
   } finally {
     server.close();
+  }
+}
+
+async function runProviderMalformedCatalogFallbackSmokeTest() {
+  const server = createServer((request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [{}] }));
+      return;
+    }
+
+    response.writeHead(500, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ error: { message: 'unexpected request' } }));
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.model = 'gpt-5.5';
+  configValues.disabledModels = [];
+  configValues.modelAliases = {};
+
+  const provider = new CodexModelProvider(
+    {
+      secrets: {
+        async get() {
+          return 'test-api-key';
+        }
+      },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, createCancellationToken());
+    assertEqual(
+      models.map((model) => model.id).join(','),
+      'codex::gpt-5.5',
+      'malformed non-empty catalog uses the explicit discovery-failure fallback'
+    );
+  } finally {
+    await closeServer(server);
   }
 }
 
@@ -1926,6 +2015,7 @@ function assertEqual(actual, expected, label) {
 }
 
 async function runProviderModelDiscoveryPolicySmokeTest() {
+  const responseRequests = [];
   const requestedModels = [];
   const requestedReasoningEfforts = [];
   const selectedModels = [];
@@ -1954,6 +2044,7 @@ async function runProviderModelDiscoveryPolicySmokeTest() {
     }
 
     const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    responseRequests.push(body);
     requestedModels.push(body.model);
     requestedReasoningEfforts.push(body.reasoning?.effort ?? 'none');
     response.writeHead(200, {
@@ -2000,6 +2091,35 @@ async function runProviderModelDiscoveryPolicySmokeTest() {
       'disabling a real slug filters both standard and long profiles'
     );
 
+    configValues.disabledModels = ['gpt-5.4', 'gpt-5.6-sol'];
+    const allDisabledModels = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    assertEqual(allDisabledModels.length, 0, 'disabling every discovered slug returns an empty picker catalog');
+
+    let allDisabledResponseMessage = '';
+    try {
+      await provider.provideLanguageModelChatResponse(
+        {
+          id: 'codex::gpt-5.4',
+          name: 'GPT-5.4',
+          family: 'gpt-5.4',
+          version: 'mock',
+          maxInputTokens: 258400
+        },
+        [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Disabled')] }],
+        {},
+        { report() {} },
+        token
+      );
+    } catch (error) {
+      allDisabledResponseMessage = error instanceof Error ? error.message : String(error);
+    }
+    assertEqual(
+      allDisabledResponseMessage,
+      'No Codex models are available after applying the configured discovery policy.',
+      'stale selection cannot bypass an all-disabled catalog'
+    );
+    assertEqual(requestedModels.length, 0, 'all-disabled stale selection never reaches Responses');
+
     configValues.disabledModels = [];
     configValues.modelAliases = { 'gpt-5.4': 'gpt-5.6-sol' };
     const aliasedModels = await provider.provideLanguageModelChatInformation({ silent: true }, token);
@@ -2011,11 +2131,11 @@ async function runProviderModelDiscoveryPolicySmokeTest() {
 
     await provider.provideLanguageModelChatResponse(
       {
-        id: 'codex::gpt-5.4::context=999999::reasoning=high',
-        name: 'GPT-5.4 (Stale long context)',
+        id: 'codex::gpt-5.4::reasoning=high',
+        name: 'GPT-5.4 (Stale alias source)',
         family: 'gpt-5.4',
         version: 'mock',
-        maxInputTokens: 949999
+        maxInputTokens: 258400
       },
       [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Ping')] }],
       {},
@@ -2026,6 +2146,180 @@ async function runProviderModelDiscoveryPolicySmokeTest() {
     assertEqual(requestedModels.join(','), 'gpt-5.6-sol', 'stale profile suffix is never sent and alias applies to the real slug');
     assertEqual(selectedModels.join(','), 'gpt-5.6-sol', 'profile alias updates selected model to the real slug');
     assertEqual(requestedReasoningEfforts.join(','), 'high', 'profile alias preserves parsed reasoning effort');
+
+    const aliasTargetModel = aliasedModels.find((model) => model.id === 'codex::gpt-5.6-sol');
+    if (!aliasTargetModel) {
+      throw new Error('Expected the alias target model in the filtered catalog.');
+    }
+    await provider.provideLanguageModelChatResponse(
+      { ...aliasTargetModel, id: `${aliasTargetModel.id}::reasoning=high` },
+      [
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Ping')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('alias ok')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Follow up')] }
+      ],
+      {},
+      { report() {} },
+      token
+    );
+    assertEqual(requestedModels.join(','), 'gpt-5.6-sol,gpt-5.6-sol', 'alias target handles the follow-up request');
+    assertEqual(selectedModels.join(','), 'gpt-5.6-sol,gpt-5.6-sol', 'alias target remains selected for follow-up');
+    assertEqual(
+      responseRequests[1].previous_response_id,
+      undefined,
+      'stale aliased selection with unknown target budget starts a new response chain'
+    );
+    assertEqual(
+      JSON.stringify(responseRequests[1].input),
+      JSON.stringify([
+        { role: 'user', content: 'Ping', type: 'message' },
+        { role: 'assistant', content: 'alias ok', type: 'message' },
+        { role: 'user', content: 'Follow up', type: 'message' }
+      ]),
+      'unknown alias target budget replays the full caller history'
+    );
+  } finally {
+    configValues.disabledModels = [];
+    configValues.modelAliases = {};
+    await closeServer(server);
+  }
+}
+
+async function runProviderNestedAliasPolicySmokeTest() {
+  const responseRequests = [];
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        models: [
+          createMockModel('alias-a', 'Alias A'),
+          createMockModel('alias-b', 'Alias B'),
+          createMockModel('alias-d', 'Alias D'),
+          createMockModel('alias-c', 'Alias C')
+        ]
+      }));
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    responseRequests.push(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+    writeSseResponse(response, 'nested alias ok', `resp_nested_${responseRequests.length}`);
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+  configValues.disabledModels = [];
+  configValues.modelAliases = {
+    'alias-a': 'alias-b',
+    'alias-b': 'alias-c'
+  };
+
+  const provider = new CodexModelProvider(
+    {
+      secrets: {
+        async get() {
+          return 'test-api-key';
+        }
+      },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const chainedModels = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    assertEqual(
+      chainedModels.map((model) => model.id).join(','),
+      'codex::alias-d,codex::alias-c',
+      'nested aliases hide their sources while retaining unrelated and final target models'
+    );
+
+    await provider.provideLanguageModelChatResponse(
+      {
+        id: 'codex::alias-a',
+        name: 'Alias A (Stale)',
+        family: 'alias-a',
+        version: 'mock',
+        maxInputTokens: 258400
+      },
+      [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Resolve nested alias')] }],
+      {},
+      { report() {} },
+      token
+    );
+    assertEqual(responseRequests[0]?.model, 'alias-c', 'stale nested alias resolves through the post-policy catalog');
+
+    configValues.modelAliases = {
+      'alias-a': 'alias-b',
+      'alias-b': 'alias-a'
+    };
+    const cyclicModels = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    assertEqual(
+      cyclicModels.map((model) => model.id).join(','),
+      'codex::alias-d,codex::alias-c',
+      'cyclic alias sources are hidden while unrelated models remain available'
+    );
+
+    let cyclicAliasMessage = '';
+    try {
+      await provider.provideLanguageModelChatResponse(
+        {
+          id: 'codex::alias-a',
+          name: 'Alias A (Stale cycle)',
+          family: 'alias-a',
+          version: 'mock',
+          maxInputTokens: 258400
+        },
+        [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Reject alias cycle')] }],
+        {},
+        { report() {} },
+        token
+      );
+    } catch (error) {
+      cyclicAliasMessage = error instanceof Error ? error.message : String(error);
+    }
+    assertEqual(
+      cyclicAliasMessage,
+      'Model alias cycle detected for "alias-a".',
+      'stale cyclic alias is rejected instead of falling back to an unrelated model'
+    );
+    assertEqual(responseRequests.length, 1, 'cyclic alias never reaches Responses');
+
+    configValues.modelAliases = {
+      'alias-a': 'alias-missing',
+      'alias-missing': 'alias-external'
+    };
+    const undiscoveredTargetModels = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    assertEqual(
+      undiscoveredTargetModels.map((model) => model.id).join(','),
+      'codex::alias-a,codex::alias-b,codex::alias-d,codex::alias-c',
+      'alias source remains visible when its terminal target is not in discovery'
+    );
+
+    await provider.provideLanguageModelChatResponse(
+      {
+        id: 'codex::alias-a',
+        name: 'Alias A (External target)',
+        family: 'alias-a',
+        version: 'mock',
+        maxInputTokens: 258400
+      },
+      [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Resolve external alias')] }],
+      {},
+      { report() {} },
+      token
+    );
+    assertEqual(responseRequests[1]?.model, 'alias-external', 'nested alias preserves an undiscovered terminal target');
   } finally {
     configValues.disabledModels = [];
     configValues.modelAliases = {};

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -819,11 +819,16 @@ async function runProviderFallbackSmokeTest() {
   let releasePreRejectionRefresh;
   let resolvePreRejectionRefreshStarted;
   let resolvePreRejectionRefreshCompleted;
+  let resolvePostRejectionCacheLookup;
+  let staleCacheLookupCount = 0;
   const preRejectionRefreshStarted = new Promise((resolve) => {
     resolvePreRejectionRefreshStarted = resolve;
   });
   const preRejectionRefreshCompleted = new Promise((resolve) => {
     resolvePreRejectionRefreshCompleted = resolve;
+  });
+  const postRejectionCacheLookup = new Promise((resolve) => {
+    resolvePostRejectionCacheLookup = resolve;
   });
 
   const server = createServer(async (request, response) => {
@@ -885,7 +890,14 @@ async function runProviderFallbackSmokeTest() {
   Date.now = () => now;
 
   const outputChannel = {
-    debug() {},
+    debug(message, payload) {
+      if (message === 'getAvailableModels cache result' && payload?.modelDiscoveryCacheState === 'stale') {
+        staleCacheLookupCount += 1;
+        if (staleCacheLookupCount === 2) {
+          resolvePostRejectionCacheLookup(payload);
+        }
+      }
+    },
     info(message) {
       if (message === 'getAvailableModels discovery success') {
         discoverySuccessCount += 1;
@@ -949,6 +961,8 @@ async function runProviderFallbackSmokeTest() {
       thrownMessage = error instanceof Error ? error.message : String(error);
     }
 
+    const rejectionRefreshLookup = await postRejectionCacheLookup;
+    assertEqual(rejectionRefreshLookup.refreshStarted, true, 'model rejection starts a versioned refresh instead of joining stale work');
     releasePreRejectionRefresh?.();
     await preRejectionRefreshCompleted;
     await new Promise((resolve) => setImmediate(resolve));
@@ -960,7 +974,6 @@ async function runProviderFallbackSmokeTest() {
       'codex::gpt-5.6-sol',
       'failed refresh retains the authoritative catalog without the rejected model'
     );
-    assertEqual(modelRequestCount >= 3, true, 'model rejection forces a versioned refresh');
     assertEqual(warnings.some((entry) => entry.message === 'response model unavailable'), true, 'unavailable warning emitted');
     assertEqual(thrownMessage.includes('hidden temporarily from the model picker'), true, 'clear unavailable-model error');
   } finally {

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -187,6 +187,7 @@ try {
   await runProviderUnavailableScopeSmokeTest();
   await runProviderModelDiscoveryPolicySmokeTest();
   await runProviderNestedAliasPolicySmokeTest();
+  await runProviderAuthoritativeCatalogSmokeTest();
   await runProviderStaleModelRefreshDoesNotBlockResponseSmokeTest();
   await runProviderModelIdDoesNotBlockColdDiscoverySmokeTest();
   console.log('Smoke test passed: provider advertises effective context profiles, sends real model slugs, and preserves runtime availability policy.');
@@ -1990,6 +1991,29 @@ function createCancellationToken() {
   };
 }
 
+function createMutableCancellationToken() {
+  let canceled = false;
+  const listeners = new Set();
+  return {
+    get isCancellationRequested() {
+      return canceled;
+    },
+    onCancellationRequested(listener) {
+      listeners.add(listener);
+      return { dispose: () => listeners.delete(listener) };
+    },
+    cancel() {
+      if (canceled) {
+        return;
+      }
+      canceled = true;
+      for (const listener of listeners) {
+        listener();
+      }
+    }
+  };
+}
+
 function writeSseResponse(response, text, responseId) {
   response.writeHead(200, {
     'content-type': 'text/event-stream',
@@ -2166,17 +2190,13 @@ async function runProviderModelDiscoveryPolicySmokeTest() {
     assertEqual(selectedModels.join(','), 'gpt-5.6-sol,gpt-5.6-sol', 'alias target remains selected for follow-up');
     assertEqual(
       responseRequests[1].previous_response_id,
-      undefined,
-      'stale aliased selection with unknown target budget starts a new response chain'
+      'resp_alias',
+      'authoritative catalog supplies the alias target budget for compatible reuse'
     );
     assertEqual(
       JSON.stringify(responseRequests[1].input),
-      JSON.stringify([
-        { role: 'user', content: 'Ping', type: 'message' },
-        { role: 'assistant', content: 'alias ok', type: 'message' },
-        { role: 'user', content: 'Follow up', type: 'message' }
-      ]),
-      'unknown alias target budget replays the full caller history'
+      JSON.stringify([{ role: 'user', content: 'Follow up', type: 'message' }]),
+      'authoritative alias target budget keeps the compatible follow-up incremental'
     );
   } finally {
     configValues.disabledModels = [];
@@ -2319,8 +2339,239 @@ async function runProviderNestedAliasPolicySmokeTest() {
       { report() {} },
       token
     );
-    assertEqual(responseRequests[1]?.model, 'alias-external', 'nested alias preserves an undiscovered terminal target');
+    assertEqual(
+      responseRequests[1]?.model,
+      'alias-a',
+      'authoritative catalog keeps the discovered source when the terminal alias target is unavailable'
+    );
   } finally {
+    configValues.disabledModels = [];
+    configValues.modelAliases = {};
+    await closeServer(server);
+  }
+}
+
+async function runProviderAuthoritativeCatalogSmokeTest() {
+  let catalog = [];
+  let failDiscovery = false;
+  let stallDiscovery = false;
+  let notifyStalledDiscoveryStarted;
+  let releaseStalledDiscovery;
+  let modelRequestCount = 0;
+  let responseRequestCount = 0;
+  let tokenCountRequestCount = 0;
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      modelRequestCount += 1;
+      if (failDiscovery) {
+        response.writeHead(503, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ error: { message: 'models unavailable' } }));
+        return;
+      }
+      if (stallDiscovery) {
+        notifyStalledDiscoveryStarted?.();
+        await new Promise((resolve) => {
+          releaseStalledDiscovery = resolve;
+        });
+      }
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: catalog }));
+      return;
+    }
+
+    for await (const _chunk of request) {
+      // Consume the request before returning the deterministic response.
+    }
+    if (request.url?.endsWith('/responses/input_tokens')) {
+      tokenCountRequestCount += 1;
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ input_tokens: 999 }));
+      return;
+    }
+
+    responseRequestCount += 1;
+    writeSseResponse(response, 'unexpected stale response', 'resp_unexpected_stale');
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+  configValues.disabledModels = [];
+  configValues.modelAliases = {};
+  const originalDateNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+
+  const provider = new CodexModelProvider(
+    {
+      secrets: {
+        async get() {
+          return 'test-api-key';
+        }
+      },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+  const staleModel = {
+    id: 'codex::gpt-5.4',
+    name: 'GPT-5.4 (Stale)',
+    family: 'gpt-5.4',
+    version: 'mock',
+    maxInputTokens: 258400
+  };
+
+  try {
+    const token = createCancellationToken();
+    const emptyModels = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    assertEqual(emptyModels.length, 0, 'successful empty catalog is authoritative');
+
+    let staleResponseMessage = '';
+    try {
+      await provider.provideLanguageModelChatResponse(
+        staleModel,
+        [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Do not send')] }],
+        {},
+        { report() {} },
+        token
+      );
+    } catch (error) {
+      staleResponseMessage = error instanceof Error ? error.message : String(error);
+    }
+    assertEqual(
+      staleResponseMessage,
+      'No Codex models are available after applying the configured discovery policy.',
+      'authoritative empty catalog rejects a stale provider model id'
+    );
+    assertEqual(responseRequestCount, 0, 'authoritative empty catalog never reaches Responses');
+
+    const emptyCatalogTokenCount = await provider.provideTokenCount(staleModel, '12345678', token);
+    assertEqual(emptyCatalogTokenCount, 2, 'empty catalog token count uses the local estimate');
+    assertEqual(tokenCountRequestCount, 0, 'empty catalog token count skips the official endpoint');
+
+    catalog = [createMockModel('gpt-5.4', 'GPT-5.4')];
+    configValues.disabledModels = ['gpt-5.4'];
+    const allFilteredModels = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    assertEqual(allFilteredModels.length, 0, 'all-filtered catalog is authoritative');
+
+    const allFilteredTokenCount = await provider.provideTokenCount(staleModel, '12345678', token);
+    assertEqual(allFilteredTokenCount, 2, 'all-filtered token count uses the local estimate');
+    assertEqual(tokenCountRequestCount, 0, 'all-filtered token count skips the official endpoint');
+
+    catalog = [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')];
+    configValues.disabledModels = [];
+    configValues.clientVersion = 'non-empty-test';
+    const nonEmptyModels = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    assertEqual(nonEmptyModels.map((model) => model.id).join(','), 'codex::gpt-5.6-sol', 'non-empty authoritative catalog');
+
+    let missingModelMessage = '';
+    try {
+      await provider.provideLanguageModelChatResponse(
+        staleModel,
+        [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Reject missing stale model')] }],
+        {},
+        { report() {} },
+        token
+      );
+    } catch (error) {
+      missingModelMessage = error instanceof Error ? error.message : String(error);
+    }
+    assertEqual(
+      missingModelMessage,
+      'Selected Codex model "gpt-5.4" is not available in the authoritative model catalog.',
+      'non-empty authoritative catalog rejects a missing stale model'
+    );
+    assertEqual(responseRequestCount, 0, 'missing stale model never reaches Responses');
+
+    const missingModelTokenCount = await provider.provideTokenCount(staleModel, '12345678', token);
+    assertEqual(missingModelTokenCount, 2, 'missing authoritative model token count uses the local estimate');
+    assertEqual(tokenCountRequestCount, 0, 'missing authoritative model token count skips the official endpoint');
+
+    const modelRequestsBeforeFailedRefresh = modelRequestCount;
+    now += 60 * 60 * 1000 + 1;
+    failDiscovery = true;
+    const expiredCatalogTokenCount = await provider.provideTokenCount(staleModel, '12345678', token);
+    assertEqual(expiredCatalogTokenCount, 2, 'failed refresh retains the expired authoritative catalog');
+    assertEqual(modelRequestCount, modelRequestsBeforeFailedRefresh + 1, 'expired authoritative catalog attempts one refresh');
+    assertEqual(tokenCountRequestCount, 0, 'failed authoritative refresh skips the official endpoint for a missing model');
+
+    let expiredCatalogResponseMessage = '';
+    try {
+      await provider.provideLanguageModelChatResponse(
+        staleModel,
+        [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Still reject missing stale model')] }],
+        {},
+        { report() {} },
+        token
+      );
+    } catch (error) {
+      expiredCatalogResponseMessage = error instanceof Error ? error.message : String(error);
+    }
+    assertEqual(
+      expiredCatalogResponseMessage,
+      'Selected Codex model "gpt-5.4" is not available in the authoritative model catalog.',
+      'failed refresh does not replace authoritative catalog with fallback'
+    );
+    assertEqual(responseRequestCount, 0, 'failed authoritative refresh never enables stale Responses requests');
+
+    failDiscovery = false;
+    configValues.clientVersion = 'cancel-test';
+    const canceledToken = {
+      isCancellationRequested: true,
+      onCancellationRequested() {
+        return { dispose() {} };
+      }
+    };
+    let cancellationRejected = false;
+    try {
+      await provider.provideTokenCount(staleModel, '12345678', canceledToken);
+    } catch {
+      cancellationRejected = true;
+    }
+    assertEqual(cancellationRejected, true, 'canceled discovery rejects instead of returning an estimate');
+
+    const postCancellationModels = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    assertEqual(
+      postCancellationModels.map((model) => model.id).join(','),
+      'codex::gpt-5.6-sol',
+      'canceled discovery does not cache a synthetic fallback catalog'
+    );
+
+    configValues.clientVersion = 'concurrent-cancel-test';
+    stallDiscovery = true;
+    const stalledDiscoveryStarted = new Promise((resolve) => {
+      notifyStalledDiscoveryStarted = resolve;
+    });
+    const leaderToken = createMutableCancellationToken();
+    const canceledLeader = provider.provideTokenCount(staleModel, '12345678', leaderToken);
+    await stalledDiscoveryStarted;
+    const uncanceledFollower = provider.provideLanguageModelChatInformation({ silent: true }, token);
+    await Promise.resolve();
+    leaderToken.cancel();
+    releaseStalledDiscovery?.();
+
+    const concurrentResults = await Promise.allSettled([canceledLeader, uncanceledFollower]);
+    assertEqual(concurrentResults[0].status, 'rejected', 'canceled discovery leader rejects');
+    assertEqual(concurrentResults[1].status, 'rejected', 'uncanceled discovery follower observes the shared abort');
+
+    stallDiscovery = false;
+    notifyStalledDiscoveryStarted = undefined;
+    releaseStalledDiscovery = undefined;
+    const postConcurrentCancellationModels = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    assertEqual(
+      postConcurrentCancellationModels.map((model) => model.id).join(','),
+      'codex::gpt-5.6-sol',
+      'shared cancellation does not cache fallback for an uncanceled follower'
+    );
+  } finally {
+    releaseStalledDiscovery?.();
+    Date.now = originalDateNow;
+    configValues.clientVersion = '0.0.0';
     configValues.disabledModels = [];
     configValues.modelAliases = {};
     await closeServer(server);

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -812,9 +812,35 @@ async function runProviderFallbackSmokeTest() {
   const selectedModels = [];
   const warnings = [];
   let thrownMessage = '';
+  let failModelRefresh = false;
+  let stallPreRejectionRefresh = false;
+  let modelRequestCount = 0;
+  let discoverySuccessCount = 0;
+  let releasePreRejectionRefresh;
+  let resolvePreRejectionRefreshStarted;
+  let resolvePreRejectionRefreshCompleted;
+  const preRejectionRefreshStarted = new Promise((resolve) => {
+    resolvePreRejectionRefreshStarted = resolve;
+  });
+  const preRejectionRefreshCompleted = new Promise((resolve) => {
+    resolvePreRejectionRefreshCompleted = resolve;
+  });
 
   const server = createServer(async (request, response) => {
     if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      modelRequestCount += 1;
+      const isPreRejectionRefresh = stallPreRejectionRefresh && modelRequestCount === 2;
+      if (isPreRejectionRefresh) {
+        resolvePreRejectionRefreshStarted();
+        await new Promise((resolve) => {
+          releasePreRejectionRefresh = resolve;
+        });
+      }
+      if (failModelRefresh && !isPreRejectionRefresh) {
+        response.writeHead(503, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ error: { message: 'models unavailable' } }));
+        return;
+      }
       response.writeHead(200, { 'content-type': 'application/json' });
       response.end(JSON.stringify({
         models: [
@@ -834,6 +860,7 @@ async function runProviderFallbackSmokeTest() {
     requestedModels.push(body.model);
 
     if (body.model === 'gpt-5.6-nova') {
+      failModelRefresh = true;
       response.writeHead(404, { 'content-type': 'application/json' });
       response.end(JSON.stringify({
         error: {
@@ -853,10 +880,20 @@ async function runProviderFallbackSmokeTest() {
   await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
   const address = server.address();
   configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  const originalDateNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
 
   const outputChannel = {
     debug() {},
-    info() {},
+    info(message) {
+      if (message === 'getAvailableModels discovery success') {
+        discoverySuccessCount += 1;
+        if (discoverySuccessCount === 2) {
+          resolvePreRejectionRefreshCompleted();
+        }
+      }
+    },
     warn(message, payload) {
       warnings.push({ message, payload });
     },
@@ -896,25 +933,39 @@ async function runProviderFallbackSmokeTest() {
       throw new Error('Expected nova model to be discoverable before temporary disable.');
     }
 
+    now += 10 * 60 * 1000 + 1;
+    stallPreRejectionRefresh = true;
+    const responseAttempt = provider.provideLanguageModelChatResponse(
+      novaModel,
+      [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Ping')] }],
+      {},
+      { report() {} },
+      token
+    );
+    await preRejectionRefreshStarted;
     try {
-      await provider.provideLanguageModelChatResponse(
-        novaModel,
-        [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Ping')] }],
-        {},
-        { report() {} },
-        token
-      );
+      await responseAttempt;
     } catch (error) {
       thrownMessage = error instanceof Error ? error.message : String(error);
     }
 
+    releasePreRejectionRefresh?.();
+    await preRejectionRefreshCompleted;
+    await new Promise((resolve) => setImmediate(resolve));
     const refreshedModels = await provider.provideLanguageModelChatInformation({ silent: true }, token);
     assertEqual(requestedModels.join(','), 'gpt-5.6-nova', 'request order without retry');
     assertEqual(selectedModels.join(','), 'gpt-5.6-nova', 'selected model does not silently change');
-    assertEqual(refreshedModels.some((item) => item.id === 'codex::gpt-5.6-nova'), false, 'rejected model hidden after temporary disable');
+    assertEqual(
+      refreshedModels.map((item) => item.id).join(','),
+      'codex::gpt-5.6-sol',
+      'failed refresh retains the authoritative catalog without the rejected model'
+    );
+    assertEqual(modelRequestCount >= 3, true, 'model rejection forces a versioned refresh');
     assertEqual(warnings.some((entry) => entry.message === 'response model unavailable'), true, 'unavailable warning emitted');
     assertEqual(thrownMessage.includes('hidden temporarily from the model picker'), true, 'clear unavailable-model error');
   } finally {
+    releasePreRejectionRefresh?.();
+    Date.now = originalDateNow;
     await closeServer(server);
   }
 }
@@ -2492,6 +2543,34 @@ async function runProviderAuthoritativeCatalogSmokeTest() {
     assertEqual(missingModelTokenCount, 2, 'missing authoritative model token count uses the local estimate');
     assertEqual(tokenCountRequestCount, 0, 'missing authoritative model token count skips the official endpoint');
 
+    const prefixStaleModel = {
+      ...staleModel,
+      id: 'codex::gpt-5.6-sol-preview',
+      family: 'gpt-5.6-sol-preview'
+    };
+    let prefixModelMessage = '';
+    try {
+      await provider.provideLanguageModelChatResponse(
+        prefixStaleModel,
+        [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Reject prefix-like stale model')] }],
+        {},
+        { report() {} },
+        token
+      );
+    } catch (error) {
+      prefixModelMessage = error instanceof Error ? error.message : String(error);
+    }
+    assertEqual(
+      prefixModelMessage,
+      'Selected Codex model "gpt-5.6-sol-preview" is not available in the authoritative model catalog.',
+      'authoritative catalog rejects implicit prefix remapping'
+    );
+    assertEqual(responseRequestCount, 0, 'prefix-like stale model never reaches Responses');
+
+    const prefixModelTokenCount = await provider.provideTokenCount(prefixStaleModel, '12345678', token);
+    assertEqual(prefixModelTokenCount, 2, 'prefix-like stale model token count uses the local estimate');
+    assertEqual(tokenCountRequestCount, 0, 'prefix-like stale model token count skips the official endpoint');
+
     const modelRequestsBeforeFailedRefresh = modelRequestCount;
     now += 60 * 60 * 1000 + 1;
     failDiscovery = true;
@@ -2557,7 +2636,14 @@ async function runProviderAuthoritativeCatalogSmokeTest() {
 
     const concurrentResults = await Promise.allSettled([canceledLeader, uncanceledFollower]);
     assertEqual(concurrentResults[0].status, 'rejected', 'canceled discovery leader rejects');
-    assertEqual(concurrentResults[1].status, 'rejected', 'uncanceled discovery follower observes the shared abort');
+    assertEqual(concurrentResults[1].status, 'fulfilled', 'uncanceled discovery follower survives leader cancellation');
+    assertEqual(
+      concurrentResults[1].status === 'fulfilled'
+        ? concurrentResults[1].value.map((model) => model.id).join(',')
+        : '',
+      'codex::gpt-5.6-sol',
+      'uncanceled discovery follower receives the shared catalog'
+    );
 
     stallDiscovery = false;
     notifyStalledDiscoveryStarted = undefined;
@@ -2566,8 +2652,29 @@ async function runProviderAuthoritativeCatalogSmokeTest() {
     assertEqual(
       postConcurrentCancellationModels.map((model) => model.id).join(','),
       'codex::gpt-5.6-sol',
-      'shared cancellation does not cache fallback for an uncanceled follower'
+      'independent cancellation leaves the shared catalog cached'
     );
+
+    configValues.clientVersion = 'concurrent-follower-cancel-test';
+    stallDiscovery = true;
+    const followerCancellationDiscoveryStarted = new Promise((resolve) => {
+      notifyStalledDiscoveryStarted = resolve;
+    });
+    const uncanceledLeader = provider.provideLanguageModelChatInformation({ silent: true }, token);
+    await followerCancellationDiscoveryStarted;
+    const followerToken = createMutableCancellationToken();
+    const canceledFollower = provider.provideTokenCount(staleModel, '12345678', followerToken);
+    await Promise.resolve();
+    followerToken.cancel();
+    releaseStalledDiscovery?.();
+
+    const followerCancellationResults = await Promise.allSettled([uncanceledLeader, canceledFollower]);
+    assertEqual(followerCancellationResults[0].status, 'fulfilled', 'uncanceled discovery leader survives follower cancellation');
+    assertEqual(followerCancellationResults[1].status, 'rejected', 'canceled discovery follower stops waiting independently');
+
+    stallDiscovery = false;
+    notifyStalledDiscoveryStarted = undefined;
+    releaseStalledDiscovery = undefined;
   } finally {
     releaseStalledDiscovery?.();
     Date.now = originalDateNow;


### PR DESCRIPTION
## Summary
- distinguish valid empty model catalogs from discovery failures and reject malformed catalog rows
- honor disabled-model policy when every discovered candidate is filtered
- resolve alias chains, reject cycles, and use resolved model budgets for response-branch compatibility
- preserve cold direct-ID resolution, but make successful cached catalogs authoritative for subsequent responses
- reject implicit prefix remapping under authoritative catalogs
- fall back to local token estimates when discovery/model resolution yields no valid model
- isolate caller cancellation from shared discovery work
- preserve filtered authoritative catalogs across failed, overlapping, and post-rejection refreshes

## Validation
- `npm run compile`
- `npm run test:smoke`
- `CI=true VSCODE_TEST_VERSION=1.104.3 npm run test:extension-host`