### PR TITLE
fix: keep exhausted credit budgets visible

### DIFF
--- a/src/accountUsage.ts
+++ b/src/accountUsage.ts
@@ -356,7 +356,9 @@ function parseCreditBudget(
       return undefined;
     }
 
-    remainingPercent = reportedRemainingPercent ?? calculatedRemainingPercent;
+    remainingPercent = calculatedRemainingPercent === 0
+      ? 0
+      : reportedRemainingPercent ?? calculatedRemainingPercent;
   } else if (reportedRemainingPercent !== undefined) {
     remainingPercent = reportedRemainingPercent;
     used = total * (1 - remainingPercent / 100);

--- a/src/accountUsage.ts
+++ b/src/accountUsage.ts
@@ -346,12 +346,12 @@ function parseCreditBudget(
   let remainingPercent: number;
 
   if (reportedUsed !== undefined) {
-    if (reportedUsed < 0 || reportedUsed > total) {
+    if (reportedUsed < 0) {
       return undefined;
     }
 
     used = reportedUsed;
-    const calculatedRemainingPercent = (total - used) / total * 100;
+    const calculatedRemainingPercent = Math.max(0, (total - used) / total * 100);
     if (reportedRemainingPercent !== undefined && Math.abs(reportedRemainingPercent - calculatedRemainingPercent) > 1) {
       return undefined;
     }
@@ -369,7 +369,7 @@ function parseCreditBudget(
     limitName: defaults.limitName,
     total,
     used,
-    remaining: total - used,
+    remaining: Math.max(0, total - used),
     remainingPercent,
     resetAt: parseResetAt(value, fetchedAt)
   };

--- a/test/smokeAccountUsage.mjs
+++ b/test/smokeAccountUsage.mjs
@@ -273,6 +273,23 @@ try {
   assertIncludes(businessSpendControlDisplay.tooltip, 'Other rate limits:', 'root spend-control keeps model limits in details');
   assertIncludes(businessSpendControlDisplay.tooltip, 'GPT-5.3-Codex-Spark-Preview', 'root spend-control identifies additional model limit');
 
+  const overdrawnSpendControlSnapshot = parseCodexAccountUsage({
+    plan_type: 'business',
+    spend_control: {
+      reached: true,
+      individual_limit: {
+        source: 'group_based_spend_controls',
+        limit: 100,
+        used: 101,
+        remaining: 0,
+        remaining_percent: 0
+      }
+    }
+  }, Date.now(), 'gpt-5.5');
+  const overdrawnSpendControlDisplay = buildCodexAccountUsageDisplay(overdrawnSpendControlSnapshot, 'gpt-5.5');
+  assertEqual(overdrawnSpendControlDisplay.compactText, 'Codex: Credits 0% · 0/100', 'overdrawn spend-control budget remains visible');
+  assertIncludes(overdrawnSpendControlDisplay.tooltip, '101 credits used', 'overdrawn spend-control retains actual usage');
+
   await assertRejects(
     fetchCodexAccountUsage({
       baseURL,

--- a/test/smokeAccountUsage.mjs
+++ b/test/smokeAccountUsage.mjs
@@ -282,7 +282,7 @@ try {
         limit: 100,
         used: 101,
         remaining: 0,
-        remaining_percent: 0
+        remaining_percent: 1
       }
     }
   }, Date.now(), 'gpt-5.5');


### PR DESCRIPTION
## Summary
- preserve reported credit usage when it exceeds the configured spend-control limit
- clamp remaining credits and percentage to zero instead of dropping the budget snapshot
- add regression coverage for an overdrawn business spend-control response

## Validation
- `node test/smokeAccountUsage.mjs`
- `npm run compile`
- `npm run test:smoke`
- `CI=true VSCODE_TEST_VERSION=1.104.3 npm run test:extension-host`