### PR TITLE
Align Codex compatibility request shaping

### DIFF
--- a/src/codexRequestBuilder.ts
+++ b/src/codexRequestBuilder.ts
@@ -82,16 +82,17 @@ export function buildCodexResponsesRequestWithMetrics(
         client_metadata: metadata
       }
     : {};
+  const reasoning = normalizeReasoningForRequest(options);
 
   const request = {
     model: options.model,
     instructions: options.instructions,
-    input: options.input,
+    input: sanitizeResponsesInputForOutbound(options.input),
     stream: true,
     store: options.store ?? false,
     ...(options.previousResponseId ? { previous_response_id: options.previousResponseId } : {}),
     ...(options.serviceTier ? { service_tier: options.serviceTier } : {}),
-    ...(options.reasoning ? { reasoning: options.reasoning } : {}),
+    ...(reasoning ? { reasoning } : {}),
     ...(tools.length > 0
       ? {
           tools: [...tools],
@@ -173,6 +174,39 @@ export function areCodexRequestsIncrementallyCompatible(
   current: CodexResponsesRequest
 ): boolean {
   return fingerprintCodexRequest(previous) === fingerprintCodexRequest(current);
+}
+
+function normalizeReasoningForRequest(options: CodexRequestBuilderOptions): Reasoning | undefined {
+  if (!options.compatibilityEnabled) {
+    return options.reasoning;
+  }
+
+  return {
+    effort: options.reasoning?.effort ?? 'medium',
+    summary: options.reasoning?.summary ?? 'auto'
+  } as Reasoning;
+}
+
+function sanitizeResponsesInputForOutbound(input: readonly ResponsesInputMessage[]): ResponsesInputMessage[] {
+  return input.map((item) => sanitizeResponseItemIdForOutbound(item));
+}
+
+function sanitizeResponseItemIdForOutbound(item: ResponsesInputMessage): ResponsesInputMessage {
+  const record = item as unknown as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(record, 'id')) {
+    return item;
+  }
+  const id = record.id;
+  if (typeof id === 'string' && isAcceptedResponsesItemId(id)) {
+    return item;
+  }
+
+  const { id: _id, ...withoutId } = record;
+  return withoutId as unknown as ResponsesInputMessage;
+}
+
+function isAcceptedResponsesItemId(id: string): boolean {
+  return /^(msg|fc|fco|rs|item)_[A-Za-z0-9_-]+$/.test(id);
 }
 
 function mapToolChoice(toolMode: vscode.LanguageModelChatToolMode | undefined): ToolChoiceOptions {

--- a/test/smokeCodexRequestBuilder.mjs
+++ b/test/smokeCodexRequestBuilder.mjs
@@ -31,6 +31,34 @@ try {
     textVerbosity: 'medium'
   };
   const request = buildCodexResponsesRequest(base);
+  const compatibilityDefaultReasoningRequest = buildCodexResponsesRequest({
+    ...base,
+    reasoning: undefined,
+    tools: []
+  });
+  const standardRequest = buildCodexResponsesRequest({
+    ...base,
+    compatibilityEnabled: false,
+    reasoning: undefined,
+    tools: []
+  });
+  const continuationInput = [
+    { type: 'message', id: '', role: 'assistant', content: 'empty id' },
+    { type: 'message', id: 'legacy-message-id', role: 'assistant', content: 'legacy id' },
+    { type: 'message', id: 'msg_valid123', role: 'assistant', content: 'valid message id' },
+    { type: 'function_call', id: 'fc_valid123', call_id: 'call_valid', name: 'read', arguments: '{}' },
+    { type: 'function_call_output', id: 'legacy-output-id', call_id: 'call_valid', output: 'result' }
+  ];
+  const sanitizedHttpRequest = buildCodexResponsesRequest({
+    ...base,
+    input: continuationInput,
+    tools: []
+  });
+  const sanitizedWebSocketEvent = buildCodexResponsesWebSocketEvent({
+    ...base,
+    input: continuationInput,
+    tools: []
+  });
   const appended = buildCodexResponsesRequest({ ...base, input: [...base.input, { type: 'message', role: 'user', content: 'next' }] });
   const event = buildCodexResponsesWebSocketEvent(base, false);
   resetCodexToolSchemaCache();
@@ -41,6 +69,21 @@ try {
   assertEqual(request.parallel_tool_calls, true, 'parallel tools');
   assertEqual(request.instructions, base.instructions, 'configured instructions preserved with tools');
   assertEqual(request.include[0], 'reasoning.encrypted_content', 'encrypted reasoning include');
+  assertEqual(JSON.stringify(request.reasoning), JSON.stringify({ effort: 'high', summary: 'auto' }), 'explicit compatibility reasoning preserved');
+  assertEqual(JSON.stringify(compatibilityDefaultReasoningRequest.reasoning), JSON.stringify({ effort: 'medium', summary: 'auto' }), 'compatibility default reasoning is normalized');
+  assertEqual(compatibilityDefaultReasoningRequest.include[0], 'reasoning.encrypted_content', 'compatibility default reasoning requests encrypted content');
+  assertEqual('reasoning' in standardRequest, false, 'standard request does not add default reasoning');
+  assertEqual('include' in standardRequest, false, 'standard request does not request encrypted reasoning');
+  assertEqual('id' in sanitizedHttpRequest.input[0], false, 'HTTP continuation omits empty response item id');
+  assertEqual('id' in sanitizedHttpRequest.input[1], false, 'HTTP continuation omits legacy response item id');
+  assertEqual(sanitizedHttpRequest.input[2].id, 'msg_valid123', 'HTTP continuation preserves valid response item id');
+  assertEqual(sanitizedHttpRequest.input[3].id, 'fc_valid123', 'HTTP continuation preserves valid function call item id');
+  assertEqual(sanitizedHttpRequest.input[3].call_id, 'call_valid', 'HTTP continuation preserves call id');
+  assertEqual('id' in sanitizedHttpRequest.input[4], false, 'HTTP continuation omits legacy tool output item id');
+  assertEqual(sanitizedHttpRequest.input[4].call_id, 'call_valid', 'HTTP continuation preserves tool output call id');
+  assertEqual('id' in sanitizedWebSocketEvent.input[1], false, 'WebSocket continuation omits legacy response item id');
+  assertEqual(sanitizedWebSocketEvent.input[2].id, 'msg_valid123', 'WebSocket continuation preserves valid response item id');
+  assertEqual(sanitizedWebSocketEvent.input[4].call_id, 'call_valid', 'WebSocket continuation preserves tool output call id');
   assertEqual(event.generate, false, 'prewarm generate flag');
   assertEqual('stream' in event, false, 'WebSocket stream omitted');
   assertEqual(areCodexRequestsIncrementallyCompatible(request, appended), true, 'input ignored by request fingerprint');


### PR DESCRIPTION
### Motivation
- Upstream `rust-v0.144.6` → `rust-v0.145.0` changed externally observable behavior to always build a `reasoning` object and request `reasoning.encrypted_content`, and to require prefixed outbound response-item IDs.  
- The extension previously omitted the entire `reasoning` field when none was supplied and replayed historical response-item `id` values unchanged, which risks backend rejection.  
- Make the smallest compatibility-preserving change to keep ChatGPT/Codex compatibility-mode request shaping aligned with the new upstream expectations.

### Description
- Always normalize and include a compatibility `reasoning` object when `compatibilityEnabled` is true, defaulting to `{ effort: 'medium', summary: 'auto' }` if no explicit reasoning is provided, while leaving non-compatibility requests unchanged.  
- Sanitize outbound Responses `input` for HTTP and WebSocket by omitting `id` fields that are empty or do not match accepted prefixed item IDs, while preserving valid prefixed IDs and linkage fields such as `call_id`.  
- Added focused smoke coverage validating explicit/default reasoning behavior, that non-compatibility requests are unchanged, and that HTTP/WebSocket continuation input sanitizes item `id` values.  
- Files changed: `src/codexRequestBuilder.ts` and `test/smokeCodexRequestBuilder.mjs`.  
- Closes #39

### Testing
- Ran `npm run check` and it passed.  
- Ran `npm run test:smoke` and the full smoke suite passed.  
- Remaining manual verification: live ChatGPT/Codex backend verification was not run (credential-dependent) and should be exercised against representative models to confirm server acceptance across the model catalog and to confirm any future response-item ID prefix requirements; no credentials or `auth.json` were accessed or exposed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6176e4f4608324a7fd259aca903634)