### PR TITLE
fix: harden native tool search lifecycle

### DIFF
--- a/src/nativeToolSearch/nativeToolCapabilities.ts
+++ b/src/nativeToolSearch/nativeToolCapabilities.ts
@@ -2,27 +2,47 @@ import { supportsNativeToolSearchModel } from './nativeToolPolicy';
 
 const unsupported = new Map<string, number>();
 const TTL_MS = 10 * 60 * 1000;
+const MAX_UNSUPPORTED_CAPABILITIES = 64;
 
 export function nativeToolSearchCapabilityKey(baseURL: string, authIdentity: string, model: string): string {
   return JSON.stringify([baseURL, authIdentity, model]);
 }
 
 export function canUseNativeToolSearch(model: string, key: string): boolean {
+  pruneUnsupportedCapabilities(Date.now());
   const rejectedAt = unsupported.get(key);
-  if (rejectedAt !== undefined && Date.now() - rejectedAt <= TTL_MS) {
-    return false;
-  }
   if (rejectedAt !== undefined) {
     unsupported.delete(key);
+    unsupported.set(key, rejectedAt);
+    return false;
   }
   return supportsNativeToolSearchModel(model);
 }
 
 export function markNativeToolSearchUnsupported(key: string): void {
-  unsupported.set(key, Date.now());
+  const now = Date.now();
+  pruneUnsupportedCapabilities(now);
+  unsupported.delete(key);
+  unsupported.set(key, now);
+  pruneUnsupportedCapabilities(now);
 }
 
 export function isNativeToolSearchUnsupportedError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /(unsupported tool type:\s*(namespace|tool_search)|unknown field:\s*defer_loading|model does not support tool_search)/i.test(message);
+}
+
+function pruneUnsupportedCapabilities(now: number): void {
+  for (const [key, rejectedAt] of unsupported) {
+    if (now - rejectedAt > TTL_MS) {
+      unsupported.delete(key);
+    }
+  }
+  while (unsupported.size > MAX_UNSUPPORTED_CAPABILITIES) {
+    const oldestKey = unsupported.keys().next().value;
+    if (typeof oldestKey !== 'string') {
+      return;
+    }
+    unsupported.delete(oldestKey);
+  }
 }

--- a/src/nativeToolSearch/nativeToolGroupingBridge.ts
+++ b/src/nativeToolSearch/nativeToolGroupingBridge.ts
@@ -19,7 +19,8 @@ export async function enableNativeToolSearchGroupingBridge(context: vscode.Exten
   const configuration = vscode.workspace.getConfiguration(VIRTUAL_TOOLS_CONFIGURATION_SECTION);
   const inspected = configuration.inspect<number>(THRESHOLD_SETTING);
   const target = getEffectiveSettingTarget(inspected);
-  const savedThresholds = getSavedThresholds(context);
+  const state = getStateForTarget(context, target);
+  const savedThresholds = getSavedThresholds(state, target === vscode.ConfigurationTarget.Global);
   if (!savedThresholds.some((saved) => saved.target === target)) {
     savedThresholds.push({ value: getSettingValueAtTarget(inspected, target), target });
   }
@@ -28,24 +29,30 @@ export async function enableNativeToolSearchGroupingBridge(context: vscode.Exten
     void vscode.window.showErrorMessage('Native Tool Search could not disable VS Code virtual tool grouping. Check that github.copilot.chat.virtualTools.threshold can be changed in Settings.');
     return;
   }
-  await context.globalState.update(PREVIOUS_KEY, savedThresholds);
-  await context.globalState.update(OWNER_KEY, true);
+  await state.update(PREVIOUS_KEY, savedThresholds);
+  await state.update(OWNER_KEY, true);
   await resetToolGroupsAndReload('Native Tool Search enabled.');
 }
 
 export async function restoreVSCodeToolGrouping(context: vscode.ExtensionContext): Promise<void> {
-  if (context.globalState.get<boolean>(OWNER_KEY) !== true) {
+  const ownedStates = [
+    { state: context.globalState, global: true },
+    { state: context.workspaceState, global: false }
+  ].filter(({ state }) => state.get<boolean>(OWNER_KEY) === true);
+  if (ownedStates.length === 0) {
     return;
   }
   const configuration = vscode.workspace.getConfiguration(VIRTUAL_TOOLS_CONFIGURATION_SECTION);
-  for (const previous of getSavedThresholds(context)) {
-    const inspected = configuration.inspect<number>(THRESHOLD_SETTING);
-    if (getSettingValueAtTarget(inspected, previous.target) === 0) {
-      await configuration.update(THRESHOLD_SETTING, previous.value, previous.target);
+  for (const owned of ownedStates) {
+    for (const previous of getSavedThresholds(owned.state, owned.global)) {
+      const inspected = configuration.inspect<number>(THRESHOLD_SETTING);
+      if (getSettingValueAtTarget(inspected, previous.target) === 0) {
+        await configuration.update(THRESHOLD_SETTING, previous.value, previous.target);
+      }
     }
+    await owned.state.update(OWNER_KEY, undefined);
+    await owned.state.update(PREVIOUS_KEY, undefined);
   }
-  await context.globalState.update(OWNER_KEY, undefined);
-  await context.globalState.update(PREVIOUS_KEY, undefined);
   await resetToolGroupsAndReload('VS Code tool grouping restored.');
 }
 
@@ -77,12 +84,17 @@ function getEffectiveSettingTarget(
   return vscode.ConfigurationTarget.Global;
 }
 
-function getSavedThresholds(context: vscode.ExtensionContext): SavedThreshold[] {
-  const saved = context.globalState.get<SavedThreshold | SavedThreshold[]>(PREVIOUS_KEY);
+function getStateForTarget(context: vscode.ExtensionContext, target: vscode.ConfigurationTarget): vscode.Memento {
+  return target === vscode.ConfigurationTarget.Global ? context.globalState : context.workspaceState;
+}
+
+function getSavedThresholds(state: vscode.Memento, global: boolean): SavedThreshold[] {
+  const saved = state.get<SavedThreshold | SavedThreshold[]>(PREVIOUS_KEY);
   const entries = Array.isArray(saved) ? saved : saved ? [saved] : [];
   return entries.flatMap((entry) => {
     const target = isConfigurationTarget(entry.target) ? entry.target : vscode.ConfigurationTarget.Global;
-    return [{ value: entry.value, target }];
+    const isGlobalTarget = target === vscode.ConfigurationTarget.Global;
+    return isGlobalTarget === global ? [{ value: entry.value, target }] : [];
   });
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -411,9 +411,17 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     }
     const usePreviousResponseId = appendedInput.length > 0
       && (!requiresFullInputForToolOutput || shouldAttemptToolOutputContinuation);
+    const fullReplayInput = toolPlan.mode === 'native-hosted'
+      ? buildCanonicalReplayInput({
+          previousSnapshot: reusableBranch?.state?.continuation,
+          convertedInput: input,
+          appendedInput,
+          catalogHash: toolPlan.catalogHash
+        })
+      : input;
     const initialRequestInput = usePreviousResponseId
       ? appendedInput
-      : input;
+      : fullReplayInput;
     const initialPreviousResponseId = usePreviousResponseId
       ? reusableBranch?.responseId
       : undefined;
@@ -958,7 +966,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         createdResponseId = undefined;
         completedResponseId = undefined;
         rawResponseItems.length = 0;
-        await streamRequest(input);
+        await streamRequest(fullReplayInput);
       } else {
         if (!initialPreviousResponseId || !isResponsesContinuationMissError(error)) {
           const unavailableModel = getExactModelNotFoundName(error, selectedModel.requestModel);
@@ -1011,7 +1019,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         completedResponseId = undefined;
         rawResponseItems.length = 0;
         activeBranchId = undefined;
-        await streamRequest(input);
+        await streamRequest(fullReplayInput);
       }
     }
 
@@ -1023,12 +1031,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         input,
       });
       const fullRequest = toolPlan.mode === 'native-hosted'
-        ? createCanonicalReplayRequest(builtFullRequest, buildCanonicalReplayInput({
-            previousSnapshot: reusableBranch?.state?.continuation,
-            convertedInput: input,
-            appendedInput,
-            catalogHash: toolPlan.catalogHash
-          }))
+        ? createCanonicalReplayRequest(builtFullRequest, fullReplayInput)
         : builtFullRequest;
       branchState = {
         ...branchState,

--- a/test/smokeNativeToolFallback.mjs
+++ b/test/smokeNativeToolFallback.mjs
@@ -1,13 +1,61 @@
 import { loadBundled, assertEqual } from './testBundleHelper.mjs';
 
-const loaded = await loadBundled('src/nativeToolSearch/nativeToolCapabilities.ts', {});
+const TTL_MS = 10 * 60 * 1000;
+const MAX_CAPABILITIES = 64;
+const originalDateNow = Date.now;
+let now = 1_000;
+Date.now = () => now;
+
 try {
-  const { canUseNativeToolSearch, isNativeToolSearchUnsupportedError, markNativeToolSearchUnsupported } = loaded.exports;
-  const key = 'endpoint-account-model';
-  assertEqual(canUseNativeToolSearch('gpt-5.6-luna', key), true, 'GPT-5.6 supports native Tool Search');
-  assertEqual(isNativeToolSearchUnsupportedError(new Error('unsupported tool type: namespace')), true, 'only explicit protocol rejection is recognized');
-  assertEqual(isNativeToolSearchUnsupportedError(new Error('rate limit')), false, 'ordinary errors do not disable native Tool Search');
-  markNativeToolSearchUnsupported(key);
-  assertEqual(canUseNativeToolSearch('gpt-5.6-luna', key), false, 'explicit rejection is cached');
-  console.log('Smoke test passed: native Tool Search fallback is narrowly classified.');
-} finally { await loaded.dispose(); }
+  const loaded = await loadBundled('src/nativeToolSearch/nativeToolCapabilities.ts', {});
+  try {
+    const { canUseNativeToolSearch, isNativeToolSearchUnsupportedError, markNativeToolSearchUnsupported } = loaded.exports;
+    const key = 'endpoint-account-model';
+    assertEqual(canUseNativeToolSearch('gpt-5.6-luna', key), true, 'GPT-5.6 supports native Tool Search');
+    assertEqual(isNativeToolSearchUnsupportedError(new Error('unsupported tool type: namespace')), true, 'only explicit protocol rejection is recognized');
+    assertEqual(isNativeToolSearchUnsupportedError(new Error('rate limit')), false, 'ordinary errors do not disable native Tool Search');
+    markNativeToolSearchUnsupported(key);
+    assertEqual(canUseNativeToolSearch('gpt-5.6-luna', key), false, 'explicit rejection is cached');
+    now += TTL_MS + 1;
+    assertEqual(canUseNativeToolSearch('gpt-5.6-luna', key), true, 'unsupported capability expires after its TTL');
+
+    for (let index = 0; index < MAX_CAPABILITIES; index += 1) {
+      now += 1;
+      markNativeToolSearchUnsupported(`overflow-${index}`);
+    }
+    assertEqual(canUseNativeToolSearch('gpt-5.6-luna', 'overflow-0'), false, 'cache hit refreshes deterministic recency');
+    now += 1;
+    markNativeToolSearchUnsupported(`overflow-${MAX_CAPABILITIES}`);
+    assertEqual(canUseNativeToolSearch('gpt-5.6-luna', 'overflow-0'), false, 'recently used capability survives overflow');
+    assertEqual(canUseNativeToolSearch('gpt-5.6-luna', 'overflow-1'), true, 'overflow evicts the deterministic oldest capability');
+    assertEqual(canUseNativeToolSearch('gpt-5.6-luna', 'overflow-2'), false, 'overflow retains newer unsupported capabilities');
+  } finally {
+    await loaded.dispose();
+  }
+
+  now = 1_000;
+  const expiryLoaded = await loadBundled('src/nativeToolSearch/nativeToolCapabilities.ts', {});
+  try {
+    const { canUseNativeToolSearch, markNativeToolSearchUnsupported } = expiryLoaded.exports;
+    markNativeToolSearchUnsupported('expired-recent');
+    now += TTL_MS - 2;
+    for (let index = 0; index < MAX_CAPABILITIES - 1; index += 1) {
+      markNativeToolSearchUnsupported(`current-${index}`);
+    }
+    now += 1;
+    assertEqual(canUseNativeToolSearch('gpt-5.6-luna', 'expired-recent'), false, 'active rejection can become most recently used');
+    now += 2;
+    markNativeToolSearchUnsupported(`current-${MAX_CAPABILITIES - 1}`);
+    assertEqual(
+      canUseNativeToolSearch('gpt-5.6-luna', 'current-0'),
+      false,
+      'global TTL pruning removes an expired recent entry before bounded eviction'
+    );
+  } finally {
+    await expiryLoaded.dispose();
+  }
+
+  console.log('Smoke test passed: native Tool Search fallback cache is narrow, globally pruned, and deterministically bounded.');
+} finally {
+  Date.now = originalDateNow;
+}

--- a/test/smokeNativeToolGroupingBridge.mjs
+++ b/test/smokeNativeToolGroupingBridge.mjs
@@ -2,49 +2,108 @@ import { loadBundled, assertEqual } from './testBundleHelper.mjs';
 
 const updates = [];
 const commands = [];
-const state = new Map();
+const sharedGlobalState = createState();
+const workspaceStates = { A: createState(), B: createState() };
+const thresholds = {
+  A: { workspace: 64, folder: 32 },
+  B: { workspace: 96, folder: 48 }
+};
+let activeWorkspace = 'A';
 let globalThreshold = 128;
-let workspaceThreshold = 64;
-let workspaceFolderThreshold = 32;
 const vscode = {
   ConfigurationTarget: { Global: 1, Workspace: 2, WorkspaceFolder: 3 },
-  window: { showWarningMessage: async () => 'Enable and Reload', showInformationMessage: () => undefined },
+  window: {
+    showWarningMessage: async () => 'Enable and Reload',
+    showErrorMessage: () => undefined
+  },
   commands: { executeCommand: async (...args) => commands.push(args) },
   workspace: {
     getConfiguration: () => ({
-      get: () => workspaceFolderThreshold ?? workspaceThreshold ?? globalThreshold,
+      get: () => thresholds[activeWorkspace].folder ?? thresholds[activeWorkspace].workspace ?? globalThreshold,
       inspect: () => ({
         globalValue: globalThreshold,
-        workspaceValue: workspaceThreshold,
-        workspaceFolderValue: workspaceFolderThreshold
+        workspaceValue: thresholds[activeWorkspace].workspace,
+        workspaceFolderValue: thresholds[activeWorkspace].folder
       }),
-      update: async (...args) => {
-        updates.push(args);
-        if (args[2] === vscode.ConfigurationTarget.WorkspaceFolder) {
-          workspaceFolderThreshold = args[1];
-        } else if (args[2] === vscode.ConfigurationTarget.Workspace) {
-          workspaceThreshold = args[1];
-        } else if (args[2] === vscode.ConfigurationTarget.Global) {
-          globalThreshold = args[1];
+      update: async (_setting, value, target) => {
+        updates.push({ workspace: activeWorkspace, value, target });
+        if (target === vscode.ConfigurationTarget.WorkspaceFolder) {
+          thresholds[activeWorkspace].folder = value;
+        } else if (target === vscode.ConfigurationTarget.Workspace) {
+          thresholds[activeWorkspace].workspace = value;
+        } else if (target === vscode.ConfigurationTarget.Global) {
+          globalThreshold = value;
         }
       }
     })
   }
 };
+
 const loaded = await loadBundled('src/nativeToolSearch/nativeToolGroupingBridge.ts', vscode);
 try {
-  const context = { globalState: { get: (key) => state.get(key), update: async (key, value) => state.set(key, value) } };
-  await loaded.exports.enableNativeToolSearchGroupingBridge(context);
-  assertEqual(updates[0][1], 0, 'bridge only changes the virtual-tools threshold after confirmation');
-  assertEqual(updates[0][2], vscode.ConfigurationTarget.WorkspaceFolder, 'bridge changes the effective workspace-folder setting before lower-priority settings');
+  const contextA = { globalState: sharedGlobalState, workspaceState: workspaceStates.A };
+  const contextB = { globalState: sharedGlobalState, workspaceState: workspaceStates.B };
+
+  activeWorkspace = 'A';
+  await loaded.exports.enableNativeToolSearchGroupingBridge(contextA);
+  await loaded.exports.enableNativeToolSearchGroupingBridge(contextA);
+  activeWorkspace = 'B';
+  await loaded.exports.enableNativeToolSearchGroupingBridge(contextB);
+  assertEqual(thresholds.A.folder, 0, 'workspace A folder target is disabled');
+  assertEqual(thresholds.B.folder, 0, 'workspace B folder target is disabled independently');
+  assertEqual(updates[0].target, vscode.ConfigurationTarget.WorkspaceFolder, 'bridge changes the effective workspace-folder target');
   assertEqual(commands[0][0], 'github.copilot.debug.resetVirtualToolGroups', 'bridge resets Copilot virtual tool groups after applying the threshold');
-  assertEqual(commands[1][0], 'workbench.action.reloadWindow', 'bridge reloads the window so the active chat rebuilds its virtual tool tree');
-  await loaded.exports.enableNativeToolSearchGroupingBridge(context);
-  assertEqual(updates[1][2], vscode.ConfigurationTarget.WorkspaceFolder, 'repeated enable changes the same effective setting');
-  await loaded.exports.restoreVSCodeToolGrouping(context);
-  assertEqual(updates[2][1], 32, 'bridge restores the original workspace-folder threshold after repeated enable');
-  assertEqual(updates[2][2], vscode.ConfigurationTarget.WorkspaceFolder, 'bridge restores at the originally modified setting target');
-  assertEqual(commands[4][0], 'github.copilot.debug.resetVirtualToolGroups', 'restore resets Copilot virtual tool groups after restoring the threshold');
-  assertEqual(commands[5][0], 'workbench.action.reloadWindow', 'restore reloads the window so the active chat rebuilds its virtual tool tree');
-  console.log('Smoke test passed: virtual tool grouping bridge saves and restores user settings safely.');
-} finally { await loaded.dispose(); }
+  assertEqual(commands[1][0], 'workbench.action.reloadWindow', 'bridge reloads after applying the threshold');
+
+  activeWorkspace = 'A';
+  await loaded.exports.restoreVSCodeToolGrouping(contextA);
+  assertEqual(thresholds.A.folder, 32, 'workspace A restores its original folder threshold after repeated enable');
+  assertEqual(thresholds.B.folder, 0, 'restoring workspace A does not consume workspace B ownership');
+  activeWorkspace = 'B';
+  await loaded.exports.restoreVSCodeToolGrouping(contextB);
+  assertEqual(thresholds.B.folder, 48, 'workspace B restores its own folder threshold');
+
+  thresholds.A.folder = undefined;
+  thresholds.B.folder = undefined;
+  thresholds.A.workspace = 64;
+  thresholds.B.workspace = 96;
+  activeWorkspace = 'A';
+  await loaded.exports.enableNativeToolSearchGroupingBridge(contextA);
+  activeWorkspace = 'B';
+  await loaded.exports.enableNativeToolSearchGroupingBridge(contextB);
+  activeWorkspace = 'A';
+  await loaded.exports.restoreVSCodeToolGrouping(contextA);
+  assertEqual(thresholds.A.workspace, 64, 'workspace A restores its workspace target');
+  assertEqual(thresholds.B.workspace, 0, 'workspace target ownership stays isolated from workspace B');
+  activeWorkspace = 'B';
+  await loaded.exports.restoreVSCodeToolGrouping(contextB);
+  assertEqual(thresholds.B.workspace, 96, 'workspace B restores its own workspace target');
+
+  thresholds.A.workspace = undefined;
+  thresholds.B.workspace = undefined;
+  globalThreshold = 128;
+  activeWorkspace = 'A';
+  await loaded.exports.enableNativeToolSearchGroupingBridge(contextA);
+  assertEqual(globalThreshold, 0, 'global target is disabled from workspace A');
+  activeWorkspace = 'B';
+  await loaded.exports.restoreVSCodeToolGrouping(contextB);
+  assertEqual(globalThreshold, 128, 'workspace B can restore globally owned state created from workspace A');
+
+  console.log('Smoke test passed: virtual tool grouping state is global only for Global targets and isolated per workspace otherwise.');
+} finally {
+  await loaded.dispose();
+}
+
+function createState() {
+  const values = new Map();
+  return {
+    get: (key) => values.get(key),
+    update: async (key, value) => {
+      if (value === undefined) {
+        values.delete(key);
+      } else {
+        values.set(key, value);
+      }
+    }
+  };
+}

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -4,6 +4,7 @@ import Module from 'node:module';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { build } from 'esbuild';
+import WebSocket, * as webSocketModule from 'ws';
 import { resolveTestTempDirectory } from './testTempDirectory.mjs';
 
 const tempDir = await mkdtemp(join(resolveTestTempDirectory(), 'codex-for-copilot-provider-fallback-'));
@@ -13,6 +14,24 @@ const moduleLoad = Module._load;
 const require = createRequire(import.meta.url);
 let performanceNow = () => Date.now();
 const performanceMock = { now: () => performanceNow() };
+let rewriteWebSocketURL;
+
+class RewritingWebSocket extends WebSocket {
+  constructor(address, protocols, options) {
+    const rewrittenAddress = rewriteWebSocketURL ? rewriteWebSocketURL(address) : address;
+    if (options === undefined) {
+      super(rewrittenAddress, protocols);
+    } else {
+      super(rewrittenAddress, protocols, options);
+    }
+  }
+}
+
+const testWebSocketModule = {
+  ...webSocketModule,
+  default: RewritingWebSocket,
+  WebSocket: RewritingWebSocket
+};
 
 const configValues = {
   baseURL: '',
@@ -121,6 +140,13 @@ const vscodeMock = {
   },
   workspace: {
     getConfiguration(section) {
+      if (section === 'http') {
+        return {
+          get(_key, defaultValue) {
+            return defaultValue;
+          }
+        };
+      }
       if (section !== 'codexModelProvider') {
         throw new Error(`Unexpected configuration section: ${section}`);
       }
@@ -144,7 +170,7 @@ await build({
   platform: 'node',
   target: 'node20',
   outfile: bundlePath,
-  external: ['vscode']
+  external: ['vscode', 'ws']
 });
 
 await build({
@@ -160,6 +186,9 @@ await build({
 Module._load = function patchedLoad(request, parent, isMain) {
   if (request === 'vscode') {
     return vscodeMock;
+  }
+  if (request === 'ws') {
+    return testWebSocketModule;
   }
   if (request === 'node:perf_hooks') {
     return { performance: performanceMock };
@@ -183,6 +212,8 @@ try {
   await runRequestEnvelopeReuseInvalidationSmokeTest();
   await runToolOutputFullInputReplaySmokeTest();
   await runModelGeneratedToolLoopFullReplaySmokeTest();
+  await runNativeHostedCanonicalReplaySmokeTest();
+  await runNativeHostedToolOutputContinuationRecoverySmokeTest();
   await runProviderCatalogVersionNeutralSmokeTest();
   await runProviderUnavailableScopeSmokeTest();
   await runProviderModelDiscoveryPolicySmokeTest();
@@ -1891,6 +1922,545 @@ async function runModelGeneratedToolLoopFullReplaySmokeTest() {
   }
 }
 
+async function runNativeHostedCanonicalReplaySmokeTest() {
+  const responseRequests = [];
+  let selectedNamespace;
+  let selectedTool;
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    responseRequests.push(body);
+
+    if (responseRequests.length === 3 && body.previous_response_id) {
+      response.writeHead(400, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        error: {
+          type: 'invalid_request_error',
+          code: 'previous_response_not_found',
+          message: 'Native replay continuation expired.',
+          param: 'previous_response_id'
+        }
+      }));
+      return;
+    }
+
+    response.writeHead(200, {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive'
+    });
+    const send = (event) => response.write(`data: ${JSON.stringify(event)}\n\n`);
+    if (responseRequests.length === 1) {
+      const namespaceTool = body.tools.find((tool) => tool.type === 'namespace');
+      selectedNamespace = namespaceTool?.name;
+      selectedTool = namespaceTool?.tools?.[0]?.name;
+      if (!selectedNamespace || !selectedTool) {
+        throw new Error('Expected native Tool Search request to contain a deferred namespace tool.');
+      }
+      const item = {
+        id: 'fc_native_replay',
+        type: 'function_call',
+        call_id: 'call_native_replay',
+        name: selectedTool,
+        namespace: selectedNamespace,
+        arguments: '{"value":"first"}'
+      };
+      send({ type: 'response.output_item.added', output_index: 0, item });
+      send({
+        type: 'response.function_call_arguments.done',
+        item_id: item.id,
+        output_index: 0,
+        name: selectedTool,
+        arguments: item.arguments
+      });
+      send({ type: 'response.output_item.done', output_index: 0, item });
+      send({ type: 'response.completed', response: { id: 'resp_native_tool', status: 'completed' } });
+    } else if (responseRequests.length === 2) {
+      send({ type: 'response.output_text.delta', delta: 'Native tool result received.' });
+      send({
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'msg_native_result',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'Native tool result received.', annotations: [] }]
+        }
+      });
+      send({ type: 'response.completed', response: { id: 'resp_native_result', status: 'completed' } });
+    } else {
+      send({ type: 'response.output_text.delta', delta: 'Native continuation recovered.' });
+      send({ type: 'response.completed', response: { id: 'resp_native_recovered', status: 'completed' } });
+    }
+    response.write('data: [DONE]\n\n');
+    response.end();
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const originalFetch = globalThis.fetch;
+  const originalBaseURL = configValues.baseURL;
+  const originalCredentialsSource = configValues.credentialsSource;
+  const originalNativeToolSearch = configValues.nativeToolSearch;
+  configValues.baseURL = 'https://chatgpt.com/backend-api/codex/responses';
+  configValues.credentialsSource = 'codexAuth';
+  configValues.nativeToolSearch = 'enabled';
+  configValues.transport = 'http';
+  globalThis.fetch = async (input, init) => {
+    const requestUrl = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    const targetUrl = new URL(requestUrl);
+    targetUrl.protocol = 'http:';
+    targetUrl.hostname = '127.0.0.1';
+    targetUrl.port = String(address.port);
+    return originalFetch(targetUrl, init);
+  };
+
+  const tools = Array.from({ length: 13 }, (_, index) => ({
+    name: `native_replay_tool_${String(index).padStart(2, '0')}`,
+    description: `Native replay tool ${index}`,
+    inputSchema: {
+      type: 'object',
+      properties: { value: { type: 'string' } },
+      required: ['value']
+    }
+  }));
+  const provider = new CodexModelProvider(
+    { subscriptions: [] },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    {
+      async getStatus() {
+        return { accountId: 'native-replay-account' };
+      },
+      async getAccessToken() {
+        return 'native-replay-token';
+      }
+    }
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected model for native canonical replay coverage.');
+    }
+
+    const firstParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Run a deferred native tool.')] }],
+      { tools },
+      { report(part) { firstParts.push(part); } },
+      token
+    );
+    const toolCall = firstParts.find((part) => part instanceof LanguageModelToolCallPart);
+    if (!toolCall || !selectedNamespace || !selectedTool) {
+      throw new Error('Expected one mapped native tool call.');
+    }
+    assertEqual(toolCall.name, selectedTool, 'native namespaced call maps back to the selected VS Code tool');
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Run a deferred native tool.')] },
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+          content: [new vscodeMock.LanguageModelToolCallPart('call_native_replay', selectedTool, { value: 'first' })]
+        },
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+          content: [new vscodeMock.LanguageModelToolResultPart('call_native_replay', [new vscodeMock.LanguageModelTextPart('native output')])]
+        }
+      ],
+      { tools },
+      { report() {} },
+      token
+    );
+
+    const recoveredParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Run a deferred native tool.')] },
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+          content: [new vscodeMock.LanguageModelToolCallPart('call_native_replay', selectedTool, { value: 'first' })]
+        },
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+          content: [new vscodeMock.LanguageModelToolResultPart('call_native_replay', [new vscodeMock.LanguageModelTextPart('native output')])]
+        },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('Native tool result received.')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Continue after the tool result.')] }
+      ],
+      { tools },
+      { report(part) { recoveredParts.push(part); } },
+      token
+    );
+
+    assertEqual(responseRequests.length, 4, 'native replay performs initial, full-replay, rejected continuation, and recovery requests');
+    assertEqual('previous_response_id' in responseRequests[1], false, 'native HTTP tool output uses full replay');
+    const initialReplayCall = responseRequests[1].input.find((item) => item.type === 'function_call');
+    assertEqual(initialReplayCall.namespace, selectedNamespace, 'native HTTP full replay preserves the raw function-call namespace');
+    assertEqual(
+      responseRequests[1].input.filter((item) => item.type === 'function_call').length,
+      1,
+      'native HTTP full replay does not duplicate the converted function call'
+    );
+    assertEqual(responseRequests[1].input.at(-1).type, 'function_call_output', 'native HTTP full replay appends the matching output');
+    assertEqual(responseRequests[2].previous_response_id, 'resp_native_result', 'native follow-up first attempts incremental continuation');
+    assertEqual(
+      JSON.stringify(responseRequests[2].input),
+      JSON.stringify([{ role: 'user', content: 'Continue after the tool result.', type: 'message' }]),
+      'native continuation sends only appended input before recovery'
+    );
+    assertEqual('previous_response_id' in responseRequests[3], false, 'native continuation-miss recovery omits the stale response id');
+    assertEqual(
+      JSON.stringify(responseRequests[3].input),
+      JSON.stringify([
+        { role: 'user', content: 'Run a deferred native tool.', type: 'message' },
+        {
+          id: 'fc_native_replay',
+          type: 'function_call',
+          call_id: 'call_native_replay',
+          name: selectedTool,
+          namespace: selectedNamespace,
+          arguments: '{"value":"first"}'
+        },
+        { type: 'function_call_output', call_id: 'call_native_replay', output: 'native output' },
+        {
+          id: 'msg_native_result',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'Native tool result received.', annotations: [] }]
+        },
+        { role: 'user', content: 'Continue after the tool result.', type: 'message' }
+      ]),
+      'native continuation-miss recovery sends exact ordered canonical input'
+    );
+    assertEqual(
+      responseRequests[3].input.filter((item) => item.type === 'function_call').length,
+      1,
+      'native continuation-miss recovery contains exactly one function call'
+    );
+    assertEqual(
+      recoveredParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
+      'Native continuation recovered.',
+      'native continuation-miss recovery reports only recovered output'
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    configValues.baseURL = originalBaseURL;
+    configValues.credentialsSource = originalCredentialsSource;
+    configValues.nativeToolSearch = originalNativeToolSearch;
+    configValues.transport = 'http';
+    await closeServer(server);
+  }
+}
+
+async function runNativeHostedToolOutputContinuationRecoverySmokeTest() {
+  const frames = [];
+  const sockets = new Set();
+  const warnings = [];
+  let httpResponseRequestCount = 0;
+  let selectedNamespace;
+  let selectedTool;
+  const server = createServer((request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+    httpResponseRequestCount += 1;
+    response.writeHead(500, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ error: { message: 'Native WebSocket replay must not fall back to HTTP.' } }));
+  });
+  const webSocketServer = new webSocketModule.WebSocketServer({ noServer: true });
+  server.on('upgrade', (request, socket, head) => {
+    webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+      webSocketServer.emit('connection', webSocket, request);
+    });
+  });
+  webSocketServer.on('connection', (webSocket) => {
+    sockets.add(webSocket);
+    webSocket.once('close', () => sockets.delete(webSocket));
+    webSocket.on('message', (data) => {
+      const frame = JSON.parse(data.toString('utf8'));
+      frames.push(frame);
+      if (frames.length === 1) {
+        const namespaceTool = frame.tools.find((tool) => tool.type === 'namespace');
+        selectedNamespace = namespaceTool?.name;
+        selectedTool = namespaceTool?.tools?.[0]?.name;
+        if (!selectedNamespace || !selectedTool) {
+          webSocket.send(JSON.stringify({
+            type: 'response.failed',
+            response: { id: 'resp_native_ws_invalid', status: 'failed', error: { message: 'Missing native namespace tool.' } }
+          }));
+          return;
+        }
+        const item = {
+          id: 'fc_native_ws_replay',
+          type: 'function_call',
+          call_id: 'call_native_ws_replay',
+          name: selectedTool,
+          namespace: selectedNamespace,
+          arguments: '{"value":"websocket"}'
+        };
+        webSocket.send(JSON.stringify({ type: 'response.output_item.added', output_index: 0, item }));
+        webSocket.send(JSON.stringify({
+          type: 'response.function_call_arguments.done',
+          item_id: item.id,
+          output_index: 0,
+          name: selectedTool,
+          arguments: item.arguments
+        }));
+        webSocket.send(JSON.stringify({ type: 'response.output_item.done', output_index: 0, item }));
+        webSocket.send(JSON.stringify({ type: 'response.completed', response: { id: 'resp_native_ws_tool', status: 'completed' } }));
+        return;
+      }
+      if (frames.length === 2) {
+        webSocket.send(JSON.stringify({
+          type: 'error',
+          error: {
+            type: 'invalid_request_error',
+            code: 'previous_response_not_found',
+            message: 'Native WebSocket tool-output continuation expired.',
+            param: 'previous_response_id'
+          },
+          status: 400
+        }));
+        return;
+      }
+      if (frames.length === 3) {
+        webSocket.send(JSON.stringify({ type: 'response.output_text.delta', delta: 'Native WebSocket continuation recovered.' }));
+        webSocket.send(JSON.stringify({ type: 'response.completed', response: { id: 'resp_native_ws_recovered', status: 'completed' } }));
+        return;
+      }
+      webSocket.send(JSON.stringify({
+        type: 'response.failed',
+        response: { id: 'resp_native_ws_extra', status: 'failed', error: { message: 'Unexpected extra provider frame.' } }
+      }));
+    });
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const originalFetch = globalThis.fetch;
+  const originalBaseURL = configValues.baseURL;
+  const originalCredentialsSource = configValues.credentialsSource;
+  const originalNativeToolSearch = configValues.nativeToolSearch;
+  const originalTransport = configValues.transport;
+  const originalWebsocketPrewarm = configValues.websocketPrewarm;
+  const originalNoProxy = process.env.NO_PROXY;
+  const originalRewriteWebSocketURL = rewriteWebSocketURL;
+  configValues.baseURL = 'https://chatgpt.com/backend-api/codex/responses';
+  configValues.credentialsSource = 'codexAuth';
+  configValues.nativeToolSearch = 'enabled';
+  configValues.transport = 'websocket';
+  configValues.websocketPrewarm = 'disabled';
+  process.env.NO_PROXY = [originalNoProxy, 'chatgpt.com'].filter(Boolean).join(',');
+  globalThis.fetch = async (input, init) => {
+    const requestUrl = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    const targetUrl = new URL(requestUrl);
+    targetUrl.protocol = 'http:';
+    targetUrl.hostname = '127.0.0.1';
+    targetUrl.port = String(address.port);
+    return originalFetch(targetUrl, init);
+  };
+  rewriteWebSocketURL = (input) => {
+    const targetUrl = new URL(input.toString());
+    targetUrl.protocol = 'ws:';
+    targetUrl.hostname = '127.0.0.1';
+    targetUrl.port = String(address.port);
+    return targetUrl;
+  };
+
+  const tools = Array.from({ length: 13 }, (_, index) => ({
+    name: `native_ws_replay_tool_${String(index).padStart(2, '0')}`,
+    description: `Native WebSocket replay tool ${index}`,
+    inputSchema: {
+      type: 'object',
+      properties: { value: { type: 'string' } },
+      required: ['value']
+    }
+  }));
+  const context = { subscriptions: [] };
+  const provider = new CodexModelProvider(
+    context,
+    {
+      debug() {},
+      info() {},
+      warn(message, data) {
+        warnings.push({ message, data });
+      },
+      error() {}
+    },
+    undefined,
+    undefined,
+    undefined,
+    {
+      async getStatus() {
+        return { accountId: 'native-ws-replay-account' };
+      },
+      async getAccessToken() {
+        return 'native-ws-replay-token';
+      }
+    }
+  );
+  const token = createMutableCancellationToken();
+
+  try {
+    const models = await withSmokeTimeout(
+      provider.provideLanguageModelChatInformation({ silent: true }, token),
+      token,
+      'native WebSocket model discovery'
+    );
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected model for native WebSocket replay coverage.');
+    }
+
+    const firstParts = [];
+    await withSmokeTimeout(
+      provider.provideLanguageModelChatResponse(
+        model,
+        [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Run a deferred native WebSocket tool.')] }],
+        { tools },
+        { report(part) { firstParts.push(part); } },
+        token
+      ),
+      token,
+      'native WebSocket function-call response'
+    );
+    const toolCall = firstParts.find((part) => part instanceof LanguageModelToolCallPart);
+    if (!toolCall || !selectedNamespace || !selectedTool) {
+      throw new Error('Expected one mapped native WebSocket tool call.');
+    }
+    assertEqual(toolCall.name, selectedTool, 'native WebSocket namespaced call maps to the selected VS Code tool');
+
+    const recoveredParts = [];
+    await withSmokeTimeout(
+      provider.provideLanguageModelChatResponse(
+        model,
+        [
+          { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Run a deferred native WebSocket tool.')] },
+          {
+            role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+            content: [new vscodeMock.LanguageModelToolCallPart('call_native_ws_replay', selectedTool, { value: 'websocket' })]
+          },
+          {
+            role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+            content: [new vscodeMock.LanguageModelToolResultPart('call_native_ws_replay', [new vscodeMock.LanguageModelTextPart('native websocket output')])]
+          }
+        ],
+        { tools },
+        { report(part) { recoveredParts.push(part); } },
+        token
+      ),
+      token,
+      'native WebSocket tool-output continuation recovery'
+    );
+
+    assertEqual(frames.length, 3, 'native WebSocket recovery sends initial, incremental, and canonical retry frames');
+    assertEqual(frames[1].previous_response_id, 'resp_native_ws_tool', 'tool output is first sent with the previous response id');
+    assertEqual(
+      JSON.stringify(frames[1].input),
+      JSON.stringify([{ type: 'function_call_output', call_id: 'call_native_ws_replay', output: 'native websocket output' }]),
+      'tool-output continuation sends only the matching incremental output'
+    );
+    assertEqual('previous_response_id' in frames[2], false, 'tool-output continuation-miss retry omits the stale response id');
+    assertEqual(
+      JSON.stringify(frames[2].input),
+      JSON.stringify([
+        { role: 'user', content: 'Run a deferred native WebSocket tool.', type: 'message' },
+        {
+          id: 'fc_native_ws_replay',
+          type: 'function_call',
+          call_id: 'call_native_ws_replay',
+          name: selectedTool,
+          namespace: selectedNamespace,
+          arguments: '{"value":"websocket"}'
+        },
+        { type: 'function_call_output', call_id: 'call_native_ws_replay', output: 'native websocket output' }
+      ]),
+      'tool-output continuation-miss retry sends exact ordered canonical replay'
+    );
+    assertEqual(
+      frames[2].input.filter((item) => item.type === 'function_call').length,
+      1,
+      'tool-output continuation-miss retry contains exactly one namespaced function call'
+    );
+    assertEqual(
+      frames[2].input.filter((item) => item.type === 'function_call_output').length,
+      1,
+      'tool-output continuation-miss retry contains exactly one matching output'
+    );
+    assertEqual(
+      warnings.filter((entry) => entry.message === 'response tool-output continuation reset').length,
+      1,
+      'tool-output continuation miss executes the dedicated provider recovery branch'
+    );
+    assertEqual(
+      warnings.some((entry) => entry.message === 'response continuation reset'),
+      false,
+      'tool-output continuation miss does not execute generic continuation recovery'
+    );
+    assertEqual(httpResponseRequestCount, 0, 'structured WebSocket continuation miss never falls back to HTTP');
+    assertEqual(
+      recoveredParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
+      'Native WebSocket continuation recovered.',
+      'tool-output continuation recovery reports only retry output'
+    );
+  } finally {
+    for (const subscription of context.subscriptions.splice(0)) {
+      subscription.dispose();
+    }
+    globalThis.fetch = originalFetch;
+    rewriteWebSocketURL = originalRewriteWebSocketURL;
+    configValues.baseURL = originalBaseURL;
+    configValues.credentialsSource = originalCredentialsSource;
+    configValues.nativeToolSearch = originalNativeToolSearch;
+    configValues.transport = originalTransport;
+    if (originalWebsocketPrewarm === undefined) {
+      delete configValues.websocketPrewarm;
+    } else {
+      configValues.websocketPrewarm = originalWebsocketPrewarm;
+    }
+    if (originalNoProxy === undefined) {
+      delete process.env.NO_PROXY;
+    } else {
+      process.env.NO_PROXY = originalNoProxy;
+    }
+    for (const socket of sockets) {
+      socket.terminate();
+    }
+    await closeWebSocketServer(webSocketServer);
+    await closeServer(server);
+  }
+}
+
 async function runProviderCatalogVersionNeutralSmokeTest() {
   const server = createServer(async (request, response) => {
     if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
@@ -2078,6 +2648,23 @@ function createMutableCancellationToken() {
   };
 }
 
+async function withSmokeTimeout(promise, token, label, timeoutMs = 5_000) {
+  let timeout;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timeout = setTimeout(() => {
+          token.cancel();
+          reject(new Error(`${label} timed out after ${timeoutMs}ms.`));
+        }, timeoutMs);
+      })
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 function writeSseResponse(response, text, responseId) {
   response.writeHead(200, {
     'content-type': 'text/event-stream',
@@ -2093,6 +2680,20 @@ function writeSseResponse(response, text, responseId) {
 async function closeServer(server) {
   await new Promise((resolve, reject) => {
     server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+async function closeWebSocketServer(server) {
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('WebSocket server cleanup timed out.')), 5_000);
+    server.close((error) => {
+      clearTimeout(timeout);
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- preserve raw namespaced function calls during HTTP full replay and both continuation-miss recovery paths
- isolate workspace/folder grouping restoration state while retaining global restoration across workspaces
- globally prune and cap unsupported native Tool Search capabilities
- add provider-level WebSocket tool-output continuation-miss coverage and exact duplicate-free canonical replay assertions

This is a focused contribution into #38 rather than a separate master feature PR.

## Validation
- focused provider, grouping, and capability smokes
- `npm run check`
- `npm run compile`
- `npm run test:smoke`
- [manually dispatched full Pull Request CI](https://github.com/victor-gurbani/Codex-For-Copilot/actions/runs/30139174626), including the pinned Extension Host test