### PR TITLE
ci: run extension host smoke before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,9 @@ jobs:
       - name: Run smoke tests
         run: npm run test:smoke
 
+      - name: Run Extension Host smoke test
+        run: xvfb-run -a npm run test:extension-host
+
       - name: Package VSIX
         run: npx vsce package --out "${{ steps.version.outputs.vsix }}"
 


### PR DESCRIPTION
## Summary
- run the existing pinned Extension Host smoke test in the release job
- gate VSIX packaging and Marketplace publication on real VS Code provider registration and tool-loop behavior
- mirror the command already used by Pull Request CI

Release Please PRs created with `GITHUB_TOKEN` do not automatically receive PR CI, so the publishing job needs this gate directly.

## Validation
- release and CI workflow YAML parse successfully
- release command exactly matches CI: `xvfb-run -a npm run test:extension-host`
- current-master compile and full smoke pass