### PR TITLE
chore: refresh vulnerable dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1423,16 +1423,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {


### PR DESCRIPTION
## Summary
- update dev-only `brace-expansion` from 5.0.7 to 5.0.8
- clear GHSA-mh99-v99m-4gvg without changing `package.json` or production dependencies

## Validation
- `npm ci`
- `npm audit --omit=dev` (0 vulnerabilities)
- `npm audit` (0 vulnerabilities)
- `npm run compile`
- `npm run test:smoke`