### PR TITLE
chore(release): define changelog policy

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,55 @@
   "draft": true,
   "force-tag-creation": true,
   "include-component-in-tag": false,
+  "always-update": true,
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores",
+      "hidden": true
+    }
+  ],
   "packages": {
     ".": {
       "package-name": "codex-for-copilot",


### PR DESCRIPTION
## Summary

- explicitly define the user-facing Release Please changelog sections
- keep internal `ci`, `test`, `build`, `refactor`, `docs`, and routine `chore` commits hidden
- enable `always-update` so an existing release PR stays synchronized when `master` advances

## Commit policy

Security or user-impacting dependency fixes should use `fix(deps): ...`; routine dependency maintenance should continue to use `chore(deps): ...`.

## Validation

- configuration remains valid JSON
- section behavior matches the existing Release Please defaults while making the repository policy explicit
- no version or release contents are changed by this PR