### PR TITLE
Superseded: support catalog-advertised reasoning efforts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:benchmark-backend": "node test/benchmarkBackend.mjs",
     "test:benchmark-provider": "node test/benchmarkProviderBackend.mjs",
     "test:codex-parity": "node test/smokeCodexProtocol.mjs && node test/smokeCodexIdentity.mjs && node test/smokeCodexRequestBuilder.mjs && node test/smokeCodexToolSchemaCache.mjs && node test/smokeCodexTurnLifecycle.mjs && node test/smokeCodexHttpLifecycle.mjs && node test/smokeCodexWebSocketLifecycle.mjs && node test/smokeCodexPreconnection.mjs && node test/smokeCodexPrewarmBudget.mjs && node test/smokeCodexCancellation.mjs && node test/smokeCodexFallback.mjs && node test/smokeCodexCompression.mjs",
-    "test:smoke": "npm run test:codex-parity && node test/smokeCodexLatency.mjs && node test/smokeStreamPresenter.mjs && node test/smokeCodexModelCache.mjs && node test/smokeResponsesClient.mjs && node test/smokeProviderFallback.mjs && node test/smokeConversationReuse.mjs && node test/smokeAccountUsage.mjs && node test/smokeAuth.mjs",
+    "test:smoke": "npm run test:codex-parity && node test/smokeReasoningEffort.mjs && node test/smokeCodexLatency.mjs && node test/smokeStreamPresenter.mjs && node test/smokeCodexModelCache.mjs && node test/smokeResponsesClient.mjs && node test/smokeProviderFallback.mjs && node test/smokeConversationReuse.mjs && node test/smokeAccountUsage.mjs && node test/smokeAuth.mjs",
     "watch": "tsc -watch -p ./",
     "vscode:prepublish": "npm run compile"
   },
@@ -241,7 +241,9 @@
             "low",
             "medium",
             "high",
-            "xhigh"
+            "xhigh",
+            "max",
+            "ultra"
           ],
           "enumDescriptions": [
             "Use the model's default Thinking Effort unless the chat UI supplies an explicit selection.",
@@ -250,7 +252,9 @@
             "Fast responses with lighter reasoning.",
             "Balances speed and reasoning depth for everyday tasks.",
             "Greater reasoning depth for complex problems.",
-            "Extra high reasoning depth for complex problems."
+            "Extra high reasoning depth for complex problems.",
+            "Maximum reasoning depth for the hardest problems.",
+            "Maximum reasoning with automatic task delegation."
           ],
           "description": "Fallback reasoning effort used when the chat UI does not provide a Thinking Effort selection."
         },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { normalizeKnownReasoningEffort, type KnownReasoningEffort } from './reasoningEffort';
 
 export interface ModelPricing {
   input?: number;
@@ -19,7 +20,7 @@ export interface ProviderConfig {
   modelAliases: Record<string, string>;
   instructions: string;
   defaultServiceTier?: 'default' | 'fast';
-  defaultReasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+  defaultReasoningEffort?: KnownReasoningEffort;
   maxOutputTokens: number;
   modelPricingUsdPerMTok: Record<string, ModelPricing>;
 }
@@ -71,17 +72,7 @@ function normalizeDefaultServiceTier(value: string): ProviderConfig['defaultServ
 }
 
 function normalizeDefaultReasoningEffort(value: string): ProviderConfig['defaultReasoningEffort'] {
-  switch (value) {
-    case 'none':
-    case 'minimal':
-    case 'low':
-    case 'medium':
-    case 'high':
-    case 'xhigh':
-      return value;
-    default:
-      return undefined;
-  }
+  return normalizeKnownReasoningEffort(value);
 }
 
 function normalizeModelPricing(value: unknown): Record<string, ModelPricing> {

--- a/src/models.ts
+++ b/src/models.ts
@@ -3,6 +3,14 @@ import type { ProviderConfig } from './config';
 import type { ApiCredentials } from './secrets';
 import { normalizeBaseURL } from './responsesClient';
 import { codexFetch } from './auth/codexAuthRequest';
+import {
+  getReasoningEffortDescription,
+  getReasoningEffortLabel,
+  normalizeReasoningEffort,
+  type ReasoningEffort
+} from './reasoningEffort';
+
+export type { ReasoningEffort } from './reasoningEffort';
 
 const REASONING_ID_DELIMITER = '::reasoning=';
 const CONTEXT_ID_DELIMITER = '::context=';
@@ -39,26 +47,6 @@ const MODEL_DEFAULT_REASONING_FALLBACKS: Partial<Record<string, ReasoningEffort>
   'gpt-5.3-codex-spark': 'high',
   'codex-auto-review': 'medium'
 };
-
-const REASONING_EFFORT_LABELS: Record<ReasoningEffort, string> = {
-  none: 'None',
-  minimal: 'Minimal',
-  low: 'Low',
-  medium: 'Medium',
-  high: 'High',
-  xhigh: 'Extra High'
-};
-
-const REASONING_EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
-  none: 'Skip extra reasoning for the fastest replies when the model supports it.',
-  minimal: 'Use a very light reasoning pass for small edits and quick follow-ups.',
-  low: 'Fast responses with lighter reasoning.',
-  medium: 'Balances speed and reasoning depth for everyday tasks.',
-  high: 'Greater reasoning depth for complex problems.',
-  xhigh: 'Extra high reasoning depth for complex problems.'
-};
-
-export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 
 interface UpstreamReasoningLevel {
   effort?: unknown;
@@ -568,11 +556,7 @@ function formatTokenCount(value: number): string {
 }
 
 function formatReasoningEffort(effort: ReasoningEffort): string {
-  return REASONING_EFFORT_LABELS[effort];
-}
-
-function getReasoningEffortDescription(effort: ReasoningEffort): string {
-  return REASONING_EFFORT_DESCRIPTIONS[effort];
+  return getReasoningEffortLabel(effort);
 }
 
 function normalizeSentence(value: string): string {
@@ -610,20 +594,6 @@ function isModelVisible(
   }
 
   return true;
-}
-
-function normalizeReasoningEffort(value: unknown): ReasoningEffort | undefined {
-  switch (value) {
-    case 'none':
-    case 'minimal':
-    case 'low':
-    case 'medium':
-    case 'high':
-    case 'xhigh':
-      return value;
-    default:
-      return undefined;
-  }
 }
 
 function getPositiveInteger(value: unknown): number | undefined {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -4,7 +4,13 @@ import { performance } from 'node:perf_hooks';
 import type { ResponseUsage } from 'openai/resources/responses/responses';
 import { compareResponsesInputHistory, convertMessagesToResponsesInput, estimateTokenCount, stableSerialize, type ResponsesInputMessage } from './convertMessages';
 import { getProviderConfig, type ProviderConfig } from './config';
-import { buildFallbackModel, buildProviderModels, fetchAvailableModels, isProviderModelIdentifier, parseModelIdentifier, type ParsedModelIdentifier, type ReasoningEffort, type ResolvedProviderModel } from './models';
+import { buildFallbackModel, buildProviderModels, fetchAvailableModels, isProviderModelIdentifier, parseModelIdentifier, type ParsedModelIdentifier, type ResolvedProviderModel } from './models';
+import {
+  resolveReasoningEffort,
+  toResponsesReasoning,
+  type ReasoningEffort,
+  type ReasoningEffortResolution
+} from './reasoningEffort';
 import {
   countInputTokens,
   disposeReusableResponsesWebSockets,
@@ -42,24 +48,6 @@ type RuntimeProvideLanguageModelChatResponseOptions = vscode.ProvideLanguageMode
   readonly modelConfiguration?: Record<string, unknown>;
   readonly configuration?: Record<string, unknown>;
 };
-
-type ReasoningEffortSource =
-  | 'modelConfiguration'
-  | 'configuration'
-  | 'modelOptions.reasoningEffort'
-  | 'modelOptions.thinkingEffort'
-  | 'modelOptions.reasoning.effort'
-  | 'modelOptions.thinking.effort'
-  | 'modelOptions.thinking'
-  | 'default'
-  | 'model'
-  | 'none';
-
-interface ReasoningEffortResolution {
-  effort: ReasoningEffort | undefined;
-  source: ReasoningEffortSource;
-  hasExplicitConflict: boolean;
-}
 
 interface ResolvedRequestModel extends ParsedModelIdentifier {
   effectiveInputBudget?: number;
@@ -300,7 +288,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       instructions: config.instructions,
       tools: options.tools,
       toolMode: options.toolMode,
-      reasoning: reasoningEffort ? { effort: reasoningEffort } : undefined,
+      reasoning: reasoningEffort ? toResponsesReasoning(reasoningEffort) : undefined,
       serviceTier: getRequestServiceTier(config.defaultServiceTier),
       store: false,
       omitMaxOutputTokens: credentials.omitMaxOutputTokens,
@@ -1621,47 +1609,7 @@ export function getReasoningEffort(
   options: RuntimeProvideLanguageModelChatResponseOptions,
   defaultReasoningEffort: ReasoningEffort | undefined
 ): ReasoningEffortResolution {
-  const modelOptions = options.modelOptions;
-  const thinking = modelOptions?.thinking as { effort?: unknown } | undefined;
-  const explicitCandidates: Array<{ effort: ReasoningEffort | undefined; source: ReasoningEffortSource }> = [
-    { effort: normalizeReasoningEffort(modelOptions?.reasoningEffort), source: 'modelOptions.reasoningEffort' },
-    { effort: normalizeReasoningEffort(modelOptions?.thinkingEffort), source: 'modelOptions.thinkingEffort' },
-    { effort: normalizeReasoningEffort((modelOptions?.reasoning as { effort?: unknown } | undefined)?.effort), source: 'modelOptions.reasoning.effort' },
-    { effort: normalizeReasoningEffort(thinking?.effort), source: 'modelOptions.thinking.effort' },
-    { effort: normalizeReasoningEffort(modelOptions?.thinking), source: 'modelOptions.thinking' },
-    { effort: normalizeReasoningEffort(options.modelConfiguration?.reasoningEffort), source: 'modelConfiguration' },
-    { effort: normalizeReasoningEffort(options.configuration?.reasoningEffort), source: 'configuration' }
-  ].filter((candidate): candidate is { effort: ReasoningEffort; source: ReasoningEffortSource } => candidate.effort !== undefined);
-  const selected = explicitCandidates[0];
-  const hasExplicitConflict = new Set(explicitCandidates.map((candidate) => candidate.effort)).size > 1;
-
-  if (selected) {
-    return { ...selected, hasExplicitConflict };
-  }
-
-  if (defaultReasoningEffort) {
-    return { effort: defaultReasoningEffort, source: 'default', hasExplicitConflict };
-  }
-
-  if (selectedReasoningEffort) {
-    return { effort: selectedReasoningEffort, source: 'model', hasExplicitConflict };
-  }
-
-  return { effort: undefined, source: 'none', hasExplicitConflict };
-}
-
-function normalizeReasoningEffort(value: unknown): ReasoningEffort | undefined {
-  switch (value) {
-    case 'none':
-    case 'minimal':
-    case 'low':
-    case 'medium':
-    case 'high':
-    case 'xhigh':
-      return value;
-    default:
-      return undefined;
-  }
+  return resolveReasoningEffort(selectedReasoningEffort, options, defaultReasoningEffort);
 }
 
 function supportsOfficialTokenCounting(baseURL: string): boolean {

--- a/src/reasoningEffort.ts
+++ b/src/reasoningEffort.ts
@@ -1,0 +1,147 @@
+import type { Reasoning } from 'openai/resources/shared';
+
+export const KNOWN_REASONING_EFFORTS = [
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra'
+] as const;
+
+export type KnownReasoningEffort = typeof KNOWN_REASONING_EFFORTS[number];
+export type ReasoningEffort = KnownReasoningEffort | (string & {});
+
+export type ReasoningEffortSource =
+  | 'modelConfiguration'
+  | 'configuration'
+  | 'modelOptions.reasoningEffort'
+  | 'modelOptions.thinkingEffort'
+  | 'modelOptions.reasoning.effort'
+  | 'modelOptions.thinking.effort'
+  | 'modelOptions.thinking'
+  | 'default'
+  | 'model'
+  | 'none';
+
+export interface ReasoningEffortInputOptions {
+  readonly modelOptions?: Record<string, unknown>;
+  readonly modelConfiguration?: Record<string, unknown>;
+  readonly configuration?: Record<string, unknown>;
+}
+
+export interface ReasoningEffortResolution {
+  effort: ReasoningEffort | undefined;
+  source: ReasoningEffortSource;
+  hasExplicitConflict: boolean;
+}
+
+const KNOWN_REASONING_EFFORT_SET = new Set<string>(KNOWN_REASONING_EFFORTS);
+
+const REASONING_EFFORT_LABELS: Readonly<Record<KnownReasoningEffort, string>> = {
+  none: 'None',
+  minimal: 'Minimal',
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  xhigh: 'Extra High',
+  max: 'Maximum',
+  ultra: 'Ultra'
+};
+
+const REASONING_EFFORT_DESCRIPTIONS: Readonly<Record<KnownReasoningEffort, string>> = {
+  none: 'Skip extra reasoning for the fastest replies when the model supports it.',
+  minimal: 'Use a very light reasoning pass for small edits and quick follow-ups.',
+  low: 'Fast responses with lighter reasoning.',
+  medium: 'Balances speed and reasoning depth for everyday tasks.',
+  high: 'Greater reasoning depth for complex problems.',
+  xhigh: 'Extra high reasoning depth for complex problems.',
+  max: 'Maximum reasoning depth for the hardest problems.',
+  ultra: 'Maximum reasoning with automatic task delegation.'
+};
+
+export function normalizeReasoningEffort(value: unknown): ReasoningEffort | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized ? normalized : undefined;
+}
+
+export function normalizeKnownReasoningEffort(value: unknown): KnownReasoningEffort | undefined {
+  const normalized = normalizeReasoningEffort(value);
+  return normalized && KNOWN_REASONING_EFFORT_SET.has(normalized)
+    ? normalized as KnownReasoningEffort
+    : undefined;
+}
+
+export function getReasoningEffortLabel(effort: ReasoningEffort): string {
+  const knownEffort = normalizeKnownReasoningEffort(effort);
+  if (knownEffort) {
+    return REASONING_EFFORT_LABELS[knownEffort];
+  }
+
+  const words = effort.split(/[-_]+/).filter(Boolean);
+  if (words.length === 0) {
+    return effort;
+  }
+
+  return words
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+    .join(' ');
+}
+
+export function getReasoningEffortDescription(effort: ReasoningEffort): string {
+  const knownEffort = normalizeKnownReasoningEffort(effort);
+  if (knownEffort) {
+    return REASONING_EFFORT_DESCRIPTIONS[knownEffort];
+  }
+
+  return `Use the ${getReasoningEffortLabel(effort)} reasoning effort advertised by the selected model.`;
+}
+
+export function resolveReasoningEffort(
+  selectedReasoningEffort: ReasoningEffort | undefined,
+  options: ReasoningEffortInputOptions,
+  defaultReasoningEffort: ReasoningEffort | undefined
+): ReasoningEffortResolution {
+  const modelOptions = options.modelOptions;
+  const thinking = modelOptions?.thinking;
+  const nestedThinkingEffort = thinking && typeof thinking === 'object' && !Array.isArray(thinking)
+    ? (thinking as { effort?: unknown }).effort
+    : undefined;
+  const explicitCandidates: Array<{ effort: ReasoningEffort | undefined; source: ReasoningEffortSource }> = [
+    { effort: normalizeReasoningEffort(modelOptions?.reasoningEffort), source: 'modelOptions.reasoningEffort' },
+    { effort: normalizeReasoningEffort(modelOptions?.thinkingEffort), source: 'modelOptions.thinkingEffort' },
+    { effort: normalizeReasoningEffort((modelOptions?.reasoning as { effort?: unknown } | undefined)?.effort), source: 'modelOptions.reasoning.effort' },
+    { effort: normalizeReasoningEffort(nestedThinkingEffort), source: 'modelOptions.thinking.effort' },
+    { effort: normalizeReasoningEffort(modelOptions?.thinking), source: 'modelOptions.thinking' },
+    { effort: normalizeReasoningEffort(options.modelConfiguration?.reasoningEffort), source: 'modelConfiguration' },
+    { effort: normalizeReasoningEffort(options.configuration?.reasoningEffort), source: 'configuration' }
+  ].filter((candidate): candidate is { effort: ReasoningEffort; source: ReasoningEffortSource } => candidate.effort !== undefined);
+  const selected = explicitCandidates[0];
+  const hasExplicitConflict = new Set(explicitCandidates.map((candidate) => candidate.effort)).size > 1;
+
+  if (selected) {
+    return { ...selected, hasExplicitConflict };
+  }
+
+  if (defaultReasoningEffort) {
+    return { effort: defaultReasoningEffort, source: 'default', hasExplicitConflict };
+  }
+
+  if (selectedReasoningEffort) {
+    return { effort: selectedReasoningEffort, source: 'model', hasExplicitConflict };
+  }
+
+  return { effort: undefined, source: 'none', hasExplicitConflict };
+}
+
+export function toResponsesReasoning(effort: ReasoningEffort): Reasoning {
+  // Codex model catalogs can advertise efforts before the public SDK schema is regenerated.
+  // Keep the forward-compatible wire value at this single typed boundary.
+  return { effort } as Reasoning;
+}

--- a/test/smokeReasoningEffort.mjs
+++ b/test/smokeReasoningEffort.mjs
@@ -1,0 +1,170 @@
+import { createRequire } from 'node:module';
+import Module from 'node:module';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { build } from 'esbuild';
+import { resolveTestTempDirectory } from './testTempDirectory.mjs';
+
+const tempDir = await mkdtemp(join(resolveTestTempDirectory(), 'codex-for-copilot-reasoning-effort-'));
+const reasoningBundlePath = join(tempDir, 'reasoningEffort.cjs');
+const modelsBundlePath = join(tempDir, 'models.cjs');
+const moduleLoad = Module._load;
+const require = createRequire(import.meta.url);
+
+await build({
+  entryPoints: ['src/reasoningEffort.ts'],
+  bundle: true,
+  format: 'cjs',
+  platform: 'node',
+  target: 'node20',
+  outfile: reasoningBundlePath
+});
+
+await build({
+  entryPoints: ['src/models.ts'],
+  bundle: true,
+  format: 'cjs',
+  platform: 'node',
+  target: 'node20',
+  outfile: modelsBundlePath,
+  external: ['vscode']
+});
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'vscode') {
+    return {};
+  }
+
+  return moduleLoad.call(this, request, parent, isMain);
+};
+
+const {
+  getReasoningEffortDescription,
+  getReasoningEffortLabel,
+  normalizeKnownReasoningEffort,
+  normalizeReasoningEffort,
+  resolveReasoningEffort,
+  toResponsesReasoning
+} = require(reasoningBundlePath);
+const { buildProviderModels } = require(modelsBundlePath);
+
+try {
+  const model = buildProviderModels(createConfig(), [createCatalogModel()], 'codexAccessToken')[0];
+  const schema = model.info.configurationSchema?.properties?.reasoningEffort;
+  if (!schema) {
+    throw new Error('Expected a reasoning effort configuration schema.');
+  }
+
+  assertEqual(
+    schema.enum.join(','),
+    'low,max,ultra,future_effort',
+    'catalog reasoning efforts remain ordered and forward-compatible'
+  );
+  assertEqual(
+    schema.enumItemLabels.join(','),
+    'Low,Maximum,Ultra,Future Effort',
+    'known and custom reasoning efforts receive readable labels'
+  );
+  assertEqual(schema.default, 'low', 'catalog default reasoning effort');
+  assertEqual(
+    schema.enumDescriptions[3],
+    'Use the Future Effort reasoning effort advertised by the selected model.',
+    'custom effort receives a truthful fallback description'
+  );
+  assertEqual(
+    model.info.detail?.includes('Thinking: Low, Maximum, Ultra, Future Effort (default: Low)'),
+    true,
+    'model detail exposes the full catalog reasoning range'
+  );
+
+  assertEqual(normalizeReasoningEffort(' future_effort '), 'future_effort', 'custom effort normalization');
+  assertEqual(normalizeReasoningEffort('   '), undefined, 'blank effort rejection');
+  assertEqual(normalizeKnownReasoningEffort('max'), 'max', 'known max setting normalization');
+  assertEqual(normalizeKnownReasoningEffort('ultra'), 'ultra', 'known ultra setting normalization');
+  assertEqual(normalizeKnownReasoningEffort('future_effort'), undefined, 'settings reject unknown effort values');
+  assertEqual(getReasoningEffortLabel('future_effort'), 'Future Effort', 'custom effort label formatting');
+  assertEqual(
+    getReasoningEffortDescription('max'),
+    'Maximum reasoning depth for the hardest problems.',
+    'maximum effort description'
+  );
+
+  assertResolution(
+    resolveReasoningEffort('low', { modelConfiguration: { reasoningEffort: 'ultra' } }, undefined),
+    'ultra',
+    'modelConfiguration',
+    false,
+    'VS Code model configuration can select Ultra'
+  );
+  assertResolution(
+    resolveReasoningEffort('low', { modelOptions: { thinking: { effort: 'future_effort' } } }, undefined),
+    'future_effort',
+    'modelOptions.thinking.effort',
+    false,
+    'future catalog effort survives runtime option resolution'
+  );
+  assertResolution(
+    resolveReasoningEffort('low', {
+      modelOptions: { reasoningEffort: 'max' },
+      modelConfiguration: { reasoningEffort: 'ultra' }
+    }, undefined),
+    'max',
+    'modelOptions.reasoningEffort',
+    true,
+    'request-level effort keeps precedence and reports conflicts'
+  );
+  assertEqual(toResponsesReasoning('ultra').effort, 'ultra', 'Ultra remains unchanged at the SDK boundary');
+
+  console.log('Smoke test passed: catalog reasoning efforts are selectable, forward-compatible, and preserved on the wire.');
+} finally {
+  Module._load = moduleLoad;
+  await rm(tempDir, { recursive: true, force: true });
+}
+
+function createConfig() {
+  return {
+    baseURL: 'https://chatgpt.com/backend-api/codex/responses',
+    clientVersion: '0.0.0',
+    credentialsSource: 'codexAuth',
+    transport: 'auto',
+    websocketPrewarm: 'auto',
+    requestCompression: 'auto',
+    model: 'gpt-5.6-sol',
+    includeHiddenModels: false,
+    disabledModels: [],
+    modelAliases: {},
+    instructions: 'Smoke test instructions',
+    defaultReasoningEffort: undefined,
+    defaultServiceTier: undefined,
+    maxOutputTokens: 8192,
+    modelPricingUsdPerMTok: {}
+  };
+}
+
+function createCatalogModel() {
+  return {
+    slug: 'gpt-5.6-sol',
+    display_name: 'GPT-5.6-Sol',
+    context_window: 372000,
+    max_context_window: 372000,
+    default_reasoning_level: 'low',
+    supported_reasoning_levels: [
+      { effort: 'low', description: 'Fast responses with lighter reasoning' },
+      { effort: 'max', description: 'Maximum reasoning depth for the hardest problems' },
+      { effort: 'ultra', description: 'Maximum reasoning with automatic task delegation' },
+      { effort: 'future_effort' }
+    ]
+  };
+}
+
+function assertResolution(actual, effort, source, hasExplicitConflict, label) {
+  assertEqual(actual.effort, effort, `${label} effort`);
+  assertEqual(actual.source, source, `${label} source`);
+  assertEqual(actual.hasExplicitConflict, hasExplicitConflict, `${label} conflict`);
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${String(expected)}, received ${String(actual)}`);
+  }
+}


### PR DESCRIPTION
## Summary

- centralize reasoning-effort compatibility and metadata
- expose GPT-5.6 `max` and `ultra` when advertised by the model catalog
- preserve future non-empty catalog values without allowing arbitrary global settings
- add focused smoke coverage for discovery, selection, and wire preservation

## Validation

Implementation must pass:

- `npm run check`
- `npm run test:smoke`
- `npm run compile`
- `git diff --check`

Closes #48

> The current task-marker file is temporary and must be removed by the implementation commit.