### PR TITLE
feat(auth): add native ChatGPT OAuth sign-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ The extension source lives in [`src/`](src/). Key modules are:
 - `secrets.ts`: credential selection across the Codex auth manager, `~/.codex/auth.json`, and SecretStorage
 - `auth/`: imported Codex credential storage, refresh, locking, JWT parsing, and request authentication
 
+The extension manifest declares the `codex-for-copilot` AuthenticationProvider under `contributes.authentication`; its ID and label must match the runtime registration in `src/extension.ts`.
+
 Compiled output is written to `out/` and should be treated as build artifacts. Tests live in `test/`. Workspace debug helpers are in `.vscode/`.
 
 Transport-related constraints that must not break:

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ Install the extension from the [VS Code Marketplace](https://marketplace.visuals
 
 Open the Command Palette and choose one of the following:
 
-- **`Codex for Copilot: Import Codex auth.json`** to import an existing Codex login.
+- **`Codex for Copilot: Sign in with ChatGPT`** for the normal browser-based login flow.
+- **`Codex for Copilot: Sign in with Device Code`** when a loopback browser callback is unavailable.
+- **`Codex for Copilot: Import Codex auth.json`** only for a read-only legacy credential snapshot.
 - **`Codex: Set API Key`** to store an API key in VS Code SecretStorage.
 
-The extension can also use the legacy `~/.codex/auth.json` location. It consumes credentials you already have and does not sign in to ChatGPT on your behalf.
+The extension stores its own ChatGPT credentials in VS Code SecretStorage and refreshes them automatically. The legacy `~/.codex/auth.json` fallback is never modified, refreshed, or revoked.
 
 ### 3. Select Codex
 
@@ -45,7 +47,7 @@ Open VS Code Chat, choose **Codex** from the model picker, and start chatting or
 ## Requirements
 
 - VS Code 1.104.0 or newer.
-- A valid imported Codex credential bundle or API key.
+- A ChatGPT sign-in, legacy Codex credential snapshot, or API key.
 
 ## Common commands
 
@@ -53,6 +55,8 @@ Open VS Code Chat, choose **Codex** from the model picker, and start chatting or
 - `Codex: Open Settings`
 - `Codex: Open Debug Logs`
 - `Codex: Refresh Account Limits`
+- `Codex for Copilot: Sign in with ChatGPT`
+- `Codex for Copilot: Sign in with Device Code`
 - `Codex for Copilot: Import Codex auth.json`
 - `Codex for Copilot: Show Auth Status`
 - `Codex for Copilot: Sign Out`

--- a/docs/chatgpt-codex-oauth-plan.md
+++ b/docs/chatgpt-codex-oauth-plan.md
@@ -1,0 +1,663 @@
+# ChatGPT Codex OAuth Authentication Plan
+
+## Status
+
+Implementation plan for adding first-party ChatGPT Codex OAuth sign-in, credential refresh, unauthorized recovery, and logout to Codex For Copilot.
+
+This document is intended to be executed directly by Codex. Keep the implementation in this pull request and update the checklist as work progresses.
+
+## Goal
+
+Allow users to sign in to Codex For Copilot with their ChatGPT account without installing Codex CLI or manually importing `~/.codex/auth.json`.
+
+The finished implementation must:
+
+- provide browser-based OAuth Authorization Code + PKCE sign-in as the default flow;
+- provide Device Code sign-in as a fallback;
+- store extension-owned OAuth credentials in VS Code `SecretStorage`;
+- proactively refresh access tokens and recover once from an unauthorized request;
+- safely coordinate refreshes across concurrent requests and multiple VS Code windows;
+- apply refreshed credentials consistently to model discovery, usage requests, HTTP Responses streaming, and Responses WebSocket sessions;
+- revoke the OAuth session on sign-out when possible;
+- preserve API-key authentication and a read-only legacy Codex credential fallback;
+- never log authorization codes, PKCE verifiers, access tokens, refresh tokens, ID tokens, or complete callback URLs.
+
+## Upstream references
+
+Use the current `openai/codex` implementation as the behavioral reference, while keeping all upstream-derived constants and protocol details isolated behind a compatibility module because this is not a separately versioned public OAuth specification.
+
+Relevant upstream files:
+
+- `codex-rs/login/src/server.rs`
+- `codex-rs/login/src/device_code_auth.rs`
+- `codex-rs/login/src/pkce.rs`
+- `codex-rs/login/src/auth/manager.rs`
+- `codex-rs/login/src/auth/revoke.rs`
+
+Important upstream behavior to preserve:
+
+- OAuth issuer: `https://auth.openai.com`
+- preferred loopback port: `1455`
+- registered fallback loopback port: `1457`
+- callback path: `/auth/callback`
+- token endpoint: `/oauth/token`
+- revoke endpoint: `/oauth/revoke`
+- access-token proactive refresh window: 5 minutes
+- fallback periodic refresh interval: 8 days
+- refresh-token error classification for expired, reused, and invalidated refresh tokens
+- Device Code polling timeout: 15 minutes
+
+Do not impersonate the Codex CLI user agent or originator. Use the extension's own identity, for example `originator=codex-for-copilot`.
+
+## Current repository state
+
+The repository already contains a partial credential subsystem:
+
+- `src/auth/codexAuthManager.ts`
+- `src/auth/codexAuthRequest.ts`
+- `src/auth/codexAuthJsonImporter.ts`
+- `src/auth/codexAuthLock.ts`
+- `src/auth/codexSecretStore.ts`
+- `src/auth/codexTokenRefresh.ts`
+- `src/auth/codexJwt.ts`
+- `src/auth/codexAuthTypes.ts`
+
+Existing capabilities include:
+
+- importing a ChatGPT-style Codex `auth.json`;
+- persisting a normalized token bundle in `SecretStorage`;
+- proactive refresh near JWT expiry;
+- an 8-day fallback refresh interval;
+- a file-based cross-window refresh lock;
+- one retry after HTTP 401 in `codexFetch`;
+- an unimplemented Device Code command placeholder.
+
+The implementation must extend and simplify this subsystem rather than add a second independent authentication stack.
+
+## Known gaps to close
+
+1. There is no native OAuth login implementation.
+2. The main Responses HTTP and WebSocket paths use an API-key snapshot when the OpenAI client is created and do not consistently participate in token refresh and 401 recovery.
+3. The current refresh error classification treats every HTTP 400 as permanent.
+4. Imported Codex CLI refresh tokens can be copied into extension storage and then rotated independently by multiple clients.
+5. Sign-out only removes local credentials and does not attempt OAuth revocation.
+6. Authentication changes do not provide one centralized lifecycle event that invalidates model caches and authenticated WebSocket sessions.
+7. The current lock can wait indefinitely and does not explicitly protect lock ownership during stale-lock cleanup.
+
+## Design principles
+
+### Single source of truth
+
+`CodexAuthManager` must be the only component that resolves, refreshes, replaces, or clears ChatGPT OAuth credentials.
+
+Callers must request a credential snapshot from the manager instead of caching access tokens independently.
+
+### Explicit credential ownership
+
+Distinguish extension-owned OAuth credentials from legacy credentials discovered from Codex CLI.
+
+- `extensionOAuth`: created by this extension; refresh and revoke are allowed.
+- `legacyCodexFile`: read from `~/.codex/auth.json`; read-only; never write, rotate, revoke, or copy its refresh token.
+- `openaiApiKey`: existing API-key flow; not refreshable.
+
+The legacy import command may remain for compatibility, but it must be presented as a legacy snapshot path. It must not create a second owner for a Codex CLI refresh token.
+
+### Safe retries
+
+An authenticated request may be retried at most once after refresh, and only before visible response activity or tool execution has been emitted.
+
+Never replay a request after text, reasoning, or a tool call has been surfaced to VS Code.
+
+### Atomic credential replacement
+
+Refresh-token rotation must replace the complete stored credential record atomically. Never update access, ID, and refresh tokens in separate writes.
+
+### No secret-bearing telemetry
+
+Logs may contain:
+
+- authentication source;
+- state transition;
+- HTTP status;
+- error classification;
+- token expiry timestamp;
+- credential revision hash or presence flags;
+- whether a refresh or retry occurred.
+
+Logs must not contain token values, authorization codes, PKCE data, raw callback query strings, or unredacted auth URLs.
+
+## Proposed credential model
+
+Replace the current unversioned bundle with a versioned discriminated union.
+
+```ts
+export type CodexCredentialRecord =
+  | ExtensionOAuthCredentialRecord
+  | LegacyCodexCredentialRecord;
+
+export interface ExtensionOAuthCredentialRecord {
+  schemaVersion: 2;
+  source: 'extensionOAuth';
+  revision: string;
+  tokens: {
+    idToken: string;
+    accessToken: string;
+    refreshToken: string;
+  };
+  accountId?: string;
+  email?: string;
+  accessTokenExpiresAt?: number;
+  lastRefreshAt: string;
+}
+
+export interface LegacyCodexCredentialRecord {
+  schemaVersion: 2;
+  source: 'legacyCodexFile';
+  revision: string;
+  accessToken: string;
+  accountId?: string;
+  email?: string;
+  accessTokenExpiresAt?: number;
+  loadedAt: string;
+}
+```
+
+Requirements:
+
+- Generate a new random `revision` for every extension-owned login or successful refresh.
+- Store extension-owned OAuth records under one `SecretStorage` key.
+- Resolve `legacyCodexFile` dynamically from disk; do not persist its refresh token.
+- Migrate existing stored bundles conservatively. Treat them as legacy imported credentials and require native sign-in before performing future refresh-token rotation.
+- Keep the existing API-key secret separate.
+
+## Target architecture
+
+### `CodexOAuthCompatibilityProfile`
+
+Add a small immutable module containing upstream-derived OAuth compatibility values:
+
+- issuer;
+- client ID;
+- authorize endpoint;
+- token endpoint;
+- revoke endpoint;
+- loopback ports;
+- callback path;
+- scopes;
+- Device Code endpoint paths;
+- extension originator.
+
+No other file should hard-code these values.
+
+Suggested file:
+
+- `src/auth/codexOAuthCompatibility.ts`
+
+### `CodexOAuthClient`
+
+Own protocol-level HTTP operations:
+
+- build authorization URL;
+- exchange authorization code for tokens;
+- refresh tokens;
+- request Device Code;
+- poll Device Code authorization;
+- revoke token;
+- parse and classify auth service errors;
+- redact sensitive URL/error information.
+
+Suggested file:
+
+- `src/auth/codexOAuthClient.ts`
+
+The class must accept an injectable `fetch` implementation and endpoint profile so tests do not contact production services.
+
+### `CodexLoginCoordinator`
+
+Own user-facing login sessions:
+
+- one active login session per extension host;
+- browser PKCE flow;
+- Device Code fallback;
+- cancellation;
+- progress reporting;
+- login completion and cleanup;
+- state transitions through `CodexAuthManager`.
+
+Suggested files:
+
+- `src/auth/codexLoginCoordinator.ts`
+- `src/auth/codexLoopbackLogin.ts`
+- `src/auth/codexDeviceCodeLogin.ts`
+- `src/auth/codexPkce.ts`
+
+### `CodexAuthManager`
+
+Remain the central session authority and expose:
+
+```ts
+interface CodexCredentialSnapshot {
+  source: 'extensionOAuth' | 'legacyCodexFile' | 'openaiApiKey';
+  accessToken: string;
+  accountId?: string;
+  expiresAt?: number;
+  revision: string;
+  refreshable: boolean;
+}
+
+interface UnauthorizedRecoveryContext {
+  snapshotRevision: string;
+  visibleActivity: boolean;
+  reason: 'http401' | 'websocketUnauthorized';
+}
+
+class CodexAuthManager {
+  readonly onDidChangeAuth: vscode.Event<CodexAuthChangeEvent>;
+
+  getStatus(): Promise<CodexAuthStatus>;
+  getCredentialSnapshot(): Promise<CodexCredentialSnapshot>;
+  signInWithBrowser(): Promise<void>;
+  signInWithDeviceCode(): Promise<void>;
+  refreshIfNeeded(): Promise<CodexCredentialSnapshot>;
+  recoverFromUnauthorized(context: UnauthorizedRecoveryContext): Promise<CodexCredentialSnapshot>;
+  signOut(): Promise<void>;
+}
+```
+
+Exact names may change, but responsibilities must remain centralized.
+
+## Phase 1: credential storage and migration
+
+- [ ] Add the versioned credential types and source ownership.
+- [ ] Replace `CodexSecretStore` with a store that validates schema and performs complete-record writes.
+- [ ] Add migration for the existing `codexForCopilot.codexAuthBundle` secret.
+- [ ] Ensure migrated imported credentials cannot rotate a Codex CLI refresh token.
+- [ ] Update `getApiCredentials` to resolve credentials through `CodexAuthManager` first.
+- [ ] Preserve explicit `secretStorage` API-key selection.
+- [ ] Update configuration descriptions so `codexAuth` means extension-managed ChatGPT login, not only `~/.codex/auth.json`.
+- [ ] Keep a read-only automatic fallback to `~/.codex/auth.json` when configured.
+
+Suggested cleanup:
+
+- rename `CodexSecretStore` to `CodexCredentialStore`;
+- remove token-bundle parsing responsibilities from `secrets.ts`;
+- keep API-key storage and OAuth credential storage clearly separated.
+
+## Phase 2: browser Authorization Code + PKCE login
+
+Implement the primary sign-in flow.
+
+### PKCE
+
+- [ ] Generate a cryptographically random verifier.
+- [ ] Derive an S256 challenge.
+- [ ] Generate a cryptographically random 32-byte state value.
+- [ ] Use base64url encoding without padding.
+- [ ] Keep verifier and state in memory only.
+
+### Loopback server
+
+- [ ] Bind only to `127.0.0.1`.
+- [ ] Prefer port `1455` and fall back to registered port `1457`.
+- [ ] Use redirect URI `http://localhost:{port}/auth/callback` exactly.
+- [ ] Reject every path except the callback, success/cancel paths if used, and a minimal health-independent request set.
+- [ ] Validate OAuth `state` using a timing-safe comparison where practical.
+- [ ] Reject missing code, missing state, state mismatch, or OAuth callback errors.
+- [ ] Close the server after success, failure, cancellation, or timeout.
+- [ ] Add a bounded login timeout.
+- [ ] Ensure a previous stale login server cannot leave the next login hanging.
+
+Use Node's built-in HTTP server unless a dependency is demonstrably necessary.
+
+### Authorization request
+
+Build the authorization URL from the compatibility profile with:
+
+- `response_type=code`;
+- the current upstream client ID;
+- the loopback redirect URI;
+- scopes matching current upstream Codex;
+- `code_challenge`;
+- `code_challenge_method=S256`;
+- `id_token_add_organizations=true`;
+- `codex_cli_simplified_flow=true` when still required upstream;
+- random `state`;
+- `originator=codex-for-copilot`.
+
+Open it with `vscode.env.openExternal`.
+
+### Token exchange
+
+- [ ] POST to `/oauth/token` with `application/x-www-form-urlencoded`.
+- [ ] Send `grant_type=authorization_code`, `code`, `redirect_uri`, `client_id`, and `code_verifier`.
+- [ ] Require non-empty ID, access, and refresh tokens.
+- [ ] Decode identity metadata without treating unverified JWT claims as authorization decisions.
+- [ ] Derive account ID using the same claim precedence as upstream where possible.
+- [ ] Persist only after the complete exchange and validation succeed.
+- [ ] Emit one `signedIn` auth-change event.
+- [ ] Show a simple local success page or redirect, without embedding tokens in the URL.
+
+## Phase 3: Device Code fallback
+
+Implement the current Codex Device Code protocol behind the compatibility profile.
+
+- [ ] Request a user code from `/api/accounts/deviceauth/usercode`.
+- [ ] Display the verification URL and one-time code in a modal/progress UI.
+- [ ] Add actions to copy the code and open the verification page.
+- [ ] Poll `/api/accounts/deviceauth/token` using the server-provided interval.
+- [ ] Stop after 15 minutes.
+- [ ] Respect VS Code cancellation.
+- [ ] Treat expected pending statuses as pending, not failures.
+- [ ] Exchange the returned authorization code through the same token-exchange implementation used by browser PKCE.
+- [ ] Persist through the same `CodexAuthManager` completion path.
+
+Browser PKCE remains the default. Device Code is a fallback for loopback restrictions, remote browser environments, and explicit user choice.
+
+## Phase 4: robust refresh and concurrency
+
+### Proactive refresh
+
+- [ ] Refresh extension-owned OAuth credentials when the access token expires within 5 minutes.
+- [ ] If JWT expiration cannot be parsed, use the 8-day last-refresh fallback.
+- [ ] Do not proactively refresh API keys or legacy Codex file credentials.
+
+### In-process single-flight
+
+- [ ] Store the active refresh promise in `CodexAuthManager`.
+- [ ] Make all concurrent callers await one refresh operation.
+- [ ] Clear the promise in `finally`.
+
+### Cross-window coordination
+
+Improve `CodexAuthLock`:
+
+- [ ] add a bounded acquisition timeout;
+- [ ] support cancellation;
+- [ ] write an owner nonce and acquisition timestamp;
+- [ ] only remove a lock when ownership still matches;
+- [ ] retain stale-lock recovery;
+- [ ] re-read `SecretStorage` after acquiring the lock;
+- [ ] skip network refresh if another window already changed the credential revision.
+
+### Refresh response handling
+
+- [ ] Submit `client_id`, `grant_type=refresh_token`, and the current refresh token.
+- [ ] Atomically persist any returned ID, access, and rotated refresh tokens.
+- [ ] Preserve an existing token only when the successful response legitimately omits that field.
+- [ ] update `lastRefreshAt` and generate a new revision;
+- [ ] emit `tokensRefreshed` only after successful persistence.
+
+### Error classification
+
+Permanent reauthentication errors:
+
+- HTTP 401 from the token endpoint;
+- `refresh_token_expired`;
+- `refresh_token_reused`;
+- `refresh_token_invalidated`;
+- explicit revoked/invalid-grant responses that clearly require reauthentication.
+
+Transient errors:
+
+- network errors;
+- timeouts;
+- HTTP 408, 429, and 5xx;
+- unknown 400 responses unless their structured code is known to be permanent.
+
+Cache a permanent refresh failure only for the exact credential revision that failed. A new login or externally changed credential record must clear that cached failure.
+
+## Phase 5: unified authenticated request pipeline
+
+The final implementation must not rely on a long-lived OAuth access token copied into an OpenAI client at activation time.
+
+### HTTP and SSE
+
+Refactor the custom fetch path so authenticated Codex HTTP requests:
+
+1. obtain a current credential snapshot immediately before sending;
+2. override the `Authorization` header with that snapshot;
+3. set or replace `ChatGPT-Account-ID` from the same snapshot;
+4. retain compression, proxy, timeout, retry, and telemetry behavior;
+5. detect a 401 before exposing the response stream;
+6. request one guarded unauthorized recovery from `CodexAuthManager`;
+7. replay the original request once with the refreshed snapshot;
+8. return the second response without another auth retry.
+
+Avoid layering the SDK's generic automatic retries on top of an unsafe authentication replay. Authentication recovery must have an explicit one-retry budget.
+
+### WebSocket
+
+For Responses WebSocket sessions:
+
+- build each new connection from the latest credential snapshot;
+- include credential revision in the connection scope/key;
+- invalidate all sessions bound to the old revision after login, refresh, account change, or sign-out;
+- recover once from an unauthorized handshake or unauthorized event only before visible activity;
+- close the failed socket before refresh;
+- recreate the OpenAI client and WebSocket with the new snapshot;
+- resend the request once;
+- never retry after text, reasoning, or tool-call activity is visible.
+
+### Existing request surfaces
+
+Route all first-party Codex requests through the same authentication behavior:
+
+- model discovery;
+- account usage and limits;
+- input-token counting;
+- HTTP Responses streaming;
+- WebSocket Responses streaming;
+- preconnection and prewarm;
+- any future Codex backend endpoint.
+
+API-key and third-party endpoint behavior must remain unchanged.
+
+## Phase 6: auth lifecycle integration
+
+Add a centralized event:
+
+```ts
+type CodexAuthChangeReason =
+  | 'signedIn'
+  | 'tokensRefreshed'
+  | 'reauthRequired'
+  | 'signedOut'
+  | 'accountChanged';
+```
+
+On a material credential revision change:
+
+- [ ] dispose reusable Responses WebSockets;
+- [ ] clear managed preconnections and prewarm state;
+- [ ] clear model-discovery caches tied to the old credential;
+- [ ] reset authenticated connection configuration keys;
+- [ ] refresh account usage state;
+- [ ] fire `onDidChangeLanguageModelChatInformation`;
+- [ ] update status UI without exposing secrets.
+
+Do not perform these invalidations repeatedly when only non-material status metadata changes.
+
+## Phase 7: sign-out and revocation
+
+Implement best-effort OAuth revocation for extension-owned credentials.
+
+- [ ] Prefer revoking the refresh token with `token_type_hint=refresh_token` and the OAuth client ID.
+- [ ] Fall back to the access token only when no refresh token is available.
+- [ ] Use the upstream `/oauth/revoke` endpoint.
+- [ ] Apply a bounded timeout, approximately 10 seconds.
+- [ ] Never block local sign-out on a revoke failure.
+- [ ] Always delete local extension-owned credentials.
+- [ ] Clear permanent refresh failures, active login state, WebSocket sessions, model caches, and usage state.
+- [ ] Do not revoke credentials read from `~/.codex/auth.json`.
+
+## Phase 8: VS Code commands and UX
+
+Update the Manage command and command palette.
+
+Recommended order:
+
+1. `Sign in with ChatGPT`
+2. `Sign in with Device Code`
+3. `Show Account Status`
+4. `Refresh Credentials`
+5. `Sign Out`
+6. `Import Codex auth.json (Legacy)`
+7. `Set API Key`
+8. `Clear API Key`
+9. `Refresh Account Limits`
+10. `Open Debug Logs`
+11. `Open Settings`
+
+Behavior:
+
+- When no credentials exist, the main action must be `Sign in with ChatGPT`.
+- Do not tell users to import `auth.json` as the normal path.
+- Show which source is active: ChatGPT OAuth, legacy Codex file, or API key.
+- Show email/account metadata, token expiry, and last refresh time when available.
+- On permanent refresh failure, present `Sign in again` and `Sign out` actions.
+- Avoid repeated modal prompts from concurrent failing requests.
+- Preserve a clear fallback for API-key users.
+
+Update user-facing error messages throughout the provider so they refer to native sign-in rather than requiring `auth.json` import.
+
+## Test plan
+
+Keep protocol logic dependency-injected and testable without real credentials.
+
+### Unit and smoke tests
+
+Add or expand tests for:
+
+- [ ] PKCE verifier/challenge format and deterministic fixture validation;
+- [ ] state generation and mismatch rejection;
+- [ ] authorization URL parameters;
+- [ ] callback missing code/state and OAuth callback errors;
+- [ ] preferred port and fallback port behavior;
+- [ ] login cancellation and timeout cleanup;
+- [ ] token exchange content type and form fields;
+- [ ] Device Code request, pending polling, completion, cancellation, and timeout;
+- [ ] credential schema migration;
+- [ ] no refresh-token persistence for legacy Codex file credentials;
+- [ ] proactive 5-minute refresh;
+- [ ] 8-day fallback refresh;
+- [ ] in-process refresh single-flight;
+- [ ] cross-window refresh revision recheck;
+- [ ] rotated refresh-token atomic persistence;
+- [ ] permanent versus transient refresh error classification;
+- [ ] permanent failure scoped to one credential revision;
+- [ ] HTTP 401 refresh and one replay;
+- [ ] no HTTP replay after visible activity;
+- [ ] WebSocket unauthorized recovery before visible activity;
+- [ ] no WebSocket replay after visible activity;
+- [ ] stale WebSocket invalidation after credential revision changes;
+- [ ] revoke request construction and timeout;
+- [ ] local sign-out after revoke failure;
+- [ ] redaction of auth URL query values and token-like error fields.
+
+Suggested files:
+
+- `test/smokeOAuthPkce.mjs`
+- `test/smokeOAuthCallback.mjs`
+- `test/smokeDeviceCodeAuth.mjs`
+- `test/smokeTokenRefresh.mjs`
+- `test/smokeAuthConcurrency.mjs`
+- `test/smokeAuthHttpRecovery.mjs`
+- `test/smokeAuthWebSocketRecovery.mjs`
+- `test/smokeAuthMigration.mjs`
+- `test/smokeAuthRevoke.mjs`
+
+Integrate them into `npm run test:smoke` or a focused `test:auth` script that is also run by `test:smoke`.
+
+### Extension-host tests
+
+Verify:
+
+- commands are registered;
+- browser login can be cancelled cleanly;
+- SecretStorage round trips the new schema;
+- auth change events invalidate provider state;
+- VS Code reload preserves extension-owned login;
+- UI messages do not include secrets.
+
+### Real-backend validation
+
+Real-backend tests must be opt-in and must not print credentials.
+
+Validate manually or through a local credential-enabled probe:
+
+1. browser sign-in from a clean profile;
+2. Device Code sign-in;
+3. model discovery;
+4. account usage refresh;
+5. HTTP first turn and continuation;
+6. WebSocket fresh and reused turns;
+7. tool-call continuation;
+8. proactive refresh using a controlled near-expiry fixture or test endpoint;
+9. two VS Code windows making concurrent requests;
+10. sign-out followed by verification that old WebSockets are unusable;
+11. sign-in to a different account and confirm all account-bound state is replaced.
+
+Run the complete check, smoke, and compile suites five consecutive times before marking the PR ready.
+
+## Security review checklist
+
+- [ ] OAuth state is mandatory and validated.
+- [ ] PKCE uses S256 and a cryptographically secure verifier.
+- [ ] Callback server binds only to loopback.
+- [ ] Login server has cancellation and timeout cleanup.
+- [ ] No token is ever placed in a success redirect URL.
+- [ ] No token, code, verifier, state, or raw callback query is logged.
+- [ ] Legacy Codex refresh tokens are not copied or rotated.
+- [ ] Refresh-token writes are atomic.
+- [ ] Unauthorized replay is limited to one attempt before visible activity.
+- [ ] Sign-out clears local state even if revocation fails.
+- [ ] Authentication changes invalidate sockets and account-bound caches.
+- [ ] Tests use fake endpoints and fake tokens by default.
+
+## Non-goals
+
+Do not include the following in this PR unless they are strictly required for authentication correctness:
+
+- Agent Identity bootstrap support;
+- Personal Access Token support;
+- enterprise forced-workspace policy UI;
+- changes to the Responses request schema unrelated to authentication;
+- changes to Tool Search behavior;
+- changes to conversation continuation semantics;
+- a new general-purpose OAuth dependency when Node and VS Code primitives are sufficient;
+- writing credentials back to Codex CLI storage.
+
+Leave clear extension points for future workspace restrictions and additional first-party auth modes, but do not expand scope prematurely.
+
+## Suggested commit structure
+
+1. `refactor(auth): version credential ownership and storage`
+2. `feat(auth): add ChatGPT browser PKCE login`
+3. `feat(auth): add device code login fallback`
+4. `fix(auth): align token refresh and concurrency semantics`
+5. `fix(auth): integrate recovery with HTTP and WebSocket transports`
+6. `feat(auth): add revocation and authentication lifecycle UI`
+7. `test(auth): cover OAuth login refresh and recovery`
+
+Keep commits cohesive. Do not create multiple commits with identical descriptions.
+
+## Acceptance criteria
+
+The implementation is complete only when all of the following are true:
+
+- [ ] A user can install the extension and sign in through `Sign in with ChatGPT` without Codex CLI.
+- [ ] Browser PKCE login succeeds on Windows, macOS, and Linux extension hosts.
+- [ ] Device Code login works as an explicit fallback.
+- [ ] Extension-owned tokens survive VS Code restart through `SecretStorage`.
+- [ ] Access tokens refresh automatically before expiry.
+- [ ] Concurrent requests and multiple VS Code windows do not reuse or double-rotate a refresh token.
+- [ ] Model discovery, account usage, HTTP Responses, and WebSocket Responses all use the current credential revision.
+- [ ] One pre-output unauthorized failure can refresh and retry safely.
+- [ ] No request is replayed after visible output or tool activity.
+- [ ] Credential changes close old authenticated WebSockets and clear account-bound caches.
+- [ ] Permanent refresh failure produces a clear sign-in-again path without repeated network attempts.
+- [ ] Sign-out attempts revocation and always removes local extension-owned credentials.
+- [ ] Legacy Codex file credentials remain read-only and are never modified or revoked.
+- [ ] API-key and non-Codex endpoint behavior remains compatible.
+- [ ] `npm run check`, all auth/smoke tests, and `npm run compile` pass five consecutive times.
+- [ ] No secret appears in logs, test output, PR descriptions, or committed fixtures.

--- a/package.json
+++ b/package.json
@@ -85,6 +85,10 @@
         "title": "Codex: Refresh Account Limits"
       },
       {
+        "command": "codexForCopilot.auth.signInWithChatGPT",
+        "title": "Codex for Copilot: Sign in with ChatGPT"
+      },
+      {
         "command": "codexForCopilot.auth.importAuthJson",
         "title": "Codex for Copilot: Import Codex auth.json"
       },
@@ -126,8 +130,8 @@
             "secretStorage"
           ],
           "enumDescriptions": [
-            "Prefer ~/.codex/auth.json when present, then fall back to the API key saved in VS Code SecretStorage.",
-            "Only use credentials from ~/.codex/auth.json.",
+            "Prefer ChatGPT sign-in, then a read-only ~/.codex/auth.json fallback, then the API key saved in VS Code SecretStorage.",
+            "Only use ChatGPT sign-in or the read-only ~/.codex/auth.json fallback.",
             "Only use the API key saved with 'Codex: Set API Key'."
           ],
           "description": "Select which credential source the provider uses."

--- a/package.json
+++ b/package.json
@@ -52,6 +52,15 @@
     "typescript": "^5.9.2"
   },
   "contributes": {
+    "authentication": [
+      {
+        "id": "codex-for-copilot",
+        "label": "Codex for Copilot",
+        "authorizationServerGlobs": [
+          "https://auth.openai.com/*"
+        ]
+      }
+    ],
     "languageModelChatProviders": [
       {
         "vendor": "codex-for-copilot",

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -11,6 +11,7 @@
 - `responsesClient.ts`: shared request builder and the HTTP/WebSocket transport facade for Responses streaming.
 - `convertMessages.ts`: conversion from VS Code chat messages into Responses input items.
 - `responseBranchStore.ts`: in-memory branch reuse cache keyed by normalized request envelope and transcript prefix.
+- `auth/codexAuthenticationProvider.ts`: bridges saved ChatGPT OAuth credentials into VS Code's Authentication session registry.
 - `codexWebSocketSession.ts`: serializes managed WebSocket streams and preserves safe continuation state.
 - `models.ts`: upstream model discovery and provider model shaping.
 - `codexModelCache.ts`: bounded stale-while-revalidate cache for discovered provider models.
@@ -22,6 +23,9 @@
 
 - Keep provider-visible callback semantics transport-agnostic: HTTP and WebSocket must report the same deltas and terminal events.
 - Keep ChatGPT Codex compatibility logic centralized in `responsesClient.ts`, `config.ts`, and `secrets.ts`; do not duplicate header or base URL normalization across call sites.
+- Native ChatGPT OAuth credentials must be exposed through the `codex-for-copilot` VS Code AuthenticationProvider and emit added, changed, or removed session events when credential state changes.
+- The loopback OAuth URL uses `localhost` but follows the upstream registered flow by binding `127.0.0.1`; callback responses must close browser connections, and server cleanup must never block credential persistence.
+- Keep the authorization endpoint and scopes synchronized with `openai/codex` `codex-rs/login/src/server.rs`; the current endpoint is `/oauth/authorize`, not the legacy `/authorize` path.
 - Keep Responses tool conversion and request-field shaping in `codexRequestBuilder.ts`; transport code consumes its shared request output rather than maintaining a second conversion path.
 - WebSocket requests must send `response.create` payloads without the HTTP-only `stream` field.
 - When `transport` is `auto`, only fall back to HTTP for transport availability failures, not for successful in-band model responses.

--- a/src/auth/codexAuthLock.ts
+++ b/src/auth/codexAuthLock.ts
@@ -1,62 +1,23 @@
-import { open } from 'node:fs/promises';
+import { open, readFile } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
 import * as vscode from 'vscode';
-
-const STALE_LOCK_MS = 60_000;
-const RETRY_DELAY_MS = 150;
-
+const STALE_LOCK_MS = 60_000; const ACQUIRE_TIMEOUT_MS = 15_000; const RETRY_DELAY_MS = 150;
 export class CodexAuthLock {
   constructor(private readonly lockUri: vscode.Uri) {}
-
-  async withLock<T>(fn: () => Promise<T>): Promise<T> {
-    await this.acquire();
-    try {
-      return await fn();
-    } finally {
-      try {
-        await vscode.workspace.fs.delete(this.lockUri);
-      } catch {
-        // Best effort cleanup only.
-      }
-    }
+  async withLock<T>(fn: () => Promise<T>, token?: vscode.CancellationToken): Promise<T> {
+    const owner = await this.acquire(token); try { return await fn(); } finally { await this.release(owner); }
   }
-
-  private async acquire(): Promise<void> {
-    while (true) {
-      if (await this.tryCreateLock()) {
-        return;
-      }
-
-      if (await this.replaceIfStale()) {
-        continue;
-      }
-      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+  private async acquire(token?: vscode.CancellationToken): Promise<string> {
+    const owner = randomBytes(16).toString('hex'); const deadline = Date.now() + ACQUIRE_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      if (token?.isCancellationRequested) throw new Error('Credential refresh was cancelled.');
+      if (await this.tryCreateLock(owner)) return owner;
+      await this.replaceIfStale(); await delay(RETRY_DELAY_MS);
     }
+    throw new Error('Timed out waiting for another VS Code window to refresh credentials.');
   }
-
-  private async tryCreateLock(): Promise<boolean> {
-    try {
-      const handle = await open(this.lockUri.fsPath, 'wx');
-      try {
-        await handle.writeFile(String(Date.now()), 'utf8');
-      } finally {
-        await handle.close();
-      }
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private async replaceIfStale(): Promise<boolean> {
-    try {
-      const stat = await vscode.workspace.fs.stat(this.lockUri);
-      if (Date.now() - stat.mtime <= STALE_LOCK_MS) {
-        return false;
-      }
-      await vscode.workspace.fs.delete(this.lockUri);
-      return true;
-    } catch {
-      return false;
-    }
-  }
+  private async tryCreateLock(owner: string): Promise<boolean> { try { const handle = await open(this.lockUri.fsPath, 'wx'); try { await handle.writeFile(JSON.stringify({ owner, createdAt: Date.now() }), 'utf8'); } finally { await handle.close(); } return true; } catch { return false; } }
+  private async replaceIfStale(): Promise<void> { try { const stat = await vscode.workspace.fs.stat(this.lockUri); if (Date.now() - stat.mtime > STALE_LOCK_MS) await vscode.workspace.fs.delete(this.lockUri); } catch { /* raced with another owner */ } }
+  private async release(owner: string): Promise<void> { try { const raw = await readFile(this.lockUri.fsPath, 'utf8'); if (JSON.parse(raw).owner === owner) await vscode.workspace.fs.delete(this.lockUri); } catch { /* best effort cleanup */ } }
 }
+function delay(ms: number): Promise<void> { return new Promise((resolve) => setTimeout(resolve, ms)); }

--- a/src/auth/codexAuthManager.ts
+++ b/src/auth/codexAuthManager.ts
@@ -2,132 +2,44 @@ import * as vscode from 'vscode';
 import { parseCodexAuthJson } from './codexAuthJsonImporter';
 import { CodexAuthLock } from './codexAuthLock';
 import { getJwtExpiration, isJwtExpiringSoon, decodeJwtPayload } from './codexJwt';
-import { CodexSecretStore } from './codexSecretStore';
-import { ACCESS_TOKEN_REFRESH_WINDOW_MS, PERIODIC_REFRESH_INTERVAL_MS, refreshCodexTokens } from './codexTokenRefresh';
-import { AuthRequiredError, CodexAuthBundle, CodexAuthStatus, ReauthRequiredError, TokenRefreshError } from './codexAuthTypes';
+import { CodexSecretStore, randomRevision } from './codexSecretStore';
+import { ACCESS_TOKEN_REFRESH_WINDOW_MS, PERIODIC_REFRESH_INTERVAL_MS } from './codexTokenRefresh';
+import { CodexOAuthClient, type OAuthTokens } from './codexOAuthClient';
+import { signInWithLoopback } from './codexLoopbackLogin';
+import { signInWithDeviceCode } from './codexDeviceCodeLogin';
+import { AuthRequiredError, type CodexAuthChangeEvent, type CodexAuthStatus, type CodexCredentialRecord, type CodexCredentialSnapshot, type ExtensionOAuthCredentialRecord, ReauthRequiredError, TokenRefreshError } from './codexAuthTypes';
 
-export class CodexAuthManager {
-  constructor(
-    private readonly store: CodexSecretStore,
-    private readonly lock: CodexAuthLock
-  ) {}
-
-  async getStatus(): Promise<CodexAuthStatus> {
-    const bundle = await this.store.getAuthBundle();
-    if (!bundle) {
-      return { authenticated: false };
-    }
-
-    const idPayload = safeDecode(bundle.tokens.id_token);
-    return {
-      authenticated: true,
-      email: typeof idPayload.email === 'string' ? idPayload.email : undefined,
-      accountId: bundle.tokens.account_id,
-      accessTokenExpiresAt: getJwtExpiration(bundle.tokens.access_token),
-      lastRefresh: bundle.last_refresh
-    };
+export class CodexAuthManager implements vscode.Disposable {
+  private refreshPromise: Promise<CodexCredentialSnapshot> | undefined;
+  private permanentFailureRevision: string | undefined;
+  private readonly changes = new vscode.EventEmitter<CodexAuthChangeEvent>();
+  readonly onDidChangeAuth = this.changes.event;
+  constructor(private readonly store: CodexSecretStore, private readonly lock: CodexAuthLock, private readonly oauth = new CodexOAuthClient()) {}
+  dispose(): void { this.changes.dispose(); }
+  async getStatus(): Promise<CodexAuthStatus> { const record = await this.store.getCredential(); if (!record) return { authenticated: false }; const snapshot = snapshotFor(record); return { authenticated: true, source: record.source, email: record.source === 'extensionOAuth' ? record.email : record.email, accountId: snapshot.accountId, accessTokenExpiresAt: snapshot.expiresAt, lastRefresh: record.source === 'extensionOAuth' ? record.lastRefreshAt : record.loadedAt, reauthRequired: this.permanentFailureRevision === snapshot.revision }; }
+  async getCredentialSnapshot(): Promise<CodexCredentialSnapshot> { const record = await this.store.getCredential(); if (!record) throw new AuthRequiredError(); if (record.source === 'extensionOAuth') await this.refreshIfNeeded(); const latest = await this.store.getCredential(); if (!latest) throw new AuthRequiredError(); return snapshotFor(latest); }
+  async getAccessToken(): Promise<string> { return (await this.getCredentialSnapshot()).accessToken; }
+  async importAuthJson(rawJson: string): Promise<void> { const bundle = parseCodexAuthJson(rawJson); const payload = safeDecode(bundle.tokens.id_token); await this.store.setLegacyCredential({ schemaVersion: 2, source: 'legacyCodexFile', revision: randomRevision(), accessToken: bundle.tokens.access_token, accountId: bundle.tokens.account_id, email: stringValue(payload.email), accessTokenExpiresAt: getJwtExpiration(bundle.tokens.access_token), loadedAt: bundle.last_refresh ?? new Date().toISOString() }); this.fire('signedIn'); }
+  async signInWithBrowser(): Promise<void> { const tokens = await signInWithLoopback(this.oauth, (uri) => vscode.env.openExternal(vscode.Uri.parse(uri))); await this.completeSignIn(tokens); }
+  async signInWithDeviceCode(): Promise<void> { await this.completeSignIn(await signInWithDeviceCode(this.oauth)); }
+  async refreshIfNeeded(reason: 'proactive' | 'unauthorized' = 'proactive'): Promise<CodexCredentialSnapshot> {
+    if (!this.refreshPromise) this.refreshPromise = this.doRefresh(reason).finally(() => { this.refreshPromise = undefined; });
+    return this.refreshPromise;
   }
-
-  async importAuthJson(rawJson: string): Promise<void> {
-    await this.store.setAuthBundle(parseCodexAuthJson(rawJson));
+  async refreshAfter401(): Promise<void> { await this.recoverFromUnauthorized({ snapshotRevision: (await this.getCredentialSnapshot()).revision, visibleActivity: false, reason: 'http401' }); }
+  async recoverFromUnauthorized(context: { snapshotRevision: string; visibleActivity: boolean; reason: 'http401' | 'websocketUnauthorized' }): Promise<CodexCredentialSnapshot> {
+    if (context.visibleActivity) throw new ReauthRequiredError('Authentication failed after response activity started.');
+    try { return await this.refreshIfNeeded('unauthorized'); } catch (error) { if (error instanceof TokenRefreshError && error.permanent) { this.permanentFailureRevision = context.snapshotRevision; this.fire('reauthRequired'); throw new ReauthRequiredError(); } throw error; }
   }
-
-  async getAccessToken(): Promise<string> {
-    const existing = await this.store.getAuthBundle();
-    if (!existing) {
-      throw new AuthRequiredError();
-    }
-
-    await this.refreshIfNeeded('proactive');
-    const latest = await this.store.getAuthBundle();
-    if (!latest) {
-      throw new AuthRequiredError();
-    }
-
-    return latest.tokens.access_token;
+  async signOut(): Promise<void> { const record = await this.store.getCredential(); if (record?.source === 'extensionOAuth') await this.oauth.revoke(record.tokens.refresh_token).catch(() => undefined); await this.store.deleteCredential(); this.permanentFailureRevision = undefined; this.fire('signedOut'); }
+  private async doRefresh(reason: 'proactive' | 'unauthorized'): Promise<CodexCredentialSnapshot> {
+    const existing = await this.store.getCredential(); if (!existing) throw new AuthRequiredError(); if (existing.source !== 'extensionOAuth') return snapshotFor(existing); if (reason === 'proactive' && !needsRefresh(existing)) return snapshotFor(existing); if (this.permanentFailureRevision === existing.revision) throw new ReauthRequiredError();
+    return this.lock.withLock(async () => { const latest = await this.store.getCredential(); if (!latest) throw new AuthRequiredError(); if (latest.source !== 'extensionOAuth') return snapshotFor(latest); if (reason === 'proactive' && !needsRefresh(latest)) return snapshotFor(latest); const tokens = await this.oauth.refresh(latest.tokens.refresh_token); const replacement: ExtensionOAuthCredentialRecord = { ...latest, revision: randomRevision(), tokens: { ...latest.tokens, ...tokens }, accessTokenExpiresAt: getJwtExpiration(tokens.access_token ?? latest.tokens.access_token), lastRefreshAt: new Date().toISOString() }; await this.store.setCredential(replacement); this.permanentFailureRevision = undefined; this.fire('tokensRefreshed', replacement.revision); return snapshotFor(replacement); });
   }
-
-  async refreshIfNeeded(reason: 'proactive' | 'unauthorized' = 'proactive'): Promise<void> {
-    const bundle = await this.store.getAuthBundle();
-    if (!bundle) {
-      throw new AuthRequiredError();
-    }
-
-    if (reason !== 'unauthorized' && !needsRefresh(bundle)) {
-      return;
-    }
-
-    await this.lock.withLock(async () => {
-      const latest = await this.store.getAuthBundle();
-      if (!latest) {
-        throw new AuthRequiredError();
-      }
-      if (reason !== 'unauthorized' && !needsRefresh(latest)) {
-        return;
-      }
-      await this.refreshBundle(latest);
-    });
-  }
-
-  async refreshAfter401(): Promise<void> {
-    try {
-      await this.refreshIfNeeded('unauthorized');
-    } catch (error) {
-      if (error instanceof TokenRefreshError && error.permanent) {
-        void vscode.window.showErrorMessage('Codex credentials expired or were revoked. Please import auth.json again.', 'Import auth.json', 'Sign out').then((action) => {
-          if (action === 'Import auth.json') {
-            void vscode.commands.executeCommand('codexForCopilot.auth.importAuthJson');
-          } else if (action === 'Sign out') {
-            void vscode.commands.executeCommand('codexForCopilot.auth.signOut');
-          }
-        });
-        throw new ReauthRequiredError();
-      }
-      throw error;
-    }
-  }
-
-  async signOut(): Promise<void> {
-    await this.store.deleteAuthBundle();
-  }
-
-  async signInWithDeviceCode(): Promise<void> {
-    await vscode.window.showInformationMessage('Device Code login is planned but not implemented yet. Please import Codex auth.json for now.');
-  }
-
-  private async refreshBundle(bundle: CodexAuthBundle): Promise<void> {
-    const refreshed = await refreshCodexTokens(bundle.tokens.refresh_token);
-    await this.store.setAuthBundle({
-      ...bundle,
-      tokens: {
-        ...bundle.tokens,
-        ...(refreshed.id_token ? { id_token: refreshed.id_token } : {}),
-        ...(refreshed.access_token ? { access_token: refreshed.access_token } : {}),
-        ...(refreshed.refresh_token ? { refresh_token: refreshed.refresh_token } : {})
-      },
-      last_refresh: new Date().toISOString()
-    });
-  }
+  private async completeSignIn(tokens: OAuthTokens): Promise<void> { const payload = safeDecode(tokens.id_token); const previous = await this.store.getCredential(); const record: ExtensionOAuthCredentialRecord = { schemaVersion: 2, source: 'extensionOAuth', revision: randomRevision(), tokens, email: stringValue(payload.email), accessTokenExpiresAt: getJwtExpiration(tokens.access_token), lastRefreshAt: new Date().toISOString() }; await this.store.setCredential(record); this.permanentFailureRevision = undefined; this.fire(previous ? 'accountChanged' : 'signedIn', record.revision); }
+  private fire(reason: CodexAuthChangeEvent['reason'], revision?: string): void { this.changes.fire({ reason, revision }); }
 }
-
-export function needsRefresh(bundle: CodexAuthBundle): boolean {
-  if (isJwtExpiringSoon(bundle.tokens.access_token, ACCESS_TOKEN_REFRESH_WINDOW_MS)) {
-    return true;
-  }
-
-  if (!bundle.last_refresh) {
-    return true;
-  }
-
-  const lastRefresh = Date.parse(bundle.last_refresh);
-  return !Number.isFinite(lastRefresh) || Date.now() - lastRefresh >= PERIODIC_REFRESH_INTERVAL_MS;
-}
-
-function safeDecode(token: string): Record<string, unknown> {
-  try {
-    const payload = decodeJwtPayload(token);
-    return payload && typeof payload === 'object' && !Array.isArray(payload) ? payload as Record<string, unknown> : {};
-  } catch {
-    return {};
-  }
-}
+export function needsRefresh(record: CodexCredentialRecord | { tokens: { access_token: string }; last_refresh?: string; lastRefreshAt?: string }): boolean { const access = 'tokens' in record ? record.tokens.access_token : record.accessToken; const last = 'lastRefreshAt' in record ? record.lastRefreshAt : ('last_refresh' in record ? record.last_refresh : undefined); return isJwtExpiringSoon(access, ACCESS_TOKEN_REFRESH_WINDOW_MS) || !last || !Number.isFinite(Date.parse(last)) || Date.now() - Date.parse(last) >= PERIODIC_REFRESH_INTERVAL_MS; }
+function snapshotFor(record: CodexCredentialRecord): CodexCredentialSnapshot { return record.source === 'extensionOAuth' ? { source: record.source, accessToken: record.tokens.access_token, accountId: record.tokens.account_id, expiresAt: record.accessTokenExpiresAt ?? getJwtExpiration(record.tokens.access_token), revision: record.revision, refreshable: true } : { source: record.source, accessToken: record.accessToken, accountId: record.accountId, expiresAt: record.accessTokenExpiresAt, revision: record.revision, refreshable: false }; }
+function safeDecode(token: string): Record<string, unknown> { try { const value = decodeJwtPayload(token); return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}; } catch { return {}; } }
+function stringValue(value: unknown): string | undefined { return typeof value === 'string' && value.trim() ? value.trim() : undefined; }

--- a/src/auth/codexAuthManager.ts
+++ b/src/auth/codexAuthManager.ts
@@ -14,13 +14,30 @@ export class CodexAuthManager implements vscode.Disposable {
   private permanentFailureRevision: string | undefined;
   private readonly changes = new vscode.EventEmitter<CodexAuthChangeEvent>();
   readonly onDidChangeAuth = this.changes.event;
-  constructor(private readonly store: CodexSecretStore, private readonly lock: CodexAuthLock, private readonly oauth = new CodexOAuthClient()) {}
+  constructor(
+    private readonly store: CodexSecretStore,
+    private readonly lock: CodexAuthLock,
+    private readonly oauth = new CodexOAuthClient(),
+    private readonly log?: (message: string, details?: Record<string, unknown>) => void
+  ) {}
   dispose(): void { this.changes.dispose(); }
-  async getStatus(): Promise<CodexAuthStatus> { const record = await this.store.getCredential(); if (!record) return { authenticated: false }; const snapshot = snapshotFor(record); return { authenticated: true, source: record.source, email: record.source === 'extensionOAuth' ? record.email : record.email, accountId: snapshot.accountId, accessTokenExpiresAt: snapshot.expiresAt, lastRefresh: record.source === 'extensionOAuth' ? record.lastRefreshAt : record.loadedAt, reauthRequired: this.permanentFailureRevision === snapshot.revision }; }
+  async getStatus(): Promise<CodexAuthStatus> { const record = await this.store.getCredential(); if (!record) return { authenticated: false }; const snapshot = snapshotFor(record); return { authenticated: true, source: record.source, email: record.email, accountId: snapshot.accountId, accessTokenExpiresAt: snapshot.expiresAt, lastRefresh: record.source === 'extensionOAuth' ? record.lastRefreshAt : record.loadedAt, reauthRequired: this.permanentFailureRevision === snapshot.revision }; }
   async getCredentialSnapshot(): Promise<CodexCredentialSnapshot> { const record = await this.store.getCredential(); if (!record) throw new AuthRequiredError(); if (record.source === 'extensionOAuth') await this.refreshIfNeeded(); const latest = await this.store.getCredential(); if (!latest) throw new AuthRequiredError(); return snapshotFor(latest); }
   async getAccessToken(): Promise<string> { return (await this.getCredentialSnapshot()).accessToken; }
   async importAuthJson(rawJson: string): Promise<void> { const bundle = parseCodexAuthJson(rawJson); const payload = safeDecode(bundle.tokens.id_token); await this.store.setLegacyCredential({ schemaVersion: 2, source: 'legacyCodexFile', revision: randomRevision(), accessToken: bundle.tokens.access_token, accountId: bundle.tokens.account_id, email: stringValue(payload.email), accessTokenExpiresAt: getJwtExpiration(bundle.tokens.access_token), loadedAt: bundle.last_refresh ?? new Date().toISOString() }); this.fire('signedIn'); }
-  async signInWithBrowser(): Promise<void> { const tokens = await signInWithLoopback(this.oauth, (uri) => vscode.env.openExternal(vscode.Uri.parse(uri))); await this.completeSignIn(tokens); }
+  async signInWithBrowser(): Promise<void> {
+    this.log?.('ChatGPT sign-in started');
+    await signInWithLoopback(
+      this.oauth,
+      (uri) => vscode.env.openExternal(vscode.Uri.parse(uri)),
+      undefined,
+      (stage, port) => this.log?.('ChatGPT sign-in stage', { stage, port }),
+      async (tokens) => {
+        await this.completeSignIn(tokens);
+        this.log?.('ChatGPT credentials stored');
+      }
+    );
+  }
   async signInWithDeviceCode(): Promise<void> { await this.completeSignIn(await signInWithDeviceCode(this.oauth)); }
   async refreshIfNeeded(reason: 'proactive' | 'unauthorized' = 'proactive'): Promise<CodexCredentialSnapshot> {
     if (!this.refreshPromise) this.refreshPromise = this.doRefresh(reason).finally(() => { this.refreshPromise = undefined; });

--- a/src/auth/codexAuthRequest.ts
+++ b/src/auth/codexAuthRequest.ts
@@ -4,32 +4,44 @@ import { ReauthRequiredError } from './codexAuthTypes';
 export async function codexFetch(
   authManager: CodexAuthManager,
   input: Parameters<typeof fetch>[0],
-  init: RequestInit = {}
+  init: RequestInit = {},
+  performFetch: typeof fetch = fetch
 ): Promise<Response> {
-  const accessToken = await authManager.getAccessToken();
-  const first = await fetch(input, withAuthorization(init, accessToken));
+  const compatibleManager = authManager as CodexAuthManager & { getAccessToken?: () => Promise<string>; refreshAfter401?: () => Promise<void> };
+  const snapshot = typeof compatibleManager.getCredentialSnapshot === 'function'
+    ? await compatibleManager.getCredentialSnapshot()
+    : { accessToken: await compatibleManager.getAccessToken!(), revision: 'legacy' };
+  const first = await performFetch(input, withAuthorization(init, snapshot));
   if (first.status !== 401) {
     return first;
   }
 
-  await authManager.refreshAfter401();
-  const retryToken = await authManager.getAccessToken();
-  const retry = await fetch(input, withAuthorization(init, retryToken));
+  await first.body?.cancel().catch(() => undefined);
+  const retrySnapshot = typeof compatibleManager.recoverFromUnauthorized === 'function'
+    ? await compatibleManager.recoverFromUnauthorized({ snapshotRevision: snapshot.revision, visibleActivity: false, reason: 'http401' })
+    : (await compatibleManager.refreshAfter401!(), { accessToken: await compatibleManager.getAccessToken!() });
+  const retry = await performFetch(input, withAuthorization(init, retrySnapshot));
   if (retry.status === 401) {
     throw new ReauthRequiredError();
   }
   return retry;
 }
 
-function withAuthorization(init: RequestInit, token: string): RequestInit {
+function withAuthorization(init: RequestInit, snapshot: { accessToken: string; accountId?: string }): RequestInit {
+  const headers = headersToRecord(init.headers);
+  deleteHeader(headers, 'Authorization');
+  deleteHeader(headers, 'ChatGPT-Account-ID');
   return {
     ...init,
     headers: {
-      ...headersToRecord(init.headers),
-      Authorization: `Bearer ${token}`
+      ...headers,
+      Authorization: `Bearer ${snapshot.accessToken}`,
+      ...(snapshot.accountId?.trim() ? { 'ChatGPT-Account-ID': snapshot.accountId.trim() } : {})
     }
   };
 }
+
+function deleteHeader(headers: Record<string, string>, target: string): void { for (const name of Object.keys(headers)) if (name.toLowerCase() === target.toLowerCase()) delete headers[name]; }
 
 function headersToRecord(headers: RequestInit['headers'] | undefined): Record<string, string> {
   if (!headers) {

--- a/src/auth/codexAuthTypes.ts
+++ b/src/auth/codexAuthTypes.ts
@@ -1,4 +1,4 @@
-export type CodexAuthMode = 'chatgpt';
+export type CodexCredentialSource = 'extensionOAuth' | 'legacyCodexFile';
 
 export interface CodexTokenData {
   id_token: string;
@@ -7,14 +7,48 @@ export interface CodexTokenData {
   account_id?: string;
 }
 
+// Kept solely for parsing older Codex auth.json files.
 export interface CodexAuthBundle {
-  auth_mode: CodexAuthMode;
+  auth_mode: 'chatgpt';
   tokens: CodexTokenData;
   last_refresh?: string;
 }
 
+export interface ExtensionOAuthCredentialRecord {
+  schemaVersion: 2;
+  source: 'extensionOAuth';
+  revision: string;
+  tokens: CodexTokenData;
+  email?: string;
+  accessTokenExpiresAt?: number;
+  lastRefreshAt: string;
+}
+
+export interface LegacyCodexCredentialRecord {
+  schemaVersion: 2;
+  source: 'legacyCodexFile';
+  revision: string;
+  accessToken: string;
+  accountId?: string;
+  email?: string;
+  accessTokenExpiresAt?: number;
+  loadedAt: string;
+}
+
+export type CodexCredentialRecord = ExtensionOAuthCredentialRecord | LegacyCodexCredentialRecord;
+
+export interface CodexCredentialSnapshot {
+  source: CodexCredentialSource | 'openaiApiKey';
+  accessToken: string;
+  accountId?: string;
+  expiresAt?: number;
+  revision: string;
+  refreshable: boolean;
+}
+
 export interface CodexAuthStatus {
   authenticated: boolean;
+  source?: CodexCredentialSource;
   email?: string;
   accountId?: string;
   accessTokenExpiresAt?: number;
@@ -22,42 +56,20 @@ export interface CodexAuthStatus {
   reauthRequired?: boolean;
 }
 
-export type CodexAuthState =
-  | 'unauthenticated'
-  | 'authenticated'
-  | 'refreshing'
-  | 'reauthRequired'
-  | 'signingIn';
+export type CodexAuthChangeReason = 'signedIn' | 'tokensRefreshed' | 'reauthRequired' | 'signedOut' | 'accountChanged';
+export interface CodexAuthChangeEvent { reason: CodexAuthChangeReason; revision?: string; }
 
 export class AuthRequiredError extends Error {
-  constructor(message = 'Codex credentials are required.') {
-    super(message);
-    this.name = 'AuthRequiredError';
-  }
+  constructor(message = 'Sign in with ChatGPT or configure an API key.') { super(message); this.name = 'AuthRequiredError'; }
 }
-
 export class ReauthRequiredError extends Error {
-  constructor(message = 'Codex credentials expired. Please import auth.json again.') {
-    super(message);
-    this.name = 'ReauthRequiredError';
-  }
+  constructor(message = 'ChatGPT credentials expired or were revoked. Please sign in again.') { super(message); this.name = 'ReauthRequiredError'; }
 }
-
 export class InvalidAuthJsonError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'InvalidAuthJsonError';
-  }
+  constructor(message: string) { super(message); this.name = 'InvalidAuthJsonError'; }
 }
-
 export class TokenRefreshError extends Error {
-  constructor(
-    message: string,
-    public readonly permanent: boolean,
-    public readonly status?: number,
-    public readonly errorCode?: string
-  ) {
-    super(message);
-    this.name = 'TokenRefreshError';
+  constructor(message: string, public readonly permanent: boolean, public readonly status?: number, public readonly errorCode?: string) {
+    super(message); this.name = 'TokenRefreshError';
   }
 }

--- a/src/auth/codexAuthenticationProvider.ts
+++ b/src/auth/codexAuthenticationProvider.ts
@@ -1,0 +1,107 @@
+import * as vscode from 'vscode';
+import { CODEX_OAUTH } from './codexOAuthCompatibility';
+import { CodexAuthManager } from './codexAuthManager';
+import type { CodexAuthChangeEvent, CodexAuthStatus, CodexCredentialSnapshot } from './codexAuthTypes';
+
+export const CODEX_AUTHENTICATION_PROVIDER_ID = 'codex-for-copilot';
+
+const supportedScopes = CODEX_OAUTH.scopes.split(' ');
+
+export class CodexAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
+  private readonly sessionChanges = new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
+  private readonly authChangeSubscription: vscode.Disposable;
+  private currentSession: vscode.AuthenticationSession | undefined;
+
+  readonly onDidChangeSessions = this.sessionChanges.event;
+
+  constructor(private readonly authManager: CodexAuthManager) {
+    this.authChangeSubscription = authManager.onDidChangeAuth((event) => {
+      void this.handleAuthenticationChange(event);
+    });
+  }
+
+  async getSessions(scopes: readonly string[] | undefined, _options: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession[]> {
+    if (scopes && !supportsRequestedScopes(scopes)) {
+      return [];
+    }
+    const session = await this.getCurrentSession();
+    this.currentSession = session;
+    return session ? [session] : [];
+  }
+
+  async createSession(scopes: readonly string[], _options: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession> {
+    if (!supportsRequestedScopes(scopes)) {
+      throw new Error('Codex for Copilot does not support the requested authentication scopes.');
+    }
+    await this.authManager.signInWithBrowser();
+    const session = await this.getCurrentSession();
+    if (!session) {
+      throw new Error('ChatGPT sign-in completed without creating a credential session.');
+    }
+    this.currentSession = session;
+    return session;
+  }
+
+  async removeSession(sessionId: string): Promise<void> {
+    const session = await this.getCurrentSession();
+    if (!session || session.id !== sessionId) {
+      throw new Error('The requested Codex for Copilot authentication session does not exist.');
+    }
+    await this.authManager.signOut();
+  }
+
+  dispose(): void {
+    this.authChangeSubscription.dispose();
+    this.sessionChanges.dispose();
+  }
+
+  private async handleAuthenticationChange(event: CodexAuthChangeEvent): Promise<void> {
+    const previousSession = this.currentSession;
+    const nextSession = event.reason === 'signedOut' || event.reason === 'reauthRequired'
+      ? undefined
+      : await this.getCurrentSession();
+    this.currentSession = nextSession;
+
+    if (!previousSession && nextSession) {
+      this.sessionChanges.fire({ added: [nextSession], removed: [], changed: [] });
+    } else if (previousSession && !nextSession) {
+      this.sessionChanges.fire({ added: [], removed: [previousSession], changed: [] });
+    } else if (previousSession && nextSession) {
+      if (previousSession.id === nextSession.id) {
+        this.sessionChanges.fire({ added: [], removed: [], changed: [nextSession] });
+      } else {
+        this.sessionChanges.fire({ added: [nextSession], removed: [previousSession], changed: [] });
+      }
+    }
+  }
+
+  private async getCurrentSession(): Promise<vscode.AuthenticationSession | undefined> {
+    const status = await this.authManager.getStatus();
+    if (!status.authenticated) {
+      return undefined;
+    }
+    try {
+      const snapshot = await this.authManager.getCredentialSnapshot();
+      return toAuthenticationSession(status, snapshot);
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+function supportsRequestedScopes(scopes: readonly string[]): boolean {
+  return scopes.every((scope) => supportedScopes.includes(scope));
+}
+
+function toAuthenticationSession(status: CodexAuthStatus, snapshot: CodexCredentialSnapshot): vscode.AuthenticationSession {
+  const accountId = snapshot.accountId ?? status.email ?? snapshot.source;
+  return {
+    id: `${snapshot.source}:${accountId}`,
+    accessToken: snapshot.accessToken,
+    account: {
+      id: accountId,
+      label: status.email ?? 'ChatGPT'
+    },
+    scopes: supportedScopes
+  };
+}

--- a/src/auth/codexDeviceCodeLogin.ts
+++ b/src/auth/codexDeviceCodeLogin.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode';
+import type { CodexOAuthClient, OAuthTokens } from './codexOAuthClient';
+
+export async function signInWithDeviceCode(client: CodexOAuthClient): Promise<OAuthTokens> {
+  const device = await client.requestDeviceCode();
+  return vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: `ChatGPT code: ${device.user_code}`, cancellable: true }, async (_progress, token) => {
+    const choice = await vscode.window.showInformationMessage(`Open ${device.verification_uri} and enter code ${device.user_code}.`, 'Open verification page', 'Copy code');
+    if (choice === 'Open verification page') await vscode.env.openExternal(vscode.Uri.parse(device.verification_uri));
+    if (choice === 'Copy code') await vscode.env.clipboard.writeText(device.user_code);
+    const deadline = Date.now() + 15 * 60_000; const interval = Math.max(1, device.interval ?? 5) * 1000;
+    while (!token.isCancellationRequested && Date.now() < deadline) { const result = await client.pollDeviceCode(device.device_auth_id, device.user_code); if (result.authorization_code && result.code_verifier) return client.exchangeAuthorizationCode(result.authorization_code, 'https://auth.openai.com/deviceauth/callback', result.code_verifier); await delay(interval); }
+    throw new Error(token.isCancellationRequested ? 'Device Code sign-in was cancelled.' : 'Device Code sign-in timed out.');
+  });
+}
+function delay(ms: number): Promise<void> { return new Promise((resolve) => setTimeout(resolve, ms)); }

--- a/src/auth/codexLoopbackLogin.ts
+++ b/src/auth/codexLoopbackLogin.ts
@@ -3,23 +3,75 @@ import { CODEX_OAUTH, type CodexOAuthCompatibilityProfile } from './codexOAuthCo
 import { generateCodexPkce, statesMatch } from './codexPkce';
 import type { CodexOAuthClient, OAuthTokens } from './codexOAuthClient';
 
-export async function signInWithLoopback(client: CodexOAuthClient, openExternal: (uri: string) => Thenable<boolean>, profile: CodexOAuthCompatibilityProfile = CODEX_OAUTH): Promise<OAuthTokens> {
+export type LoopbackSignInStage = 'listening' | 'browserOpened' | 'callbackReceived' | 'exchangingCode' | 'completed';
+
+export async function signInWithLoopback(
+  client: CodexOAuthClient,
+  openExternal: (uri: string) => Thenable<boolean>,
+  profile: CodexOAuthCompatibilityProfile = CODEX_OAUTH,
+  onStage?: (stage: LoopbackSignInStage, port: number) => void,
+  persistTokens?: (tokens: OAuthTokens) => Promise<void>
+): Promise<OAuthTokens> {
   const { server, port } = await bindLoopback(profile.loopbackPorts);
+  onStage?.('listening', port);
   const redirectUri = `http://localhost:${port}${profile.callbackPath}`;
   const pkce = generateCodexPkce();
-  const result = new Promise<{ code: string }>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error('ChatGPT sign-in timed out.')), 5 * 60_000); timeout.unref?.();
+  let timeout: NodeJS.Timeout | undefined;
+  const result = new Promise<{ code: string; response: import('node:http').ServerResponse }>((resolve, reject) => {
+    timeout = setTimeout(() => reject(new Error('ChatGPT sign-in timed out.')), 5 * 60_000);
+    timeout.unref?.();
     server.on('request', (request, response) => {
       const url = new URL(request.url ?? '/', redirectUri);
       if (url.pathname !== profile.callbackPath) { response.writeHead(404).end(); return; }
+      onStage?.('callbackReceived', port);
       const code = url.searchParams.get('code'); const state = url.searchParams.get('state'); const oauthError = url.searchParams.get('error');
-      if (oauthError || !code || !statesMatch(pkce.state, state ?? undefined)) { response.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' }).end('<h1>Sign-in could not be verified.</h1>You can close this tab.'); clearTimeout(timeout); reject(new Error('ChatGPT sign-in callback was rejected.')); return; }
-      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' }).end('<h1>Signed in to Codex for Copilot.</h1>You can close this tab and return to VS Code.'); clearTimeout(timeout); resolve({ code });
+      if (oauthError || !code || !statesMatch(pkce.state, state ?? undefined)) { response.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8', Connection: 'close' }).end('<h1>Sign-in could not be verified.</h1>You can close this tab.'); clearTimeout(timeout); reject(new Error('ChatGPT sign-in callback was rejected.')); return; }
+      clearTimeout(timeout);
+      resolve({ code, response });
     });
   });
-  try { await openExternal(client.createAuthorizationUrl(redirectUri, pkce.verifier, pkce.challenge, pkce.state)); const { code } = await result; return await client.exchangeAuthorizationCode(code, redirectUri, pkce.verifier); } finally { await new Promise<void>((resolve) => server.close(() => resolve())); }
+  try {
+    const opened = await openExternal(client.createAuthorizationUrl(redirectUri, pkce.verifier, pkce.challenge, pkce.state));
+    if (!opened) throw new Error('VS Code could not open the ChatGPT sign-in page.');
+    onStage?.('browserOpened', port);
+    const { code, response } = await result;
+    onStage?.('exchangingCode', port);
+    try {
+      const tokens = await client.exchangeAuthorizationCode(code, redirectUri, pkce.verifier);
+      await persistTokens?.(tokens);
+      onStage?.('completed', port);
+      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', Connection: 'close' }).end('<h1>Signed in to Codex for Copilot.</h1>You can close this tab and return to VS Code.');
+      return tokens;
+    } catch (error) {
+      response.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8', Connection: 'close' }).end('<h1>Sign-in could not be completed.</h1>Return to VS Code for details.');
+      throw error;
+    }
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    closeLoopbackServer(server);
+  }
 }
 async function bindLoopback(ports: readonly number[]): Promise<{ server: Server; port: number }> {
-  for (const port of ports) { const server = createServer(); try { await new Promise<void>((resolve, reject) => { server.once('error', reject); server.listen(port, '127.0.0.1', () => { server.off('error', reject); resolve(); }); }); return { server, port }; } catch { server.close(); } }
+  for (const port of ports) {
+    const server = createServer();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(port, '127.0.0.1', () => {
+          server.off('error', reject);
+          resolve();
+        });
+      });
+      return { server, port };
+    } catch {
+      server.close();
+    }
+  }
   throw new Error('ChatGPT sign-in could not bind a local callback port. Use Device Code sign-in instead.');
+}
+
+function closeLoopbackServer(server: Server): void {
+  server.close();
+  server.closeIdleConnections?.();
+  server.closeAllConnections?.();
 }

--- a/src/auth/codexLoopbackLogin.ts
+++ b/src/auth/codexLoopbackLogin.ts
@@ -1,0 +1,25 @@
+import { createServer, type Server } from 'node:http';
+import { CODEX_OAUTH, type CodexOAuthCompatibilityProfile } from './codexOAuthCompatibility';
+import { generateCodexPkce, statesMatch } from './codexPkce';
+import type { CodexOAuthClient, OAuthTokens } from './codexOAuthClient';
+
+export async function signInWithLoopback(client: CodexOAuthClient, openExternal: (uri: string) => Thenable<boolean>, profile: CodexOAuthCompatibilityProfile = CODEX_OAUTH): Promise<OAuthTokens> {
+  const { server, port } = await bindLoopback(profile.loopbackPorts);
+  const redirectUri = `http://localhost:${port}${profile.callbackPath}`;
+  const pkce = generateCodexPkce();
+  const result = new Promise<{ code: string }>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('ChatGPT sign-in timed out.')), 5 * 60_000); timeout.unref?.();
+    server.on('request', (request, response) => {
+      const url = new URL(request.url ?? '/', redirectUri);
+      if (url.pathname !== profile.callbackPath) { response.writeHead(404).end(); return; }
+      const code = url.searchParams.get('code'); const state = url.searchParams.get('state'); const oauthError = url.searchParams.get('error');
+      if (oauthError || !code || !statesMatch(pkce.state, state ?? undefined)) { response.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' }).end('<h1>Sign-in could not be verified.</h1>You can close this tab.'); clearTimeout(timeout); reject(new Error('ChatGPT sign-in callback was rejected.')); return; }
+      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' }).end('<h1>Signed in to Codex for Copilot.</h1>You can close this tab and return to VS Code.'); clearTimeout(timeout); resolve({ code });
+    });
+  });
+  try { await openExternal(client.createAuthorizationUrl(redirectUri, pkce.verifier, pkce.challenge, pkce.state)); const { code } = await result; return await client.exchangeAuthorizationCode(code, redirectUri, pkce.verifier); } finally { await new Promise<void>((resolve) => server.close(() => resolve())); }
+}
+async function bindLoopback(ports: readonly number[]): Promise<{ server: Server; port: number }> {
+  for (const port of ports) { const server = createServer(); try { await new Promise<void>((resolve, reject) => { server.once('error', reject); server.listen(port, '127.0.0.1', () => { server.off('error', reject); resolve(); }); }); return { server, port }; } catch { server.close(); } }
+  throw new Error('ChatGPT sign-in could not bind a local callback port. Use Device Code sign-in instead.');
+}

--- a/src/auth/codexOAuthClient.ts
+++ b/src/auth/codexOAuthClient.ts
@@ -1,0 +1,58 @@
+import { CODEX_OAUTH, type CodexOAuthCompatibilityProfile } from './codexOAuthCompatibility';
+import { TokenRefreshError } from './codexAuthTypes';
+
+export interface OAuthTokens { id_token: string; access_token: string; refresh_token: string; account_id?: string; }
+export interface DeviceCodeResponse { device_auth_id: string; user_code: string; verification_uri: string; interval: number; }
+type FetchLike = typeof fetch;
+
+export class CodexOAuthClient {
+  constructor(private readonly request: FetchLike = fetch, private readonly profile: CodexOAuthCompatibilityProfile = CODEX_OAUTH) {}
+  createAuthorizationUrl(redirectUri: string, verifier: string, challenge: string, state: string): string {
+    const url = new URL(this.profile.authorizeUrl);
+    url.search = new URLSearchParams({ response_type: 'code', client_id: this.profile.clientId, redirect_uri: redirectUri, scope: this.profile.scopes, code_challenge: challenge, code_challenge_method: 'S256', state, id_token_add_organizations: 'true', codex_cli_simplified_flow: 'true', originator: 'codex-for-copilot' }).toString();
+    return url.toString();
+  }
+  async exchangeAuthorizationCode(code: string, redirectUri: string, verifier: string): Promise<OAuthTokens> {
+    return this.token({ grant_type: 'authorization_code', code, redirect_uri: redirectUri, code_verifier: verifier, client_id: this.profile.clientId }) as Promise<OAuthTokens>;
+  }
+  async refresh(refreshToken: string): Promise<Partial<OAuthTokens>> {
+    return this.token({ grant_type: 'refresh_token', refresh_token: refreshToken, client_id: this.profile.clientId }, true);
+  }
+  async requestDeviceCode(): Promise<DeviceCodeResponse> {
+    const response = await this.request(this.profile.deviceCodeUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ client_id: this.profile.clientId, originator: 'codex-for-copilot' }) });
+    const body = await jsonObject(response);
+    if (!response.ok || !isString(body.device_auth_id) || !isString(body.user_code)) throw new Error('Could not start Device Code sign-in.');
+    const interval = typeof body.interval === 'number' ? body.interval : Number(body.interval);
+    return { device_auth_id: body.device_auth_id, user_code: body.user_code, verification_uri: `${this.profile.issuer}/codex/device`, interval: Number.isFinite(interval) && interval > 0 ? interval : 5 };
+  }
+  async pollDeviceCode(deviceAuthId: string, userCode: string): Promise<{ authorization_code?: string; code_verifier?: string; pending: boolean }> {
+    const response = await this.request(this.profile.deviceTokenUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ device_auth_id: deviceAuthId, user_code: userCode }) });
+    const body = await jsonObject(response);
+    if (response.ok && isString(body.authorization_code) && isString(body.code_verifier)) return { authorization_code: body.authorization_code, code_verifier: body.code_verifier, pending: false };
+    const code = typeof body.error === 'string' ? body.error : '';
+    if (response.status === 404 || response.status === 428 || /pending|authorization_pending/i.test(code)) return { pending: true };
+    throw new Error('Device Code sign-in was rejected.');
+  }
+  async revoke(token: string): Promise<void> {
+    const controller = new AbortController(); const timeout = setTimeout(() => controller.abort(), 10_000);
+    try { await this.request(this.profile.revokeUrl, { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: new URLSearchParams({ token, token_type_hint: 'refresh_token', client_id: this.profile.clientId }), signal: controller.signal }); } finally { clearTimeout(timeout); }
+  }
+  private async token(values: Record<string, string>, allowPartial = false): Promise<OAuthTokens | Partial<OAuthTokens>> {
+    let response: Response;
+    try { response = await this.request(this.profile.tokenUrl, { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: new URLSearchParams(values) }); }
+    catch { throw new TokenRefreshError('ChatGPT token request failed due to a network error.', false); }
+    const body = await jsonObject(response);
+    if (!response.ok) {
+      const code = typeof body.error === 'string' ? body.error : undefined;
+      const permanent = response.status === 401 || (response.status === 400 && Boolean(code && /^(invalid_grant|refresh_token_(expired|reused|invalidated)|revoked)$/i.test(code)));
+      throw new TokenRefreshError('ChatGPT token request failed.', permanent, response.status, code);
+    }
+    const tokens: Partial<OAuthTokens> = {};
+    for (const key of ['id_token', 'access_token', 'refresh_token'] as const) if (isString(body[key])) tokens[key] = body[key].trim();
+    if (isString(body.account_id)) tokens.account_id = body.account_id.trim();
+    if (!allowPartial && (!tokens.id_token || !tokens.access_token || !tokens.refresh_token)) throw new Error('ChatGPT token response was incomplete.');
+    return tokens as OAuthTokens;
+  }
+}
+async function jsonObject(response: Response): Promise<Record<string, unknown>> { try { const value = await response.json(); return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}; } catch { return {}; } }
+function isString(value: unknown): value is string { return typeof value === 'string' && value.trim().length > 0; }

--- a/src/auth/codexOAuthCompatibility.ts
+++ b/src/auth/codexOAuthCompatibility.ts
@@ -1,0 +1,27 @@
+export interface CodexOAuthCompatibilityProfile {
+  issuer: string;
+  clientId: string;
+  authorizeUrl: string;
+  tokenUrl: string;
+  revokeUrl: string;
+  deviceCodeUrl: string;
+  deviceTokenUrl: string;
+  loopbackPorts: readonly number[];
+  callbackPath: string;
+  scopes: string;
+}
+
+// Isolate values copied from the current public Codex implementation. These are
+// compatibility values, not a new public OAuth contract for this extension.
+export const CODEX_OAUTH: CodexOAuthCompatibilityProfile = {
+  issuer: 'https://auth.openai.com',
+  clientId: 'app_EMoamEEZ73f0CkXaXp7hrann',
+  authorizeUrl: 'https://auth.openai.com/authorize',
+  tokenUrl: 'https://auth.openai.com/oauth/token',
+  revokeUrl: 'https://auth.openai.com/oauth/revoke',
+  deviceCodeUrl: 'https://auth.openai.com/api/accounts/deviceauth/usercode',
+  deviceTokenUrl: 'https://auth.openai.com/api/accounts/deviceauth/token',
+  loopbackPorts: [1455, 1457],
+  callbackPath: '/auth/callback',
+  scopes: 'openid profile email offline_access'
+};

--- a/src/auth/codexOAuthCompatibility.ts
+++ b/src/auth/codexOAuthCompatibility.ts
@@ -16,12 +16,12 @@ export interface CodexOAuthCompatibilityProfile {
 export const CODEX_OAUTH: CodexOAuthCompatibilityProfile = {
   issuer: 'https://auth.openai.com',
   clientId: 'app_EMoamEEZ73f0CkXaXp7hrann',
-  authorizeUrl: 'https://auth.openai.com/authorize',
+  authorizeUrl: 'https://auth.openai.com/oauth/authorize',
   tokenUrl: 'https://auth.openai.com/oauth/token',
   revokeUrl: 'https://auth.openai.com/oauth/revoke',
   deviceCodeUrl: 'https://auth.openai.com/api/accounts/deviceauth/usercode',
   deviceTokenUrl: 'https://auth.openai.com/api/accounts/deviceauth/token',
   loopbackPorts: [1455, 1457],
   callbackPath: '/auth/callback',
-  scopes: 'openid profile email offline_access'
+  scopes: 'openid profile email offline_access api.connectors.read api.connectors.invoke'
 };

--- a/src/auth/codexPkce.ts
+++ b/src/auth/codexPkce.ts
@@ -1,0 +1,14 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+
+export interface CodexPkceCodes { verifier: string; challenge: string; state: string; }
+
+export function generateCodexPkce(): CodexPkceCodes {
+  const verifier = randomBytes(64).toString('base64url');
+  return { verifier, challenge: createHash('sha256').update(verifier).digest('base64url'), state: randomBytes(32).toString('base64url') };
+}
+
+export function statesMatch(expected: string, actual: string | undefined): boolean {
+  if (!actual) return false;
+  const left = Buffer.from(expected); const right = Buffer.from(actual);
+  return left.length === right.length && timingSafeEqual(left, right);
+}

--- a/src/auth/codexSecretStore.ts
+++ b/src/auth/codexSecretStore.ts
@@ -1,29 +1,36 @@
 import * as vscode from 'vscode';
-import type { CodexAuthBundle } from './codexAuthTypes';
+import type { CodexAuthBundle, CodexCredentialRecord, ExtensionOAuthCredentialRecord, LegacyCodexCredentialRecord } from './codexAuthTypes';
 
 export const CODEX_AUTH_SECRET_KEY = 'codexForCopilot.codexAuthBundle';
 
 export class CodexSecretStore {
   constructor(private readonly secrets: vscode.SecretStorage) {}
-
-  async getAuthBundle(): Promise<CodexAuthBundle | undefined> {
+  async getCredential(): Promise<CodexCredentialRecord | undefined> {
     const raw = await this.secrets.get(CODEX_AUTH_SECRET_KEY);
-    if (!raw) {
-      return undefined;
-    }
-
+    if (!raw) return undefined;
     try {
-      return JSON.parse(raw) as CodexAuthBundle;
-    } catch {
-      return undefined;
-    }
+      const value = JSON.parse(raw) as unknown;
+      if (isCredential(value)) return value;
+      const legacy = value as CodexAuthBundle;
+      if (legacy?.auth_mode === 'chatgpt' && legacy.tokens?.access_token && legacy.tokens?.id_token && legacy.tokens?.refresh_token) {
+        // Old imports were copied from Codex CLI. Preserve the access token only;
+        // the extension must never rotate a refresh token it does not own.
+        return { schemaVersion: 2, source: 'legacyCodexFile', revision: randomRevision(), accessToken: legacy.tokens.access_token, accountId: legacy.tokens.account_id, loadedAt: legacy.last_refresh ?? new Date().toISOString() };
+      }
+    } catch { /* invalid stored secret is treated as absent */ }
+    return undefined;
   }
-
-  async setAuthBundle(bundle: CodexAuthBundle): Promise<void> {
-    await this.secrets.store(CODEX_AUTH_SECRET_KEY, JSON.stringify(bundle));
-  }
-
-  async deleteAuthBundle(): Promise<void> {
-    await this.secrets.delete(CODEX_AUTH_SECRET_KEY);
-  }
+  async setCredential(record: ExtensionOAuthCredentialRecord): Promise<void> { await this.secrets.store(CODEX_AUTH_SECRET_KEY, JSON.stringify(record)); }
+  async setLegacyCredential(record: LegacyCodexCredentialRecord): Promise<void> { await this.secrets.store(CODEX_AUTH_SECRET_KEY, JSON.stringify(record)); }
+  async deleteCredential(): Promise<void> { await this.secrets.delete(CODEX_AUTH_SECRET_KEY); }
+  // Compatibility helpers retained for existing consumers during migration.
+  async getAuthBundle(): Promise<CodexAuthBundle | undefined> { const record = await this.getCredential(); return record?.source === 'extensionOAuth' ? { auth_mode: 'chatgpt', tokens: record.tokens, last_refresh: record.lastRefreshAt } : undefined; }
+  async setAuthBundle(bundle: CodexAuthBundle): Promise<void> { await this.setCredential({ schemaVersion: 2, source: 'extensionOAuth', revision: randomRevision(), tokens: bundle.tokens, lastRefreshAt: bundle.last_refresh ?? new Date().toISOString() }); }
+  async deleteAuthBundle(): Promise<void> { await this.deleteCredential(); }
+}
+export function randomRevision(): string { return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`; }
+function isCredential(value: unknown): value is CodexCredentialRecord {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<CodexCredentialRecord>;
+  return candidate.schemaVersion === 2 && (candidate.source === 'extensionOAuth' || candidate.source === 'legacyCodexFile');
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,11 @@ export function activate(context: vscode.ExtensionContext): void {
   const accountUsageStatusBar = new CodexAccountUsageStatusBar(context, outputChannel, authManager);
   const provider = new CodexModelProvider(context, outputChannel, undefined, accountUsageStatusBar, accountUsageStatusBar, authManager);
 
+  context.subscriptions.push(authManager, authManager.onDidChangeAuth(() => {
+    provider.handleAuthenticationChanged();
+    void accountUsageStatusBar.refresh();
+  }));
+
   context.subscriptions.push(
     outputChannel,
     accountUsageStatusBar,
@@ -71,10 +76,18 @@ export function activate(context: vscode.ExtensionContext): void {
       await authManager.signOut();
       vscode.window.showInformationMessage('Codex credentials removed.');
     }),
+    vscode.commands.registerCommand('codexForCopilot.auth.signInWithChatGPT', async () => {
+      try {
+        await authManager.signInWithBrowser();
+        vscode.window.showInformationMessage('Signed in with ChatGPT.');
+      } catch (error) {
+        vscode.window.showErrorMessage(error instanceof Error ? error.message : 'ChatGPT sign-in failed.');
+      }
+    }),
     vscode.commands.registerCommand('codexForCopilot.auth.showStatus', async () => {
       const status = await authManager.getStatus();
       if (!status.authenticated) {
-        vscode.window.showInformationMessage('Codex credentials are not imported.');
+        vscode.window.showInformationMessage('Not signed in.');
         return;
       }
       const details = [
@@ -83,7 +96,7 @@ export function activate(context: vscode.ExtensionContext): void {
         status.accessTokenExpiresAt ? `Access token expires: ${new Date(status.accessTokenExpiresAt).toLocaleString()}` : undefined,
         status.lastRefresh ? `Last refresh: ${status.lastRefresh}` : undefined
       ].filter(Boolean).join('\n');
-      vscode.window.showInformationMessage(details || 'Codex credentials are imported.');
+      vscode.window.showInformationMessage(details || 'Signed in with ChatGPT.');
     }),
     vscode.commands.registerCommand('codexForCopilot.auth.signInWithDeviceCode', async () => {
       await authManager.signInWithDeviceCode();
@@ -94,11 +107,13 @@ export function activate(context: vscode.ExtensionContext): void {
     }),
     vscode.commands.registerCommand('codexModelProvider.manage', async () => {
       const action = await vscode.window.showQuickPick(
-        ['Import Codex auth.json', 'Show Auth Status', 'Sign Out', 'Sign in with Device Code', 'Refresh Account Limits', 'Open Debug Logs', 'Set API Key', 'Clear API Key', 'Open Settings'],
+        ['Sign in with ChatGPT', 'Sign in with Device Code', 'Show Auth Status', 'Sign Out', 'Import Codex auth.json (Legacy)', 'Refresh Account Limits', 'Open Debug Logs', 'Set API Key', 'Clear API Key', 'Open Settings'],
         { title: 'Codex' }
       );
 
-      if (action === 'Import Codex auth.json') {
+      if (action === 'Sign in with ChatGPT') {
+        await vscode.commands.executeCommand('codexForCopilot.auth.signInWithChatGPT');
+      } else if (action === 'Import Codex auth.json (Legacy)') {
         await vscode.commands.executeCommand('codexForCopilot.auth.importAuthJson');
       } else if (action === 'Show Auth Status') {
         await vscode.commands.executeCommand('codexForCopilot.auth.showStatus');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { CodexAccountUsageStatusBar } from './accountUsageStatusBar';
 import { CodexModelProvider } from './provider';
 import { CodexAuthLock } from './auth/codexAuthLock';
 import { CodexAuthManager } from './auth/codexAuthManager';
+import { CodexAuthenticationProvider, CODEX_AUTHENTICATION_PROVIDER_ID } from './auth/codexAuthenticationProvider';
 import { CodexSecretStore } from './auth/codexSecretStore';
 import { InvalidAuthJsonError } from './auth/codexAuthTypes';
 import { clearApiKey, setApiKey } from './secrets';
@@ -12,8 +13,11 @@ export function activate(context: vscode.ExtensionContext): void {
   void vscode.workspace.fs.createDirectory(context.globalStorageUri);
   const authManager = new CodexAuthManager(
     new CodexSecretStore(context.secrets),
-    new CodexAuthLock(vscode.Uri.joinPath(context.globalStorageUri, 'codex-auth-refresh.lock'))
+    new CodexAuthLock(vscode.Uri.joinPath(context.globalStorageUri, 'codex-auth-refresh.lock')),
+    undefined,
+    (message, details) => outputChannel.info(message, details)
   );
+  const authenticationProvider = new CodexAuthenticationProvider(authManager);
   const accountUsageStatusBar = new CodexAccountUsageStatusBar(context, outputChannel, authManager);
   const provider = new CodexModelProvider(context, outputChannel, undefined, accountUsageStatusBar, accountUsageStatusBar, authManager);
 
@@ -24,7 +28,14 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(
     outputChannel,
+    authenticationProvider,
     accountUsageStatusBar,
+    vscode.authentication.registerAuthenticationProvider(
+      CODEX_AUTHENTICATION_PROVIDER_ID,
+      'Codex for Copilot',
+      authenticationProvider,
+      { supportsMultipleAccounts: false }
+    ),
     vscode.lm.registerLanguageModelChatProvider('codex-for-copilot', provider),
     vscode.commands.registerCommand('codexModelProvider.openDebugLogs', () => {
       outputChannel.show(true);
@@ -81,6 +92,7 @@ export function activate(context: vscode.ExtensionContext): void {
         await authManager.signInWithBrowser();
         vscode.window.showInformationMessage('Signed in with ChatGPT.');
       } catch (error) {
+        outputChannel.error('ChatGPT sign-in failed', error);
         vscode.window.showErrorMessage(error instanceof Error ? error.message : 'ChatGPT sign-in failed.');
       }
     }),

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -182,6 +182,14 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     );
   }
 
+  handleAuthenticationChanged(): void {
+    disposeReusableResponsesWebSockets();
+    resetCodexFetchCapabilities();
+    this.lastConnectionConfigurationKey = undefined;
+    this.modelCache.clear();
+    this.modelInfoChangedEmitter.fire();
+  }
+
   async provideLanguageModelChatInformation(
     options: vscode.PrepareLanguageModelChatModelOptions,
     token: vscode.CancellationToken
@@ -553,6 +561,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         baseURL: config.baseURL,
         apiKey: credentials.apiKey,
         headers: credentials.headers,
+        authManager: credentials.authManager,
         transport: config.transport,
         compatibilityProfile,
         identity: requestIdentity,

--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -80,6 +80,7 @@ export interface StreamResponseTextOptions {
   baseURL: string;
   apiKey: string;
   headers?: Record<string, string>;
+  authManager?: CodexAuthManager;
   transport?: 'auto' | 'http' | 'websocket';
   compatibilityProfile?: CodexCompatibilityProfile;
   identity?: CodexRequestIdentity;
@@ -572,6 +573,22 @@ async function streamCodexResponseTextOverManagedWebSocket(
     } catch (error) {
       codexConnectionManager.closeThread(scope);
       const classified = classifyManagedWebSocketError(error, options);
+      if (attempt === 0 && !visibleActivity && options.authManager && isUnauthorizedError(error)) {
+        const currentSnapshot = await options.authManager.getCredentialSnapshot();
+        const snapshot = await options.authManager.recoverFromUnauthorized({
+          snapshotRevision: currentSnapshot.revision,
+          visibleActivity: false,
+          reason: 'websocketUnauthorized'
+        });
+        options.apiKey = snapshot.accessToken;
+        options.headers = {
+          ...options.headers,
+          ...(snapshot.accountId ? { 'ChatGPT-Account-ID': snapshot.accountId } : {})
+        };
+        managed = codexConnectionManager.getOrCreate(scope, createOpenAIClient(options), createResponsesWsOptions(buildDynamicHeaders(options, 'websocket'), options.baseURL));
+        options.onTransportMetrics?.({ retryReason: 'websocket_unauthorized_recovered' });
+        continue;
+      }
       if (attempt === 0 && !visibleActivity && /connection limit/i.test(classified.message)) {
         managed = codexConnectionManager.getOrCreate(scope, client, createResponsesWsOptions(headers, options.baseURL));
         options.onTransportMetrics?.({ retryReason: 'websocket_connection_limit_reached' });
@@ -586,6 +603,12 @@ async function streamCodexResponseTextOverManagedWebSocket(
       throw classified;
     }
   }
+}
+
+function isUnauthorizedError(error: unknown): boolean {
+  return error instanceof AuthenticationError
+    || error instanceof APIError && error.status === 401
+    || collectErrorMessages(error).some((message) => /\b401\b|unauthori[sz]ed|invalid api key/i.test(message));
 }
 
 function reportManagedWebSocketRequestMetrics(
@@ -766,10 +789,10 @@ function evictReusableWebSocketSessions(): void {
 }
 
 function createOpenAIClient(
-  options: Pick<StreamResponseTextOptions, 'apiKey' | 'baseURL' | 'headers' | 'compatibilityProfile' | 'requestCompression' | 'onTransportMetrics'>,
+  options: Pick<StreamResponseTextOptions, 'apiKey' | 'baseURL' | 'headers' | 'authManager' | 'compatibilityProfile' | 'requestCompression' | 'onTransportMetrics'>,
   defaultHeaders?: Record<string, string>
 ): OpenAI {
-  const customFetch = createCodexFetchAdapter({
+  const compressedFetch = createCodexFetchAdapter({
     endpointKey: options.compatibilityProfile?.endpointKey ?? normalizeBaseURL(options.baseURL),
     compatibilityEnabled: options.compatibilityProfile?.enabled ?? false,
     compression: options.requestCompression ?? 'disabled',
@@ -782,6 +805,9 @@ function createOpenAIClient(
       responseStatus: observation.responseStatus
     })
   });
+  const customFetch: typeof fetch = options.authManager
+    ? (input, init) => codexFetch(options.authManager!, input, init, compressedFetch)
+    : compressedFetch;
   return new OpenAI({
     apiKey: options.apiKey,
     baseURL: normalizeBaseURL(options.baseURL),

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -50,14 +50,13 @@ export async function clearApiKey(context: vscode.ExtensionContext): Promise<voi
 async function readCodexAuthCredentials(authManager?: CodexAuthManager): Promise<ApiCredentials | undefined> {
   if (authManager) {
     try {
-      const status = await authManager.getStatus();
-      const accessToken = await authManager.getAccessToken();
+      const snapshot = await authManager.getCredentialSnapshot();
       const headers: Record<string, string> = { 'User-Agent': DEFAULT_USER_AGENT };
-      if (status.accountId?.trim()) {
-        headers['ChatGPT-Account-ID'] = status.accountId.trim();
+      if (snapshot.accountId?.trim()) {
+        headers['ChatGPT-Account-ID'] = snapshot.accountId.trim();
       }
       return {
-        apiKey: accessToken,
+        apiKey: snapshot.accessToken,
         headers,
         source: 'codexAuth',
         authManager,

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -7,6 +7,8 @@
 ## Key Files
 
 - `smokeResponsesClient.mjs`: local mock coverage for HTTP transport, WebSocket transport, WebSocket-to-HTTP fallback, and reasoning-item identity.
+- `smokeAuth.mjs`: local coverage for OAuth credential parsing, token refresh, and the VS Code authentication-session lifecycle.
+- `extensionHostSmoke.cjs`: asserts the manifest declares the Codex VS Code AuthenticationProvider before exercising the language-model boundary.
 - `smokeCodexRequestBuilder.mjs`: request-shape coverage, including configured-instruction preservation for requests with function tools.
 - `smokeProviderFallback.mjs`: local mock coverage for provider recovery, unavailable-model handling, full-input replay for tool-result continuations, and interleaved reasoning/text presentation.
 - `smokeCodexWebSocketLifecycle.mjs`: managed WebSocket handshake, prewarm, incremental request, full tool-replay request shape, and reasoning-item identity coverage.
@@ -25,6 +27,8 @@
 ## Constraints
 
 - Prefer narrow transport semantics checks over broad suites.
+- Authentication smoke coverage must verify that a native ChatGPT sign-in adds a VS Code session, a token refresh changes it, and sign-out removes it.
+- Loopback OAuth smoke coverage must verify the callback response closes the browser connection, success is shown only after credential persistence, token-exchange failures reach the browser, and login completion is not blocked by callback-server cleanup.
 - Keep HTTP and WebSocket assertions aligned so transport parity regressions are caught in one place.
 - An in-band `Model not found` error for the requested model must not make `auto` issue an HTTP fallback request.
 - Keep branch reuse semantics deterministic: append-only reuse, fork reset, and tool-change busting should be covered by local smoke tests.

--- a/test/extensionHostSmoke.cjs
+++ b/test/extensionHostSmoke.cjs
@@ -8,6 +8,9 @@ async function run() {
   const extensionId = `${manifest.publisher}.${manifest.name}`.toLowerCase();
   const extension = vscode.extensions.getExtension(extensionId);
   assert(extension, 'Extension is not registered in VS Code.');
+  const authenticationProvider = manifest.contributes.authentication?.find((provider) => provider.id === 'codex-for-copilot');
+  assert(authenticationProvider, 'Codex authentication provider is not declared in the extension manifest.');
+  assert.strictEqual(authenticationProvider.label, 'Codex for Copilot');
 
   let modelDiscoveryRequestCount = 0;
   let responseRequestCount = 0;

--- a/test/smokeAuth.mjs
+++ b/test/smokeAuth.mjs
@@ -37,6 +37,8 @@ export * from ${repoImport('src/auth/codexJwt')};
 export * from ${repoImport('src/auth/codexAuthManager')};
 export * from ${repoImport('src/auth/codexAuthRequest')};
 export * from ${repoImport('src/auth/codexAuthLock')};
+export * from ${repoImport('src/auth/codexPkce')};
+export * from ${repoImport('src/auth/codexOAuthClient')};
 `));
 
 await build({
@@ -92,12 +94,13 @@ try {
 
   let calls = 0;
   const manager = {
-    async getAccessToken() {
+    async getCredentialSnapshot() {
       calls += 1;
-      return calls === 1 ? 'old-token' : 'new-token';
+      return { accessToken: calls === 1 ? 'old-token' : 'new-token', accountId: 'acct_1', revision: calls === 1 ? 'old' : 'new' };
     },
-    async refreshAfter401() {
+    async recoverFromUnauthorized() {
       calls += 10;
+      return { accessToken: 'new-token', accountId: 'acct_1', revision: 'new' };
     }
   };
   const seenAuth = [];
@@ -109,7 +112,17 @@ try {
   assertEqual(response.status, 200, '401 retry succeeds');
   assertEqual(JSON.stringify(seenAuth), JSON.stringify(['Bearer old-token', 'Bearer new-token']), 'retry uses refreshed token');
 
-  console.log('Smoke test passed: auth import, JWT parsing, refresh decisions, and 401 retry are correct.');
+  const pkce = auth.generateCodexPkce();
+  assertEqual(pkce.verifier.length >= 43, true, 'PKCE verifier has RFC-compliant length');
+  assertEqual(pkce.challenge.length >= 43, true, 'PKCE challenge has RFC-compliant length');
+  assertEqual(auth.statesMatch(pkce.state, pkce.state), true, 'PKCE state matches itself');
+  assertEqual(auth.statesMatch(pkce.state, 'incorrect'), false, 'PKCE state rejects mismatch');
+  const oauth = new auth.CodexOAuthClient(async () => new Response(JSON.stringify({ id_token: futureToken, access_token: 'access', refresh_token: 'refresh' }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+  const url = new URL(oauth.createAuthorizationUrl('http://localhost:1455/auth/callback', pkce.verifier, pkce.challenge, pkce.state));
+  assertEqual(url.searchParams.get('code_challenge_method'), 'S256', 'authorization URL uses PKCE S256');
+  assertEqual(url.searchParams.get('state'), pkce.state, 'authorization URL includes state');
+
+  console.log('Smoke test passed: auth import, PKCE, JWT parsing, refresh decisions, and 401 retry are correct.');
 } finally {
   Module._load = moduleLoad;
   await rm(tempDir, { recursive: true, force: true });

--- a/test/smokeAuth.mjs
+++ b/test/smokeAuth.mjs
@@ -1,6 +1,7 @@
 import { createRequire } from 'node:module';
 import Module from 'node:module';
 import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import { join } from 'node:path';
 import { build } from 'esbuild';
 import { resolveTestTempDirectory } from './testTempDirectory.mjs';
@@ -11,6 +12,24 @@ const entryPath = join(tempDir, 'auth-entry.ts');
 const repoImport = (relativePath) => JSON.stringify(join(process.cwd(), relativePath));
 const require = createRequire(import.meta.url);
 const moduleLoad = Module._load;
+const nativeFetch = globalThis.fetch;
+class EventEmitter {
+  constructor() {
+    this.listeners = new Set();
+    this.event = (listener) => {
+      this.listeners.add(listener);
+      return { dispose: () => this.listeners.delete(listener) };
+    };
+  }
+  fire(value) {
+    for (const listener of this.listeners) {
+      listener(value);
+    }
+  }
+  dispose() {
+    this.listeners.clear();
+  }
+}
 Module._load = function patchedLoad(request, parent, isMain) {
   if (request === 'vscode') {
     return {
@@ -26,7 +45,8 @@ Module._load = function patchedLoad(request, parent, isMain) {
         }
       },
       window: { showErrorMessage: async () => undefined, showInformationMessage: async () => undefined },
-      commands: { executeCommand: async () => undefined }
+      commands: { executeCommand: async () => undefined },
+      EventEmitter
     };
   }
   return moduleLoad.call(this, request, parent, isMain);
@@ -39,6 +59,8 @@ export * from ${repoImport('src/auth/codexAuthRequest')};
 export * from ${repoImport('src/auth/codexAuthLock')};
 export * from ${repoImport('src/auth/codexPkce')};
 export * from ${repoImport('src/auth/codexOAuthClient')};
+export * from ${repoImport('src/auth/codexAuthenticationProvider')};
+export * from ${repoImport('src/auth/codexLoopbackLogin')};
 `));
 
 await build({
@@ -111,6 +133,7 @@ try {
   const response = await auth.codexFetch(manager, 'http://example.test', {});
   assertEqual(response.status, 200, '401 retry succeeds');
   assertEqual(JSON.stringify(seenAuth), JSON.stringify(['Bearer old-token', 'Bearer new-token']), 'retry uses refreshed token');
+  globalThis.fetch = nativeFetch;
 
   const pkce = auth.generateCodexPkce();
   assertEqual(pkce.verifier.length >= 43, true, 'PKCE verifier has RFC-compliant length');
@@ -119,10 +142,109 @@ try {
   assertEqual(auth.statesMatch(pkce.state, 'incorrect'), false, 'PKCE state rejects mismatch');
   const oauth = new auth.CodexOAuthClient(async () => new Response(JSON.stringify({ id_token: futureToken, access_token: 'access', refresh_token: 'refresh' }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
   const url = new URL(oauth.createAuthorizationUrl('http://localhost:1455/auth/callback', pkce.verifier, pkce.challenge, pkce.state));
+  assertEqual(url.origin + url.pathname, 'https://auth.openai.com/oauth/authorize', 'authorization URL matches Codex OAuth endpoint');
+  assertEqual(url.searchParams.get('scope'), 'openid profile email offline_access api.connectors.read api.connectors.invoke', 'authorization URL matches Codex OAuth scopes');
   assertEqual(url.searchParams.get('code_challenge_method'), 'S256', 'authorization URL uses PKCE S256');
   assertEqual(url.searchParams.get('state'), pkce.state, 'authorization URL includes state');
 
-  console.log('Smoke test passed: auth import, PKCE, JWT parsing, refresh decisions, and 401 retry are correct.');
+  const callbackPort = await findAvailablePort();
+  const loopbackClient = {
+    createAuthorizationUrl(redirectUri, _verifier, _challenge, state) {
+      const callback = new URL(redirectUri);
+      callback.searchParams.set('state', state);
+      return callback.toString();
+    },
+    async exchangeAuthorizationCode(code) {
+      assertEqual(code, 'authorization-code', 'IPv6 callback authorization code');
+      return { id_token: futureToken, access_token: 'access', refresh_token: 'refresh' };
+    }
+  };
+  const loopbackStages = [];
+  let callbackConnection;
+  let credentialsPersisted = false;
+  let callbackPromise;
+  const loopbackTokens = await auth.signInWithLoopback(loopbackClient, async (redirectUri) => {
+    const callback = new URL(redirectUri);
+    callbackPromise = fetch(`http://127.0.0.1:${callback.port}${callback.pathname}?code=authorization-code&state=${callback.searchParams.get('state')}`).then(async (response) => {
+      callbackConnection = response.headers.get('connection');
+      assertEqual(response.status, 200, 'callback reports success after credentials are persisted');
+      assertEqual(credentialsPersisted, true, 'callback success waits for credential persistence');
+    });
+    return true;
+  }, { loopbackPorts: [callbackPort], callbackPath: '/auth/callback' }, (stage) => loopbackStages.push(stage), async () => {
+    credentialsPersisted = true;
+  });
+  await callbackPromise;
+  assertEqual(loopbackTokens.access_token, 'access', 'loopback callback completes OAuth sign-in');
+  assertEqual(callbackConnection, 'close', 'callback response closes the browser connection');
+  assertEqual(loopbackStages.at(-1), 'completed', 'loopback sign-in completes before server cleanup');
+
+  const failedCallbackPort = await findAvailablePort();
+  let failedCallbackPromise;
+  const failedLoopbackClient = {
+    createAuthorizationUrl: loopbackClient.createAuthorizationUrl,
+    async exchangeAuthorizationCode() {
+      throw new Error('token exchange failed');
+    }
+  };
+  await assertRejects(() => auth.signInWithLoopback(failedLoopbackClient, async (redirectUri) => {
+    const callback = new URL(redirectUri);
+    failedCallbackPromise = fetch(`http://127.0.0.1:${callback.port}${callback.pathname}?code=authorization-code&state=${callback.searchParams.get('state')}`).then((response) => {
+      assertEqual(response.status, 500, 'callback reports token exchange failure');
+    });
+    return true;
+  }, { loopbackPorts: [failedCallbackPort], callbackPath: '/auth/callback' }), 'token exchange failure rejects loopback sign-in');
+  await failedCallbackPromise;
+
+  const authChanges = new EventEmitter();
+  let signedInSnapshot;
+  const fakeAuthManager = {
+    onDidChangeAuth: authChanges.event,
+    async getStatus() {
+      return signedInSnapshot
+        ? { authenticated: true, email: 'user@example.com' }
+        : { authenticated: false };
+    },
+    async getCredentialSnapshot() {
+      if (!signedInSnapshot) {
+        throw new Error('not signed in');
+      }
+      return signedInSnapshot;
+    },
+    async signInWithBrowser() {
+      signedInSnapshot = {
+        source: 'extensionOAuth',
+        accessToken: 'initial-access-token',
+        accountId: 'acct_1',
+        revision: 'first',
+        refreshable: true
+      };
+      authChanges.fire({ reason: 'signedIn' });
+    },
+    async signOut() {
+      signedInSnapshot = undefined;
+      authChanges.fire({ reason: 'signedOut' });
+    }
+  };
+  const authenticationProvider = new auth.CodexAuthenticationProvider(fakeAuthManager);
+  const sessionChanges = [];
+  authenticationProvider.onDidChangeSessions((event) => sessionChanges.push(event));
+  assertEqual((await authenticationProvider.getSessions(undefined, {})).length, 0, 'unauthenticated provider has no sessions');
+  const session = await authenticationProvider.createSession(['openid'], {});
+  await flushEvents();
+  assertEqual(session.account.id, 'acct_1', 'session uses Codex account ID');
+  assertEqual(sessionChanges[0].added[0].id, session.id, 'sign-in adds a VS Code session');
+  signedInSnapshot = { ...signedInSnapshot, accessToken: 'refreshed-access-token', revision: 'second' };
+  authChanges.fire({ reason: 'tokensRefreshed' });
+  await flushEvents();
+  assertEqual(sessionChanges[1].changed[0].accessToken, 'refreshed-access-token', 'token refresh updates the VS Code session');
+  await authenticationProvider.removeSession(session.id);
+  await flushEvents();
+  assertEqual(sessionChanges[2].removed[0].id, session.id, 'sign-out removes the VS Code session');
+  await assertRejects(() => authenticationProvider.createSession(['unsupported-scope'], {}), 'unsupported authentication scope rejected');
+  authenticationProvider.dispose();
+
+  console.log('Smoke test passed: auth import, PKCE, loopback completion, JWT parsing, refresh decisions, 401 retry, and VS Code authentication sessions are correct.');
 } finally {
   Module._load = moduleLoad;
   await rm(tempDir, { recursive: true, force: true });
@@ -145,4 +267,25 @@ function assertThrows(fn, label) {
     return;
   }
   throw new Error(`${label}: expected throw`);
+}
+
+async function assertRejects(fn, label) {
+  try {
+    await fn();
+  } catch {
+    return;
+  }
+  throw new Error(`${label}: expected rejection`);
+}
+
+async function flushEvents() {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function findAvailablePort() {
+  const server = createServer();
+  await new Promise((resolve, reject) => server.listen(0, '127.0.0.1').once('listening', resolve).once('error', reject));
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
 }


### PR DESCRIPTION
## Summary

Implements native ChatGPT Codex OAuth authentication for Codex For Copilot and exposes the signed-in account through VS Code's Authentication API.

- Adds browser Authorization Code + PKCE login on registered loopback ports 1455/1457, plus Device Code fallback.
- Aligns the authorization endpoint and scopes with the current `openai/codex` login implementation.
- Registers a `codex-for-copilot` AuthenticationProvider so sign-in, refresh, account changes, and sign-out are reflected in VS Code Accounts.
- Stores extension-owned, versioned credentials in SecretStorage; imported and file-based Codex credentials remain read-only and are never rotated or revoked.
- Keeps callback cleanup non-blocking and shows browser success only after token exchange and credential persistence complete.
- Adds proactive refresh, bounded cross-window locking, one pre-output HTTP 401 recovery, guarded WebSocket unauthorized recovery, and best-effort refresh-token revocation.
- Invalidates authenticated sockets, model cache, and account usage when authentication changes.
- Adds focused OAuth/session lifecycle coverage and a manifest assertion in the Extension Host smoke test.

## Validation

- `node test/smokeAuth.mjs`
- `npm run check`
- `npm run compile`
- `npm run test:smoke`
- `npm run test:extension-host`
- Manual browser sign-in in an Extension Development Host