### PR TITLE
Preserve response item IDs for rust-v0.146.0 compatibility

### DIFF
--- a/src/codexRequestBuilder.ts
+++ b/src/codexRequestBuilder.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 import type { ResponseCreateParamsStreaming, ToolChoiceOptions } from 'openai/resources/responses/responses';
 import type { Reasoning } from 'openai/resources/shared';
@@ -87,7 +88,10 @@ export function buildCodexResponsesRequestWithMetrics(
   const request = {
     model: options.model,
     instructions: options.instructions,
-    input: sanitizeResponsesInputForOutbound(options.input),
+    input: sanitizeResponsesInputForOutbound(
+      options.input,
+      options.compatibilityEnabled && !options.previousResponseId && options.input.length > 1
+    ),
     stream: true,
     store: options.store ?? false,
     ...(options.previousResponseId ? { previous_response_id: options.previousResponseId } : {}),
@@ -187,8 +191,42 @@ function normalizeReasoningForRequest(options: CodexRequestBuilderOptions): Reas
   } as Reasoning;
 }
 
-function sanitizeResponsesInputForOutbound(input: readonly ResponsesInputMessage[]): ResponsesInputMessage[] {
-  return input.map((item) => sanitizeResponseItemIdForOutbound(item));
+function sanitizeResponsesInputForOutbound(
+  input: readonly ResponsesInputMessage[],
+  assignReplayIds: boolean
+): ResponsesInputMessage[] {
+  return input.map((item, index) => {
+    const sanitized = sanitizeResponseItemIdForOutbound(item);
+    const record = sanitized as unknown as Record<string, unknown>;
+    const original = item as unknown as Record<string, unknown>;
+    if (!assignReplayIds
+      || Object.prototype.hasOwnProperty.call(original, 'id')
+      || Object.prototype.hasOwnProperty.call(record, 'id')
+      || isFreshTrailingUserMessage(item, index, input.length)) {
+      return sanitized;
+    }
+
+    const prefix = responseItemIdPrefix(record.type);
+    if (!prefix) {
+      return sanitized;
+    }
+    return {
+      ...record,
+      id: `${prefix}_${createHash('sha256').update(`${index}:${stableSerialize(record)}`).digest('hex').slice(0, 24)}`
+    } as unknown as ResponsesInputMessage;
+  });
+}
+
+function isFreshTrailingUserMessage(item: ResponsesInputMessage, index: number, inputLength: number): boolean {
+  return index === inputLength - 1 && item.type === 'message' && item.role === 'user';
+}
+
+function responseItemIdPrefix(type: unknown): 'msg' | 'fc' | 'fco' | 'rs' | undefined {
+  if (type === 'message') return 'msg';
+  if (type === 'function_call') return 'fc';
+  if (type === 'function_call_output') return 'fco';
+  if (type === 'reasoning') return 'rs';
+  return undefined;
 }
 
 function sanitizeResponseItemIdForOutbound(item: ResponsesInputMessage): ResponsesInputMessage {

--- a/test/smokeCodexRequestBuilder.mjs
+++ b/test/smokeCodexRequestBuilder.mjs
@@ -59,6 +59,15 @@ try {
     input: continuationInput,
     tools: []
   });
+  const replayInput = [
+    { type: 'message', role: 'user', content: 'earlier user input' },
+    { type: 'message', role: 'assistant', content: 'earlier assistant output' },
+    { type: 'function_call', call_id: 'call_replay', name: 'read', arguments: '{}' },
+    { type: 'function_call_output', call_id: 'call_replay', output: 'result' }
+  ];
+  const replayRequest = buildCodexResponsesRequest({ ...base, input: replayInput, tools: [] });
+  const repeatedReplayRequest = buildCodexResponsesRequest({ ...base, input: replayInput, tools: [] });
+  const freshRequest = buildCodexResponsesRequest({ ...base, input: base.input, tools: [] });
   const appended = buildCodexResponsesRequest({ ...base, input: [...base.input, { type: 'message', role: 'user', content: 'next' }] });
   const event = buildCodexResponsesWebSocketEvent(base, false);
   resetCodexToolSchemaCache();
@@ -84,6 +93,12 @@ try {
   assertEqual('id' in sanitizedWebSocketEvent.input[1], false, 'WebSocket continuation omits legacy response item id');
   assertEqual(sanitizedWebSocketEvent.input[2].id, 'msg_valid123', 'WebSocket continuation preserves valid response item id');
   assertEqual(sanitizedWebSocketEvent.input[4].call_id, 'call_valid', 'WebSocket continuation preserves tool output call id');
+  assertEqual(replayRequest.input[0].id.startsWith('msg_'), true, 'full replay assigns an ID to historical user input');
+  assertEqual(replayRequest.input[1].id.startsWith('msg_'), true, 'full replay assigns an ID to client-created assistant input');
+  assertEqual(replayRequest.input[2].id.startsWith('fc_'), true, 'full replay assigns an ID to a client-created function call');
+  assertEqual(replayRequest.input[3].id.startsWith('fco_'), true, 'full replay assigns an ID to a client-created tool result');
+  assertEqual(JSON.stringify(replayRequest.input), JSON.stringify(repeatedReplayRequest.input), 'full replay item IDs are stable');
+  assertEqual('id' in freshRequest.input[0], false, 'ordinary fresh user input does not receive a fabricated ID');
   assertEqual(event.generate, false, 'prewarm generate flag');
   assertEqual('stream' in event, false, 'WebSocket stream omitted');
   assertEqual(areCodexRequestsIncrementallyCompatible(request, appended), true, 'input ignored by request fingerprint');


### PR DESCRIPTION
### Motivation

- Upstream `rust-v0.146.0` introduces stable client-side response item IDs, WebSocket retry behavior for `previous_response_not_found`, and deferred-tool/tool-search adjustments that can affect continuation/replay contracts.  The change here targets the externally-observable Responses item identity compatibility portion of that range (`rust-v0.145.0` → `rust-v0.146.0`).
- The goal is to avoid rejected replay payloads or duplicated/missing output by ensuring the extension emits only valid IDs, preserves server IDs, and assigns deterministic IDs when a full-history replay is required.

### Description

- When building compatibility-mode requests that perform a full-history replay, `sanitizeResponsesInputForOutbound` now assigns deterministic, type-prefixed IDs (`msg_`, `fc_`, `fco_`, `rs_`) to client-created historical items derived from a stable hash of the item index and canonicalized content. 
- Existing valid server-provided IDs are preserved, explicit invalid or unprefixed historical IDs are removed (not replaced), and ordinary fresh trailing user messages remain ID-free to avoid fabricating IDs for new input.
- Added helper functions `isFreshTrailingUserMessage`, `responseItemIdPrefix`, and used `createHash('sha256')` + `stableSerialize` to derive stable replay IDs; the new behavior only applies when compatibility-mode requests rebuild multi-item history (smallest change to preserve existing fallback/continuation semantics).
- Added focused smoke coverage in `test/smokeCodexRequestBuilder.mjs` to assert sanitized continuation behavior, stable assigned IDs across repeated full replays, IDs for messages/function calls/tool results on replay, and that single fresh requests do not receive fabricated IDs.

### Testing

- Ran type-checking with `npm run check`, which completed successfully. 
- Ran the full smoke suite with `npm run test:smoke`, which passed (including the updated `smokeCodexRequestBuilder.mjs` assertions). 
- No live-backend verification was performed as part of this change (local smoke tests use the repository's mock servers). 
- Remaining manual verification: exercise a multi-turn Responses conversation against the ChatGPT Codex backend after server-side `previous_response_id` eviction to confirm the full replay is accepted, and exercise a real tool-call/result continuation to validate generated item IDs remain accepted across WebSocket continuation recovery.

Closes #54

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ab070aaa4832498035f21f80bc01e)