### PR TITLE
fix: improve Codex reasoning thinking presentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:benchmark-backend": "node test/benchmarkBackend.mjs",
     "test:benchmark-provider": "node test/benchmarkProviderBackend.mjs",
     "test:codex-parity": "node test/smokeCodexProtocol.mjs && node test/smokeCodexIdentity.mjs && node test/smokeCodexRequestBuilder.mjs && node test/smokeCodexToolSchemaCache.mjs && node test/smokeCodexTurnLifecycle.mjs && node test/smokeCodexHttpLifecycle.mjs && node test/smokeCodexWebSocketLifecycle.mjs && node test/smokeCodexPreconnection.mjs && node test/smokeCodexPrewarmBudget.mjs && node test/smokeCodexCancellation.mjs && node test/smokeCodexFallback.mjs && node test/smokeCodexCompression.mjs",
-    "test:smoke": "npm run test:codex-parity && node test/smokeReasoningEffort.mjs && node test/smokeCodexLatency.mjs && node test/smokeStreamPresenter.mjs && node test/smokeCodexModelCache.mjs && node test/smokeResponsesClient.mjs && node test/smokeProviderFallback.mjs && node test/smokeConversationReuse.mjs && node test/smokeAccountUsage.mjs && node test/smokeAuth.mjs",
+    "test:smoke": "npm run test:codex-parity && node test/smokeReasoningEffort.mjs && node test/smokeCodexLatency.mjs && node test/smokeStreamPresenter.mjs && node test/smokeReasoningStreamPresenter.mjs && node test/smokeCodexModelCache.mjs && node test/smokeResponsesClient.mjs && node test/smokeProviderFallback.mjs && node test/smokeConversationReuse.mjs && node test/smokeAccountUsage.mjs && node test/smokeAuth.mjs",
     "watch": "tsc -watch -p ./",
     "vscode:prepublish": "npm run compile"
   },

--- a/src/codexRequestBuilder.ts
+++ b/src/codexRequestBuilder.ts
@@ -181,9 +181,10 @@ function normalizeReasoningForRequest(options: CodexRequestBuilderOptions): Reas
     return options.reasoning;
   }
 
+  const effort = options.reasoning?.effort ?? 'medium';
   return {
-    effort: options.reasoning?.effort ?? 'medium',
-    summary: options.reasoning?.summary ?? 'auto'
+    effort,
+    ...(effort === 'none' ? {} : { summary: options.reasoning?.summary ?? 'auto' })
   } as Reasoning;
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -36,7 +36,8 @@ import { shortHash } from './codexTelemetry';
 import { CodexLatencyRecorder, type CodexLatencyContext } from './codexLatency';
 import { createCodexContinuationSnapshot } from './codexContinuation';
 import { resolveCodexToolSchemas } from './codexToolSchemaCache';
-import { StreamPresenter } from './streamPresenter';
+import { StreamPresenter, mergeStreamPresentationMetrics } from './streamPresenter';
+import { ReasoningStreamPresenter } from './reasoningStreamPresenter';
 import {
   CodexModelCache,
   MODEL_CACHE_FRESH_TTL_MS,
@@ -483,7 +484,6 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             latencyMs: number;
           }
         | undefined;
-      let hasReportedText = false;
       let previousResponseIdUsed = false;
       if (config.transport === 'http') {
         latency.mark('connectionAcquired');
@@ -526,25 +526,48 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         };
       };
 
-      const presenter = new StreamPresenter(
-        (_kind, receivedAt) => latency.mark('firstBackendDelta', receivedAt),
-        (kind, reportedAt) => {
-          reportedVisibleOutput = true;
-          recordFirstVisibleOutput(kind, reportedAt);
-          if (kind === 'text') {
-            latency.mark('firstText', reportedAt);
-          } else {
-            latency.mark('firstReasoning', reportedAt);
-          }
+      const reportVisiblePart = (
+        kind: 'text' | 'reasoning' | 'tool_call',
+        part: vscode.LanguageModelResponsePart,
+        reportedAt = Date.now()
+      ) => {
+        progress.report(part);
+        reportedVisibleOutput = true;
+        recordFirstVisibleOutput(kind, reportedAt);
+        if (kind === 'text') {
+          latency.mark('firstText', reportedAt);
+        } else if (kind === 'reasoning') {
+          latency.mark('firstReasoning', reportedAt);
         }
+      };
+
+      const presenter = new StreamPresenter(
+        (_kind, receivedAt) => latency.mark('firstBackendDelta', receivedAt)
       );
+      let loggedMissingThinkingPart = false;
+      const reasoningPresenter = new ReasoningStreamPresenter((update) => {
+        const thinkingPart = createThinkingPart(update.value, update.id, {
+          source: update.source,
+          itemId: update.itemId,
+          outputIndex: update.outputIndex,
+          phase: update.phase
+        });
+        if (thinkingPart) {
+          reportVisiblePart('reasoning', thinkingPart);
+        } else if (!loggedMissingThinkingPart) {
+          loggedMissingThinkingPart = true;
+          this.outputChannel.debug('Reasoning output received, but LanguageModelThinkingPart is unavailable.');
+        }
+      }, {
+        onBackendDelta: (receivedAt) => latency.mark('firstBackendDelta', receivedAt)
+      });
       let presentationMetricsRecorded = false;
       const recordPresentationMetrics = () => {
         if (presentationMetricsRecorded) {
           return;
         }
         presentationMetricsRecorded = true;
-        const metrics = presenter.metrics();
+        const metrics = mergeStreamPresentationMetrics(presenter.metrics(), reasoningPresenter.metrics());
         latency.recordContext({
           metricVersion: 2,
           backendDeltaCount: metrics.backendDeltaCount,
@@ -585,37 +608,25 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         maxOutputTokens: requestOptions.maxOutputTokens,
         token,
         onTextDelta: (text) => {
+          if (text) {
+            reasoningPresenter.close();
+          }
           presenter.push({
             kind: 'text',
             identity: 'text',
             text,
             emit: (presentedText) => {
-              hasReportedText ||= presentedText.length > 0;
-              progress.report(new vscode.LanguageModelTextPart(presentedText));
+              reportVisiblePart('text', new vscode.LanguageModelTextPart(presentedText));
             }
           });
         },
-        onReasoningTextDelta: ({ text, itemId, contentIndex }) => {
-          if (hasReportedText) {
-            return;
-          }
-
-          const identity = `reasoning:${itemId}:${contentIndex}`;
-          const thinkingPartId = `${itemId}:${contentIndex}`;
-          if (!createThinkingPart(text, thinkingPartId)) {
-            return;
-          }
-
-          presenter.push({
-            kind: 'reasoning',
-            identity,
-            text,
-            emit: (presentedText) => {
-              const thinkingPart = createThinkingPart(presentedText, thinkingPartId);
-              if (thinkingPart) {
-                progress.report(thinkingPart);
-              }
-            }
+        onReasoningDelta: (delta) => {
+          reasoningPresenter.push(delta);
+        },
+        onReasoningLifecycleEvent: (event) => {
+          this.outputChannel.info('response reasoning lifecycle', {
+            requestModel: selectedModel.requestModel,
+            ...event
           });
         },
         onToolCallAdded: (callId) => {
@@ -635,12 +646,11 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           latency.mark('firstToolCallArgumentsDone');
         },
         onToolCall: (callId, name, toolInput) => {
+          reasoningPresenter.startNextPhase();
           presenter.flushBoundary();
-          reportedVisibleOutput = true;
           const reportedAt = Date.now();
           latency.mark('firstToolCall', reportedAt);
-          recordFirstVisibleOutput('tool_call', reportedAt);
-          progress.report(new vscode.LanguageModelToolCallPart(callId, name, toolInput));
+          reportVisiblePart('tool_call', new vscode.LanguageModelToolCallPart(callId, name, toolInput), reportedAt);
           latency.mark('firstToolCallReported', reportedAt);
           this.rememberReportedToolCall(callId, name, reportedAt);
           reportedToolCallIds.add(callId);
@@ -716,6 +726,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           });
         },
         onResponseCompleted: (response) => {
+          reasoningPresenter.close();
           this.markReportedToolCallsResponseCompleted(reportedToolCallIds);
           presenter.flushBoundary();
           recordPresentationMetrics();
@@ -767,11 +778,13 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           void this.accountUsageRefreshSink?.refresh();
         },
         onResponseFailed: (message) => {
+          reasoningPresenter.close();
           presenter.flushBoundary();
           recordPresentationMetrics();
           this.outputChannel.error(`response failed model=${selectedModel.requestModel} previousResponseId=${previousResponseId ?? 'none'} message=${message}`);
         },
         onTransportFallback: ({ from, to, reason }) => {
+          reasoningPresenter.flush();
           actualTransport = 'http-fallback';
           latency.mark('connectionAcquired');
           latency.recordContext({ transportActual: actualTransport });
@@ -799,6 +812,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         }
         });
       } finally {
+        reasoningPresenter.close();
         presenter.flushBoundary();
         recordPresentationMetrics();
       }
@@ -1667,13 +1681,17 @@ function createAbortError(): Error {
   return error;
 }
 
-function createThinkingPart(text: string, id?: string): vscode.LanguageModelResponsePart | undefined {
+function createThinkingPart(
+  value: string | string[],
+  id?: string,
+  metadata?: { readonly [key: string]: unknown }
+): vscode.LanguageModelResponsePart | undefined {
   const ThinkingPart = (vscode as VSCodeWithThinkingPart).LanguageModelThinkingPart;
   if (typeof ThinkingPart !== 'function') {
     return undefined;
   }
 
-  return new ThinkingPart(text, id) as vscode.LanguageModelResponsePart;
+  return new ThinkingPart(value, id, metadata) as vscode.LanguageModelResponsePart;
 }
 
 function createUsageDataPart(usage: ResponseUsage | null | undefined): vscode.LanguageModelResponsePart | undefined {

--- a/src/reasoningEffort.ts
+++ b/src/reasoningEffort.ts
@@ -140,8 +140,21 @@ export function resolveReasoningEffort(
   return { effort: undefined, source: 'none', hasExplicitConflict };
 }
 
-export function toResponsesReasoning(effort: ReasoningEffort): Reasoning {
+export interface BuildReasoningOptions {
+  effort: ReasoningEffort;
+  summary?: 'auto' | 'concise' | 'detailed';
+}
+
+export function buildResponsesReasoning(options: BuildReasoningOptions): Reasoning {
   // Codex model catalogs can advertise efforts before the public SDK schema is regenerated.
   // Keep the forward-compatible wire value at this single typed boundary.
-  return { effort } as Reasoning;
+  return {
+    effort: options.effort,
+    ...(options.effort === 'none' || !options.summary ? {} : { summary: options.summary })
+  } as Reasoning;
+}
+
+/** @deprecated Prefer buildResponsesReasoning for new request construction. */
+export function toResponsesReasoning(effort: ReasoningEffort): Reasoning {
+  return buildResponsesReasoning({ effort });
 }

--- a/src/reasoningStreamPresenter.ts
+++ b/src/reasoningStreamPresenter.ts
@@ -1,0 +1,174 @@
+import type { ReasoningStreamDelta } from './responsesClient';
+import { StreamPresenter, type StreamPresentationMetrics } from './streamPresenter';
+
+export type ReasoningPresentationMode = 'idle' | 'reasoning-text' | 'summary' | 'closed';
+
+export interface ReasoningPresentationUpdate {
+  value: string;
+  itemId: string;
+  source: ReasoningStreamDelta['source'];
+  partIndex: number;
+  outputIndex: number;
+  presentationId?: string;
+  phase: number;
+  id: string;
+}
+
+export interface ReasoningStreamPresenterOptions {
+  onBackendDelta?: (at: number) => void;
+}
+
+const MAX_RAW_FALLBACK_CHARACTERS = 8_192;
+
+/** Owns one response's thinking presentation lifecycle, independently of transport and VS Code APIs. */
+export class ReasoningStreamPresenter {
+  private mode: ReasoningPresentationMode = 'idle';
+  private phase = 0;
+  private rawFallback?: { delta: ReasoningStreamDelta; identity: string; text: string };
+  private rawFallbackTruncated = false;
+  private rawBackendDeltaCount = 0;
+  private rawProgressReportCount = 0;
+  private rawFirstBackendDeltaAt?: number;
+  private rawFirstReportAt?: number;
+  private hasPresentedSummary = false;
+  private lastSummaryIdentity?: string;
+  private readonly stream: StreamPresenter;
+
+  constructor(
+    private readonly emit: (update: ReasoningPresentationUpdate) => void,
+    private readonly options: ReasoningStreamPresenterOptions = {}
+  ) {
+    this.stream = new StreamPresenter(
+      (_kind, at) => this.options.onBackendDelta?.(at)
+    );
+  }
+
+  push(delta: ReasoningStreamDelta): void {
+    if (!delta.text || this.mode === 'closed') {
+      return;
+    }
+    if (delta.source === 'reasoning-text' && this.mode === 'summary') {
+      return;
+    }
+
+    if (delta.source === 'reasoning-text') {
+      this.bufferRawFallback(delta);
+      this.mode = 'reasoning-text';
+      return;
+    }
+
+    if (this.mode === 'reasoning-text') {
+      // VS Code concatenates adjacent Thinking parts regardless of their IDs.
+      // Do not report raw deltas before we know whether a server summary exists.
+      this.rawFallback = undefined;
+      this.rawFallbackTruncated = false;
+      this.stream.flushBoundary();
+    }
+
+    this.mode = 'summary';
+    const id = this.summaryIdentity(delta);
+    const isNextSummaryPart = this.hasPresentedSummary && this.lastSummaryIdentity !== id;
+    this.hasPresentedSummary = true;
+    this.lastSummaryIdentity = id;
+    this.stream.push({
+      kind: 'reasoning',
+      identity: id,
+      // IDs are not visual boundaries in VS Code's Thinking renderer. A
+      // textual boundary keeps independently declared summary parts readable.
+      text: `${isNextSummaryPart ? '\n\n' : ''}${delta.text}`,
+      emit: (text) => this.emit({ ...delta, value: text, phase: this.phase, id })
+    });
+  }
+
+  flush(): void {
+    this.stream.flushBoundary();
+  }
+
+  /** Starts a new visual reasoning phase after a tool call. */
+  startNextPhase(): void {
+    this.finishPhase();
+    this.phase += 1;
+    this.mode = 'idle';
+    this.hasPresentedSummary = false;
+    this.lastSummaryIdentity = undefined;
+  }
+
+  close(): void {
+    if (this.mode !== 'closed') {
+      this.finishPhase();
+      this.mode = 'closed';
+    }
+  }
+
+  get presentationMode(): ReasoningPresentationMode {
+    return this.mode;
+  }
+
+  metrics(): StreamPresentationMetrics {
+    const summaryMetrics = this.stream.metrics();
+    return {
+      ...summaryMetrics,
+      backendDeltaCount: summaryMetrics.backendDeltaCount + this.rawBackendDeltaCount,
+      progressReportCount: summaryMetrics.progressReportCount + this.rawProgressReportCount,
+      firstBackendDeltaAt: firstDefined(summaryMetrics.firstBackendDeltaAt, this.rawFirstBackendDeltaAt),
+      firstReportAt: firstDefined(summaryMetrics.firstReportAt, this.rawFirstReportAt)
+    };
+  }
+
+  private finishPhase(): void {
+    if (this.mode === 'reasoning-text') {
+      this.emitRawFallback();
+      return;
+    }
+    this.stream.flushBoundary();
+  }
+
+  private bufferRawFallback(delta: ReasoningStreamDelta): void {
+    const receivedAt = Date.now();
+    this.rawBackendDeltaCount += 1;
+    this.rawFirstBackendDeltaAt ??= receivedAt;
+    this.options.onBackendDelta?.(receivedAt);
+
+    const identity = `${delta.itemId}:${delta.outputIndex}:${delta.partIndex}`;
+    const separator = this.rawFallback && this.rawFallback.identity !== identity ? '\n\n' : '';
+    if (!this.rawFallback) {
+      this.rawFallback = { delta, identity, text: '' };
+    }
+    const remaining = MAX_RAW_FALLBACK_CHARACTERS - this.rawFallback.text.length;
+    if (remaining <= 0) {
+      this.rawFallbackTruncated = true;
+      return;
+    }
+    const addition = `${separator}${delta.text}`;
+    this.rawFallback.text += addition.slice(0, remaining);
+    this.rawFallbackTruncated ||= addition.length > remaining;
+  }
+
+  private emitRawFallback(): void {
+    const rawFallback = this.rawFallback;
+    this.rawFallback = undefined;
+    if (!rawFallback?.text) {
+      return;
+    }
+    const reportedAt = Date.now();
+    const id = `${rawFallback.delta.itemId}:reasoning:reasoning-text:${rawFallback.delta.partIndex}:phase:${this.phase}`;
+    this.emit({
+      ...rawFallback.delta,
+      value: `${rawFallback.text}${this.rawFallbackTruncated ? '\n\n[Reasoning output truncated]' : ''}`,
+      phase: this.phase,
+      id
+    });
+    this.rawProgressReportCount += 1;
+    this.rawFirstReportAt ??= reportedAt;
+    this.rawFallbackTruncated = false;
+  }
+
+  private summaryIdentity(delta: ReasoningStreamDelta): string {
+    const semanticPartId = delta.presentationId ?? String(delta.partIndex);
+    return `${delta.itemId}:reasoning:summary:${semanticPartId}:phase:${this.phase}`;
+  }
+}
+
+function firstDefined(...values: readonly (number | undefined)[]): number | undefined {
+  return values.filter((value): value is number => value !== undefined).sort((left, right) => left - right)[0];
+}

--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -66,6 +66,33 @@ interface ReusableResponsesWebSocketSession {
 
 const reusableWebSocketSessions = new Map<string, ReusableResponsesWebSocketSession>();
 
+export type ReasoningStreamSource = 'summary' | 'reasoning-text';
+
+export interface ReasoningStreamDelta {
+  source: ReasoningStreamSource;
+  text: string;
+  itemId: string;
+  partIndex: number;
+  outputIndex: number;
+  /**
+   * Stable identity for one server-declared reasoning summary part. This is
+   * distinct from summary_index when a backend reuses that index for several
+   * separately rendered summary entries.
+   */
+  presentationId?: string;
+}
+
+export interface ReasoningStreamLifecycleEvent {
+  phase: 'part-added' | 'text-started' | 'text-completed' | 'part-completed';
+  source: ReasoningStreamSource;
+  itemId: string;
+  partIndex: number;
+  outputIndex: number;
+  presentationId?: string;
+  sequenceNumber?: number;
+  textLength?: number;
+}
+
 export interface CountInputTokensOptions {
   baseURL: string;
   apiKey: string;
@@ -104,12 +131,8 @@ export interface StreamResponseTextOptions {
   maxOutputTokens: number;
   token: vscode.CancellationToken;
   onTextDelta: (text: string) => void;
-  onReasoningTextDelta?: (delta: {
-    text: string;
-    itemId: string;
-    contentIndex: number;
-    outputIndex: number;
-  }) => void;
+  onReasoningDelta?: (delta: ReasoningStreamDelta) => void;
+  onReasoningLifecycleEvent?: (event: ReasoningStreamLifecycleEvent) => void;
   onToolCallAdded?: (callId: string, name: string) => void;
   onToolCallArgumentsDelta?: (callId: string, name: string) => void;
   onToolCallArgumentsDone?: (callId: string, name: string) => void;
@@ -555,6 +578,7 @@ async function streamCodexResponseTextOverManagedWebSocket(
         onEvent: (event) => {
           if (event.type === 'response.output_text.delta'
             || event.type === 'response.reasoning_text.delta'
+            || (event as unknown as { type?: string }).type === 'response.reasoning_summary_text.delta'
             || event.type === 'response.function_call_arguments.done'
             || event.type === 'response.output_item.done') {
             visibleActivity = true;
@@ -986,6 +1010,9 @@ function createResponsesServerEventHandler(
 ): (event: ResponsesServerEvent) => void {
   const functionCallsByItemId = new Map<string, { callId: string; name: string }>();
   const reportedFunctionCallItemIds = new Set<string>();
+  const summaryPresentationIdsByPart = new Map<string, string>();
+  const startedReasoningPresentationIds = new Set<string>();
+  let nextSummaryPresentationId = 0;
 
   const reportFunctionCall = (itemId: string, callId: string, name: string, argumentsJson: string) => {
     const normalizedCallId = callId.trim();
@@ -999,6 +1026,86 @@ function createResponsesServerEventHandler(
   };
 
   return (event) => {
+    const reasoningEvent = event as unknown as Record<string, unknown>;
+    if (reasoningEvent.type === 'response.reasoning_summary_part.added') {
+      const itemId = typeof reasoningEvent.item_id === 'string' ? reasoningEvent.item_id : '';
+      const outputIndex = typeof reasoningEvent.output_index === 'number' ? reasoningEvent.output_index : 0;
+      const summaryIndex = typeof reasoningEvent.summary_index === 'number' ? reasoningEvent.summary_index : 0;
+      if (itemId) {
+        const sequenceNumber = typeof reasoningEvent.sequence_number === 'number'
+          ? reasoningEvent.sequence_number
+          : ++nextSummaryPresentationId;
+        const partKey = getSummaryPartKey(itemId, outputIndex, summaryIndex);
+        const presentationId = `summary-part:${sequenceNumber}`;
+        summaryPresentationIdsByPart.set(
+          partKey,
+          presentationId
+        );
+        options.onReasoningLifecycleEvent?.({
+          phase: 'part-added',
+          source: 'summary',
+          itemId,
+          partIndex: summaryIndex,
+          outputIndex,
+          presentationId,
+          sequenceNumber
+        });
+      }
+      return;
+    }
+
+    if (reasoningEvent.type === 'response.reasoning_summary_text.done'
+      || reasoningEvent.type === 'response.reasoning_text.done') {
+      const source: ReasoningStreamSource = reasoningEvent.type === 'response.reasoning_summary_text.done'
+        ? 'summary'
+        : 'reasoning-text';
+      const itemId = typeof reasoningEvent.item_id === 'string' ? reasoningEvent.item_id : '';
+      const outputIndex = typeof reasoningEvent.output_index === 'number' ? reasoningEvent.output_index : 0;
+      const index = source === 'summary' ? reasoningEvent.summary_index : reasoningEvent.content_index;
+      const partIndex = typeof index === 'number' ? index : 0;
+      const partKey = getSummaryPartKey(itemId, outputIndex, partIndex);
+      const presentationId = source === 'summary' ? summaryPresentationIdsByPart.get(partKey) : undefined;
+      const text = typeof reasoningEvent.text === 'string' ? reasoningEvent.text : '';
+      if (itemId) {
+        options.onReasoningLifecycleEvent?.({
+          phase: 'text-completed',
+          source,
+          itemId,
+          partIndex,
+          outputIndex,
+          presentationId,
+          textLength: text.length
+        });
+      }
+      if (source === 'summary') {
+        summaryPresentationIdsByPart.delete(partKey);
+      }
+      return;
+    }
+
+    if (reasoningEvent.type === 'response.reasoning_summary_part.done') {
+      const itemId = typeof reasoningEvent.item_id === 'string' ? reasoningEvent.item_id : '';
+      const outputIndex = typeof reasoningEvent.output_index === 'number' ? reasoningEvent.output_index : 0;
+      const summaryIndex = typeof reasoningEvent.summary_index === 'number' ? reasoningEvent.summary_index : 0;
+      const partKey = getSummaryPartKey(itemId, outputIndex, summaryIndex);
+      const presentationId = summaryPresentationIdsByPart.get(partKey);
+      if (itemId) {
+        options.onReasoningLifecycleEvent?.({
+          phase: 'part-completed',
+          source: 'summary',
+          itemId,
+          partIndex: summaryIndex,
+          outputIndex,
+          presentationId,
+          sequenceNumber: typeof reasoningEvent.sequence_number === 'number'
+            ? reasoningEvent.sequence_number
+            : undefined
+        });
+      }
+      summaryPresentationIdsByPart.delete(partKey);
+      return;
+    }
+
     if (event.type === 'response.output_item.added' && event.item.type === 'function_call') {
       if (event.item.id) {
         functionCallsByItemId.set(event.item.id, {
@@ -1035,8 +1142,35 @@ function createResponsesServerEventHandler(
       return;
     }
 
-    handleResponsesServerEvent(event, options, reportFunctionCall);
+    handleResponsesServerEvent(
+      event,
+      options,
+      reportFunctionCall,
+      (itemId, outputIndex, summaryIndex) => {
+        const partKey = getSummaryPartKey(itemId, outputIndex, summaryIndex);
+        const existingPresentationId = summaryPresentationIdsByPart.get(partKey);
+        if (existingPresentationId) {
+          return existingPresentationId;
+        }
+
+        const presentationId = `summary-fallback:${++nextSummaryPresentationId}`;
+        summaryPresentationIdsByPart.set(partKey, presentationId);
+        return presentationId;
+      },
+      (lifecycleEvent) => {
+        const presentationKey = `${lifecycleEvent.source}:${lifecycleEvent.itemId}:${lifecycleEvent.outputIndex}:${lifecycleEvent.presentationId ?? lifecycleEvent.partIndex}`;
+        if (startedReasoningPresentationIds.has(presentationKey)) {
+          return;
+        }
+        startedReasoningPresentationIds.add(presentationKey);
+        options.onReasoningLifecycleEvent?.(lifecycleEvent);
+      }
+    );
   };
+}
+
+function getSummaryPartKey(itemId: string, outputIndex: number, summaryIndex: number): string {
+  return `${itemId}:${outputIndex}:${summaryIndex}`;
 }
 
 function firstNonEmptyString(...values: string[]): string {
@@ -1046,7 +1180,9 @@ function firstNonEmptyString(...values: string[]): string {
 function handleResponsesServerEvent(
   event: ResponsesServerEvent,
   options: StreamResponseTextOptions,
-  reportFunctionCall: (itemId: string, callId: string, name: string, argumentsJson: string) => void
+  reportFunctionCall: (itemId: string, callId: string, name: string, argumentsJson: string) => void,
+  getSummaryPresentationId?: (itemId: string, outputIndex: number, summaryIndex: number) => string | undefined,
+  reportReasoningTextStarted?: (event: ReasoningStreamLifecycleEvent) => void
 ): void {
   if (event.type === 'response.output_item.done') {
     options.onRawResponseItem?.(event.item);
@@ -1057,13 +1193,39 @@ function handleResponsesServerEvent(
     return;
   }
 
-  if (event.type === 'response.reasoning_text.delta') {
-    options.onReasoningTextDelta?.({
-      text: event.delta,
-      itemId: event.item_id,
-      contentIndex: event.content_index,
-      outputIndex: event.output_index
-    });
+  const reasoningEvent = event as unknown as Record<string, unknown>;
+  if (reasoningEvent.type === 'response.reasoning_summary_text.delta'
+    || reasoningEvent.type === 'response.reasoning_text.delta') {
+    const source: ReasoningStreamSource = reasoningEvent.type === 'response.reasoning_summary_text.delta'
+      ? 'summary'
+      : 'reasoning-text';
+    const text = typeof reasoningEvent.delta === 'string' ? reasoningEvent.delta : '';
+    const itemId = typeof reasoningEvent.item_id === 'string' ? reasoningEvent.item_id : '';
+    const index = source === 'summary' ? reasoningEvent.summary_index : reasoningEvent.content_index;
+    const outputIndex = typeof reasoningEvent.output_index === 'number' ? reasoningEvent.output_index : 0;
+    const partIndex = typeof index === 'number' ? index : 0;
+    if (text && itemId) {
+      const presentationId = source === 'summary'
+        ? getSummaryPresentationId?.(itemId, outputIndex, partIndex)
+        : undefined;
+      options.onReasoningDelta?.({
+        source,
+        text,
+        itemId,
+        partIndex,
+        outputIndex,
+        presentationId
+      });
+      reportReasoningTextStarted?.({
+        phase: 'text-started',
+        source,
+        itemId,
+        partIndex,
+        outputIndex,
+        presentationId,
+        textLength: text.length
+      });
+    }
     return;
   }
 

--- a/src/streamPresenter.ts
+++ b/src/streamPresenter.ts
@@ -15,6 +15,8 @@ export interface StreamPresentationMetrics {
   firstReportAt?: number;
   coalescingDelayP95Ms?: number;
   coalescingDelayMaxMs?: number;
+  /** Internal timing samples used when several presenters share one response. */
+  coalescingDelaysMs: readonly number[];
 }
 
 export interface StreamPresenterTimer {
@@ -124,7 +126,8 @@ export class StreamPresenter {
       firstBackendDeltaAt: this.firstBackendDeltaAt,
       firstReportAt: this.firstReportAt,
       coalescingDelayP95Ms: percentile(delays, 0.95),
-      coalescingDelayMaxMs: delays.at(-1)
+      coalescingDelayMaxMs: delays.at(-1),
+      coalescingDelaysMs: delays
     };
   }
 
@@ -149,9 +152,30 @@ export class StreamPresenter {
   }
 }
 
+/** Combines text and reasoning presentation telemetry for one response stream. */
+export function mergeStreamPresentationMetrics(
+  ...metrics: readonly StreamPresentationMetrics[]
+): StreamPresentationMetrics {
+  const delays = metrics.flatMap((metric) => metric.coalescingDelaysMs).sort((left, right) => left - right);
+  return {
+    backendDeltaCount: metrics.reduce((total, metric) => total + metric.backendDeltaCount, 0),
+    progressReportCount: metrics.reduce((total, metric) => total + metric.progressReportCount, 0),
+    coalescedDeltaCount: metrics.reduce((total, metric) => total + metric.coalescedDeltaCount, 0),
+    firstBackendDeltaAt: firstDefined(metrics.map((metric) => metric.firstBackendDeltaAt)),
+    firstReportAt: firstDefined(metrics.map((metric) => metric.firstReportAt)),
+    coalescingDelayP95Ms: percentile(delays, 0.95),
+    coalescingDelayMaxMs: delays.at(-1),
+    coalescingDelaysMs: delays
+  };
+}
+
 function percentile(values: readonly number[], fraction: number): number | undefined {
   if (values.length === 0) {
     return undefined;
   }
   return values[Math.min(values.length - 1, Math.ceil(values.length * fraction) - 1)];
+}
+
+function firstDefined(values: readonly (number | undefined)[]): number | undefined {
+  return values.filter((value): value is number => value !== undefined).sort((left, right) => left - right)[0];
 }

--- a/test/realBackendProbe.mjs
+++ b/test/realBackendProbe.mjs
@@ -21,6 +21,13 @@ const shouldRunToolContinuationProbe = process.env.CODEX_TEST_TOOL_CONTINUATION 
 const requestStore = process.env.CODEX_TEST_STORE === '1';
 const requestedPrewarm = parsePrewarmSetting(process.env.CODEX_TEST_PREWARM);
 const requestedReasoningEffort = parseReasoningEffort(process.env.CODEX_TEST_REASONING_EFFORT);
+const requestedReasoning = requestedReasoningEffort
+  ? {
+      effort: requestedReasoningEffort,
+      ...(requestedReasoningEffort === 'none' ? {} : { summary: 'auto' })
+    }
+  : undefined;
+const requireReasoningSummary = process.env.CODEX_TEST_REQUIRE_REASONING_SUMMARY === '1';
 const requestTimeoutMs = parsePositiveInteger(process.env.CODEX_TEST_TIMEOUT_MS, 60_000);
 const requestServiceTier = requestedServiceTier === 'fast'
   ? 'priority'
@@ -112,6 +119,7 @@ try {
   assertEqual(credentials.omitMaxOutputTokens, true, 'omit max_output_tokens');
 
   const deltas = [];
+  const reasoningSources = new Set();
   const sessionEvents = [];
   const transportMetrics = [];
   let createdServiceTier = null;
@@ -175,11 +183,12 @@ try {
     model: requestedModel,
     instructions: 'You are a test assistant.',
     ...(requestServiceTier ? { serviceTier: requestServiceTier } : {}),
-    ...(requestedReasoningEffort ? { reasoning: { effort: requestedReasoningEffort } } : {}),
+    ...(requestedReasoning ? { reasoning: requestedReasoning } : {}),
     input: [{ role: 'user', content: 'Reply with OK only.' }],
     maxOutputTokens: 32,
     token,
     onTextDelta: (text) => deltas.push(text),
+    onReasoningDelta: ({ source }) => reasoningSources.add(source),
     onResponseCreated: (response) => {
       createdServiceTier = response.service_tier ?? null;
       previousResponseId = response.id ?? previousResponseId;
@@ -200,6 +209,9 @@ try {
   }));
 
   assertEqual(deltas.join('').trim(), 'OK', 'real backend output');
+  if (requireReasoningSummary && requestedReasoningEffort && requestedReasoningEffort !== 'none') {
+    assertEqual(reasoningSources.has('summary'), true, 'real backend reasoning summary stream');
+  }
   if (runPreconnectionProbe) {
     assertEqual(sessionEvents[0]?.origin, 'preconnected', 'real backend preconnection origin');
     preconnection = { ...preconnection, formalConnectionOrigin: sessionEvents[0].origin };
@@ -234,7 +246,7 @@ try {
       model: requestedModel,
       instructions: 'You are a test assistant.',
       ...(requestServiceTier ? { serviceTier: requestServiceTier } : {}),
-      ...(requestedReasoningEffort ? { reasoning: { effort: requestedReasoningEffort } } : {}),
+      ...(requestedReasoning ? { reasoning: requestedReasoning } : {}),
       input: [{ role: 'user', content: 'Reply with PONG only.' }],
       maxOutputTokens: 32,
       token: undefined,
@@ -291,6 +303,8 @@ try {
     requestStore,
     requestedPrewarm,
     requestedReasoningEffort: requestedReasoningEffort ?? null,
+    requireReasoningSummary,
+    reasoningSources: [...reasoningSources],
     requestedServiceTier: requestedServiceTier ?? null,
     requestServiceTier: requestServiceTier ?? null,
     createdServiceTier,

--- a/test/smokeCodexRequestBuilder.mjs
+++ b/test/smokeCodexRequestBuilder.mjs
@@ -36,6 +36,11 @@ try {
     reasoning: undefined,
     tools: []
   });
+  const noReasoningRequest = buildCodexResponsesRequest({
+    ...base,
+    reasoning: { effort: 'none', summary: 'auto' },
+    tools: []
+  });
   const standardRequest = buildCodexResponsesRequest({
     ...base,
     compatibilityEnabled: false,
@@ -71,6 +76,7 @@ try {
   assertEqual(request.include[0], 'reasoning.encrypted_content', 'encrypted reasoning include');
   assertEqual(JSON.stringify(request.reasoning), JSON.stringify({ effort: 'high', summary: 'auto' }), 'explicit compatibility reasoning preserved');
   assertEqual(JSON.stringify(compatibilityDefaultReasoningRequest.reasoning), JSON.stringify({ effort: 'medium', summary: 'auto' }), 'compatibility default reasoning is normalized');
+  assertEqual(JSON.stringify(noReasoningRequest.reasoning), JSON.stringify({ effort: 'none' }), 'none does not request a reasoning summary');
   assertEqual(compatibilityDefaultReasoningRequest.include[0], 'reasoning.encrypted_content', 'compatibility default reasoning requests encrypted content');
   assertEqual('reasoning' in standardRequest, false, 'standard request does not add default reasoning');
   assertEqual('include' in standardRequest, false, 'standard request does not request encrypted reasoning');

--- a/test/smokeCodexWebSocketLifecycle.mjs
+++ b/test/smokeCodexWebSocketLifecycle.mjs
@@ -124,7 +124,7 @@ try {
       text.push(delta);
       presentation.push({ type: 'text', delta });
     },
-    onReasoningTextDelta: (delta) => reasoningDeltas.push(delta),
+    onReasoningDelta: (delta) => reasoningDeltas.push(delta),
     onToolCall: (callId, name, input) => {
       toolCalls.push({ callId, name, input });
       presentation.push({ type: 'tool', callId });
@@ -164,9 +164,10 @@ try {
     input: { number: 10 }
   }]), 'managed WebSocket reports a function call once');
   assertEqual(JSON.stringify(reasoningDeltas), JSON.stringify([{
+    source: 'reasoning-text',
     text: 'Planning',
     itemId: 'rs_managed',
-    contentIndex: 0,
+    partIndex: 0,
     outputIndex: 0
   }]), 'managed WebSocket reasoning item identity');
   assertEqual(rawItems.length, 2, 'raw output items retained');

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -1076,11 +1076,10 @@ async function runInterleavedResponsePresentationSmokeTest() {
         ? { type: 'thinking', value: part.value, id: part.id }
         : { type: 'text', value: part.value });
     assertEqual(JSON.stringify(presentation), JSON.stringify([
-      { type: 'thinking', value: 'Optimized ', id: 'rs_planning:0' },
-      { type: 'thinking', value: 'tool selection', id: 'rs_planning:0' },
+      { type: 'thinking', value: 'Optimized tool selection', id: 'rs_planning:reasoning:reasoning-text:0:phase:0' },
       { type: 'text', value: '我先看一下仓库的' },
       { type: 'text', value: '结构。' }
-    ]), 'interleaved reasoning does not interrupt visible text streaming');
+    ]), 'raw reasoning falls back as one bounded Thinking part before visible text');
   } finally {
     await closeServer(server);
   }
@@ -1387,7 +1386,13 @@ async function runContinuationMissAfterVisibleOutputSmokeTest() {
       'cache-control': 'no-cache',
       connection: 'keep-alive'
     });
-    response.write(`data: ${JSON.stringify({ type: 'response.output_text.delta', delta: 'partial visible output' })}\n\n`);
+    response.write(`data: ${JSON.stringify({
+      type: 'response.reasoning_summary_text.delta',
+      item_id: 'rs_visible_summary',
+      output_index: 0,
+      summary_index: 0,
+      delta: 'partial visible reasoning'
+    })}\n\n`);
     response.write(`data: ${JSON.stringify({
       type: 'response.failed',
       response: {
@@ -1471,9 +1476,9 @@ async function runContinuationMissAfterVisibleOutputSmokeTest() {
     assertEqual(responseRequests.length, 2, 'visible continuation miss is never replayed');
     assertEqual(responseRequests[1].previous_response_id, 'resp_visible_initial', 'visible continuation uses prior response');
     assertEqual(
-      visibleParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
-      'partial visible output',
-      'visible continuation output is emitted once'
+      visibleParts.filter((part) => part instanceof LanguageModelThinkingPart).map((part) => part.value).join(''),
+      'partial visible reasoning',
+      'visible reasoning continuation output is emitted once'
     );
     assertEqual(
       warnings.some((entry) => entry.message === 'response continuation reset'),
@@ -1511,9 +1516,9 @@ async function runContinuationMissAfterVisibleOutputSmokeTest() {
       'next turn reports only new-chain output'
     );
     assertEqual(
-      visibleParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
-      'partial visible output',
-      'visible continuation output remains unduplicated after the next turn'
+      visibleParts.filter((part) => part instanceof LanguageModelThinkingPart).map((part) => part.value).join(''),
+      'partial visible reasoning',
+      'visible reasoning continuation output remains unduplicated after the next turn'
     );
     assertEqual(
       warnings.some((entry) => entry.message === 'response continuation reset'),

--- a/test/smokeReasoningEffort.mjs
+++ b/test/smokeReasoningEffort.mjs
@@ -44,6 +44,7 @@ const {
   normalizeKnownReasoningEffort,
   normalizeReasoningEffort,
   resolveReasoningEffort,
+  buildResponsesReasoning,
   toResponsesReasoning
 } = require(reasoningBundlePath);
 const { buildProviderModels } = require(modelsBundlePath);
@@ -114,6 +115,16 @@ try {
     'request-level effort keeps precedence and reports conflicts'
   );
   assertEqual(toResponsesReasoning('ultra').effort, 'ultra', 'Ultra remains unchanged at the SDK boundary');
+  assertEqual(
+    JSON.stringify(buildResponsesReasoning({ effort: 'high', summary: 'auto' })),
+    JSON.stringify({ effort: 'high', summary: 'auto' }),
+    'explicit reasoning summary is preserved'
+  );
+  assertEqual(
+    JSON.stringify(buildResponsesReasoning({ effort: 'none', summary: 'auto' })),
+    JSON.stringify({ effort: 'none' }),
+    'none omits reasoning summary'
+  );
 
   console.log('Smoke test passed: catalog reasoning efforts are selectable, forward-compatible, and preserved on the wire.');
 } finally {

--- a/test/smokeReasoningStreamPresenter.mjs
+++ b/test/smokeReasoningStreamPresenter.mjs
@@ -1,0 +1,61 @@
+import { loadBundled, assertEqual } from './testBundleHelper.mjs';
+
+const loaded = await loadBundled('src/reasoningStreamPresenter.ts');
+try {
+  const { ReasoningStreamPresenter } = loaded.exports;
+  const emitted = [];
+  const presenter = new ReasoningStreamPresenter((update) => emitted.push(update));
+  const raw = (text) => presenter.push({
+    source: 'reasoning-text', text, itemId: 'rs_1', partIndex: 0, outputIndex: 0
+  });
+  const summary = (text, presentationId) => presenter.push({
+    source: 'summary', text, itemId: 'rs_1', partIndex: 0, outputIndex: 0, presentationId
+  });
+
+  raw('Raw ');
+  raw('reasoning');
+  summary('Summary', 'summary-part:1');
+  summary('Next summary part', 'summary-part:2');
+  presenter.startNextPhase();
+  summary('Post-tool plan', 'summary-part:2');
+  presenter.close();
+  summary(' late');
+
+  assertEqual(JSON.stringify(emitted.map(({ value, id, source }) => ({ value, id, source }))), JSON.stringify([
+    { value: 'Summary', id: 'rs_1:reasoning:summary:summary-part:1:phase:0', source: 'summary' },
+    { value: '\n\nNext summary part', id: 'rs_1:reasoning:summary:summary-part:2:phase:0', source: 'summary' },
+    { value: 'Post-tool plan', id: 'rs_1:reasoning:summary:summary-part:2:phase:1', source: 'summary' }
+  ]), 'summary is streamed immediately and replaces unreported raw reasoning');
+  assertEqual(
+    aggregateAdjacentThinking(emitted.slice(0, 2)),
+    'Summary\n\nNext summary part',
+    'VS Code-style adjacent Thinking aggregation keeps distinct summary parts readable'
+  );
+  assertEqual(presenter.metrics().backendDeltaCount, 5, 'raw and summary backend deltas are included in metrics');
+  assertEqual(presenter.metrics().progressReportCount, 3, 'only visible summary reports are counted');
+  assertEqual(presenter.presentationMode, 'closed', 'close seals one response reasoning stream');
+
+  const rawOnly = [];
+  const rawOnlyPresenter = new ReasoningStreamPresenter((update) => rawOnly.push(update));
+  rawOnlyPresenter.push({
+    source: 'reasoning-text', text: 'No summary was returned.', itemId: 'rs_raw', partIndex: 0, outputIndex: 0
+  });
+  rawOnlyPresenter.close();
+  assertEqual(
+    JSON.stringify(rawOnly.map(({ value, id }) => ({ value, id }))),
+    JSON.stringify([{
+      value: 'No summary was returned.',
+      id: 'rs_raw:reasoning:reasoning-text:0:phase:0'
+    }]),
+    'raw reasoning is emitted only as the bounded no-summary fallback'
+  );
+  console.log('Smoke test passed: reasoning summary streaming uses VS Code-safe aggregation and bounded raw fallback.');
+} finally {
+  await loaded.dispose();
+}
+
+// Mirrors VS Code's relevant renderer contract: adjacent non-empty Thinking
+// parts concatenate even when their IDs and metadata differ.
+function aggregateAdjacentThinking(parts) {
+  return parts.map((part) => part.value).join('');
+}

--- a/test/smokeResponsesClient.mjs
+++ b/test/smokeResponsesClient.mjs
@@ -180,7 +180,82 @@ async function runHttpTransportSmokeTest(streamResponseText) {
       body: JSON.parse(Buffer.concat(chunks).toString('utf8'))
     };
 
-    writeSseResponse(response, ['hello', ' world']);
+    writeSseResponse(response, [
+      {
+        type: 'response.reasoning_summary_part.added',
+        item_id: 'rs_http',
+        summary_index: 1,
+        output_index: 0,
+        sequence_number: 1,
+        part: { type: 'summary_text', text: '' }
+      },
+      {
+        type: 'response.reasoning_summary_text.delta',
+        item_id: 'rs_http',
+        summary_index: 1,
+        output_index: 0,
+        delta: 'Brief plan'
+      },
+      {
+        type: 'response.reasoning_summary_text.done',
+        item_id: 'rs_http',
+        summary_index: 1,
+        output_index: 0,
+        text: 'Brief plan'
+      },
+      {
+        type: 'response.reasoning_summary_part.added',
+        item_id: 'rs_http',
+        summary_index: 1,
+        output_index: 0,
+        sequence_number: 2,
+        part: { type: 'summary_text', text: '' }
+      },
+      {
+        type: 'response.reasoning_summary_text.delta',
+        item_id: 'rs_http',
+        summary_index: 1,
+        output_index: 0,
+        delta: 'Next step'
+      },
+      {
+        type: 'response.reasoning_summary_text.done',
+        item_id: 'rs_http',
+        summary_index: 1,
+        output_index: 0,
+        text: 'Next step'
+      },
+      {
+        type: 'response.reasoning_summary_text.delta',
+        item_id: 'rs_fallback',
+        summary_index: 0,
+        output_index: 0,
+        delta: 'Fallback one'
+      },
+      {
+        type: 'response.reasoning_summary_text.done',
+        item_id: 'rs_fallback',
+        summary_index: 0,
+        output_index: 0,
+        text: 'Fallback one'
+      },
+      {
+        type: 'response.reasoning_summary_text.delta',
+        item_id: 'rs_fallback',
+        summary_index: 0,
+        output_index: 0,
+        delta: 'Fallback two'
+      },
+      {
+        type: 'response.reasoning_summary_text.done',
+        item_id: 'rs_fallback',
+        summary_index: 0,
+        output_index: 0,
+        text: 'Fallback two'
+      },
+      { type: 'response.output_text.delta', delta: 'hello' },
+      { type: 'response.output_text.delta', delta: ' world' }
+    ]);
   });
 
   await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
@@ -188,6 +263,8 @@ async function runHttpTransportSmokeTest(streamResponseText) {
   try {
     const address = server.address();
     const deltas = [];
+    const reasoningDeltas = [];
+    const reasoningLifecycleEvents = [];
 
     await streamResponseText({
       baseURL: `http://127.0.0.1:${address.port}/backend-api/codex/responses`,
@@ -200,11 +277,38 @@ async function runHttpTransportSmokeTest(streamResponseText) {
       input: [{ role: 'user', content: 'Ping' }],
       maxOutputTokens: 32,
       token: createCancellationToken(),
-      onTextDelta: (text) => deltas.push(text)
+      onTextDelta: (text) => deltas.push(text),
+      onReasoningDelta: (delta) => reasoningDeltas.push(delta),
+      onReasoningLifecycleEvent: (event) => reasoningLifecycleEvents.push(event)
     });
 
     assertHttpRequest(capturedRequest, '/backend-api/codex/responses');
     assertEqual(deltas.join(''), 'hello world', 'HTTP streamed text');
+    assertEqual(JSON.stringify(reasoningDeltas), JSON.stringify([{
+      source: 'summary', text: 'Brief plan', itemId: 'rs_http', partIndex: 1, outputIndex: 0,
+      presentationId: 'summary-part:1'
+    }, {
+      source: 'summary', text: 'Next step', itemId: 'rs_http', partIndex: 1, outputIndex: 0,
+      presentationId: 'summary-part:2'
+    }, {
+      source: 'summary', text: 'Fallback one', itemId: 'rs_fallback', partIndex: 0, outputIndex: 0,
+      presentationId: 'summary-fallback:1'
+    }, {
+      source: 'summary', text: 'Fallback two', itemId: 'rs_fallback', partIndex: 0, outputIndex: 0,
+      presentationId: 'summary-fallback:2'
+    }]), 'HTTP normalizes reasoning summary item identity');
+    assertEqual(JSON.stringify(reasoningLifecycleEvents), JSON.stringify([
+      { phase: 'part-added', source: 'summary', itemId: 'rs_http', partIndex: 1, outputIndex: 0, presentationId: 'summary-part:1', sequenceNumber: 1 },
+      { phase: 'text-started', source: 'summary', itemId: 'rs_http', partIndex: 1, outputIndex: 0, presentationId: 'summary-part:1', textLength: 10 },
+      { phase: 'text-completed', source: 'summary', itemId: 'rs_http', partIndex: 1, outputIndex: 0, presentationId: 'summary-part:1', textLength: 10 },
+      { phase: 'part-added', source: 'summary', itemId: 'rs_http', partIndex: 1, outputIndex: 0, presentationId: 'summary-part:2', sequenceNumber: 2 },
+      { phase: 'text-started', source: 'summary', itemId: 'rs_http', partIndex: 1, outputIndex: 0, presentationId: 'summary-part:2', textLength: 9 },
+      { phase: 'text-completed', source: 'summary', itemId: 'rs_http', partIndex: 1, outputIndex: 0, presentationId: 'summary-part:2', textLength: 9 },
+      { phase: 'text-started', source: 'summary', itemId: 'rs_fallback', partIndex: 0, outputIndex: 0, presentationId: 'summary-fallback:1', textLength: 12 },
+      { phase: 'text-completed', source: 'summary', itemId: 'rs_fallback', partIndex: 0, outputIndex: 0, presentationId: 'summary-fallback:1', textLength: 12 },
+      { phase: 'text-started', source: 'summary', itemId: 'rs_fallback', partIndex: 0, outputIndex: 0, presentationId: 'summary-fallback:2', textLength: 12 },
+      { phase: 'text-completed', source: 'summary', itemId: 'rs_fallback', partIndex: 0, outputIndex: 0, presentationId: 'summary-fallback:2', textLength: 12 }
+    ]), 'reasoning lifecycle logs structural boundaries without retaining reasoning text');
   } finally {
     server.close();
   }
@@ -680,7 +784,7 @@ async function runWebSocketTransportSmokeTest(streamResponseText) {
       maxOutputTokens: 32,
       token: createCancellationToken(),
       onTextDelta: (text) => deltas.push(text),
-      onReasoningTextDelta: (delta) => reasoningDeltas.push(delta),
+      onReasoningDelta: (delta) => reasoningDeltas.push(delta),
       onWebSocketSession: (event) => {
         sessionEvent = event;
       }
@@ -699,9 +803,10 @@ async function runWebSocketTransportSmokeTest(streamResponseText) {
     assertEqual(JSON.stringify(capturedClientEvent.input), JSON.stringify([{ role: 'user', content: 'Ping' }]), 'WebSocket input');
     assertEqual(deltas.join(''), 'hello websocket', 'WebSocket streamed text');
     assertEqual(JSON.stringify(reasoningDeltas), JSON.stringify([{
+      source: 'reasoning-text',
       text: 'Planning',
       itemId: 'rs_ws',
-      contentIndex: 0,
+      partIndex: 0,
       outputIndex: 0
     }]), 'WebSocket reasoning item identity');
     assertEqual(sessionEvent?.reused, false, 'WebSocket initial session reuse state');
@@ -1387,7 +1492,10 @@ function writeSseResponse(response, deltas) {
   });
 
   for (const delta of deltas) {
-    response.write(`data: ${JSON.stringify({ type: 'response.output_text.delta', delta })}\n\n`);
+    const event = typeof delta === 'string'
+      ? { type: 'response.output_text.delta', delta }
+      : delta;
+    response.write(`data: ${JSON.stringify(event)}\n\n`);
   }
 
   response.write('data: {"type":"response.completed","response":{"id":"resp_mock","object":"response","status":"completed"}}\n\n');


### PR DESCRIPTION
## Summary

- stream reasoning-summary deltas immediately through one stable, bounded Thinking presentation path
- prefer summaries over raw reasoning: raw output is held back and emitted only as an 8 KiB no-summary fallback, preventing VS Code from concatenating raw reasoning and its summary
- keep separately declared summary parts readable with explicit Markdown boundaries instead of relying on Thinking part IDs
- route text, reasoning, and tool-call reports through a shared visible-output path so continuation recovery, first-visible latency, and aggregated presentation metrics are correct
- extend the real-backend probe to request summaries, record returned reasoning event sources, and optionally require a summary event with `CODEX_TEST_REQUIRE_REASONING_SUMMARY=1`

## Validation

- `npm run check`
- `npm run test:smoke`
- `CODEX_TEST_MODEL=gpt-5.6-sol CODEX_TEST_REASONING_EFFORT=low npm run test:real-backend`

The live HTTP probe passed and confirmed the request path with `summary: "auto"`; its intentionally minimal `OK` prompt produced no reasoning events, so this PR does not claim a live summary-event assertion from that run. The mock HTTP/WebSocket and provider tests cover summary streaming, VS Code-style Thinking concatenation, and a continuation miss after visible reasoning.

`npm run test:extension-host` cannot start in this headless container (no X server). CI remains the Extension Host gate.