### PR TITLE
ci(release): enforce squash-based changelog metadata

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,49 @@
+name: Pull Request Title
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate Conventional Commit title
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Check pull request title
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(feat|fix|perf|revert|docs|refactor|test|build|ci|chore)(\([a-z0-9][a-z0-9._/-]*\))?!?:[[:space:]].+'
+
+          if [[ "${PR_TITLE}" =~ ${pattern} ]]; then
+            exit 0
+          fi
+
+          cat <<'EOF'
+          Pull request titles must follow Conventional Commits so squash merges
+          produce exactly one Release Please changelog entry.
+
+          Examples:
+            feat(auth): add native ChatGPT OAuth sign-in
+            fix(streaming): preserve visible output metrics
+            perf(transport): reduce websocket startup latency
+            chore(master): release 1.4.2
+          EOF
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,14 @@ This changelog is maintained by Release Please from Conventional Commit titles m
 
 ### Bug Fixes
 
-* improve Codex reasoning thinking presentation ([abb6ca2](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/abb6ca235d402c0f27377d5f62faa89c441f67ec))
-* improve Codex reasoning thinking presentation ([f12c766](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/f12c766014e4ad39bee9f1c6a795151660eb8608))
+* improve Codex reasoning thinking presentation ([#56](https://github.com/GaussianGuaicai/Codex-For-Copilot/pull/56)) ([abb6ca2](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/abb6ca235d402c0f27377d5f62faa89c441f67ec))
 
 ## [1.4.0](https://github.com/GaussianGuaicai/Codex-For-Copilot/compare/v1.3.3...v1.4.0) (2026-07-27)
 
 
 ### Features
 
-* **auth:** add native ChatGPT OAuth sign-in ([ce83ec2](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/ce83ec2dc23dc0d7bc7c433f02a7081df755a863))
-* **auth:** add native ChatGPT OAuth sign-in ([8a65566](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/8a65566bfb2d53fa41028d66b8b4d09f9bf57125))
+* **auth:** add native ChatGPT OAuth sign-in ([#52](https://github.com/GaussianGuaicai/Codex-For-Copilot/pull/52)) ([ce83ec2](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/ce83ec2dc23dc0d7bc7c433f02a7081df755a863))
 
 ## [1.3.3](https://github.com/GaussianGuaicai/Codex-For-Copilot/compare/v1.3.2...v1.3.3) (2026-07-26)
 
@@ -54,8 +52,7 @@ This changelog is maintained by Release Please from Conventional Commit titles m
 
 * classify wrapped continuation misses ([80da656](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/80da656fc4fcd1769e9c8aab11cefd11005bca29))
 * invalidate stale continuation branches ([f45a755](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/f45a755f9a84fca70172ea311814ae63d8c7e23d))
-* match IPv6 no_proxy hosts ([47f7856](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/47f78567b5dae52259aa9d45640ad15affd8aeda))
-* match IPv6 no_proxy hosts ([8edd2ad](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/8edd2adb9540b4b06a3f895df6826fa111746aa3))
+* match IPv6 no_proxy hosts ([#26](https://github.com/GaussianGuaicai/Codex-For-Copilot/pull/26)) ([47f7856](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/47f78567b5dae52259aa9d45640ad15affd8aeda))
 * recover wrapped continuation misses ([ed38c37](https://github.com/GaussianGuaicai/Codex-For-Copilot/commit/ed38c37363bb37cd15f2e0ef42431987e995c103))
 
 ## [1.2.0](https://github.com/GaussianGuaicai/Codex-For-Copilot/compare/v1.1.2...v1.2.0) (2026-07-19)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,6 +27,19 @@ In **Settings → Actions → General**, confirm that workflow permissions allow
 
 Release Please uses the repository `GITHUB_TOKEN`, so the release pull request it creates does not automatically trigger another `pull_request` workflow. The publishing job runs the complete check, compile, and smoke-test sequence after the release pull request is merged. To validate the generated release branch before merging, manually run **Pull Request CI** and select the Release Please branch in the workflow branch selector.
 
+### Merge policy
+
+Treat each pull request as one release unit. In **Settings → General → Pull Requests**:
+
+- enable **Allow squash merging**;
+- set the default squash commit message to the pull request title;
+- disable **Allow merge commits**;
+- disable **Allow rebase merging**.
+
+For stronger enforcement, add a ruleset for `master` with **Require linear history** enabled. These settings ensure that one pull request produces one commit on `master`, so Release Please produces one changelog entry instead of separately reading both an original commit and a merge commit.
+
+The lightweight **Pull Request Title** workflow validates the title whenever a pull request is opened or renamed. Keep that check required in the `master` ruleset so every squash commit remains valid Conventional Commit metadata.
+
 ## Version selection
 
 Use Conventional Commit prefixes in the final pull request title used for squash merging:


### PR DESCRIPTION
## Summary

- add a lightweight `Pull Request Title` workflow that validates Conventional Commit PR titles on open, rename, update, and reopen events
- document the repository merge policy required for one PR → one `master` commit → one Release Please changelog entry
- remove the existing duplicate entries from releases 1.2.1, 1.4.0, and 1.4.1 while retaining links to their pull requests and merge commits

## Design

The title check is implemented with native Bash only. It has read-only permissions, no checkout, no third-party action dependency, and a two-minute timeout. It accepts the release-visible types configured by Release Please, including scoped and breaking-change titles.

## Validation

- compared the branch against `master`: three intended files changed
- exercised the title regex against valid scoped, unscoped, and breaking-change examples plus invalid casing and empty-scope examples
- verified the branch is based on the current `master` head

## Repository settings after merge

The GitHub App cannot change repository merge-policy settings through the available API. In **Settings → General → Pull Requests**:

- enable **Allow squash merging**
- default the squash commit message to the PR title
- disable **Allow merge commits**
- disable **Allow rebase merging**

Then add or update the `master` ruleset to require linear history and require the **Validate Conventional Commit title** status check.