### PR TITLE
fix: improve extension logging diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,21 @@ Open VS Code Chat, choose **Codex** from the model picker, and start chatting or
 
 - `Codex: Manage`
 - `Codex: Open Settings`
-- `Codex: Open Debug Logs`
+- `Codex: Open Logs`
 - `Codex: Refresh Account Limits`
 - `Codex for Copilot: Sign in with ChatGPT`
 - `Codex for Copilot: Sign in with Device Code`
 - `Codex for Copilot: Import Codex auth.json`
 - `Codex for Copilot: Show Auth Status`
 - `Codex for Copilot: Sign Out`
+
+## Diagnostics and privacy
+
+Use **Codex: Open Logs** to view the extension's structured VS Code log channel. Each model request, authentication flow, model discovery operation, and account-limit refresh receives an `operationId`; search for that value to follow one operation through retries, WebSocket fallback, and completion.
+
+The channel follows VS Code's native log level. Use **Developer: Set Log Level...** and select the Codex channel to enable Debug or Trace detail when investigating a problem.
+
+Logs never include prompt or instruction text, reasoning, tool arguments/results, credentials, cookies, or Turn State. They retain only safe counts, sizes, hashes, identifiers hashed for correlation, transport decisions, and redacted error metadata.
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:benchmark-backend": "node test/benchmarkBackend.mjs",
     "test:benchmark-provider": "node test/benchmarkProviderBackend.mjs",
     "test:codex-parity": "node test/smokeCodexProtocol.mjs && node test/smokeCodexIdentity.mjs && node test/smokeCodexRequestBuilder.mjs && node test/smokeCodexToolSchemaCache.mjs && node test/smokeCodexTurnLifecycle.mjs && node test/smokeCodexHttpLifecycle.mjs && node test/smokeCodexWebSocketLifecycle.mjs && node test/smokeCodexPreconnection.mjs && node test/smokeCodexPrewarmBudget.mjs && node test/smokeCodexCancellation.mjs && node test/smokeCodexFallback.mjs && node test/smokeCodexCompression.mjs",
-    "test:smoke": "npm run test:codex-parity && node test/smokeReasoningEffort.mjs && node test/smokeCodexLatency.mjs && node test/smokeStreamPresenter.mjs && node test/smokeReasoningStreamPresenter.mjs && node test/smokeCodexModelCache.mjs && node test/smokeResponsesClient.mjs && node test/smokeProviderFallback.mjs && node test/smokeConversationReuse.mjs && node test/smokeAccountUsage.mjs && node test/smokeAuth.mjs",
+    "test:smoke": "npm run test:codex-parity && node test/smokeCodexLogger.mjs && node test/smokeReasoningEffort.mjs && node test/smokeCodexLatency.mjs && node test/smokeStreamPresenter.mjs && node test/smokeReasoningStreamPresenter.mjs && node test/smokeCodexModelCache.mjs && node test/smokeResponsesClient.mjs && node test/smokeProviderFallback.mjs && node test/smokeConversationReuse.mjs && node test/smokeAccountUsage.mjs && node test/smokeAuth.mjs",
     "watch": "tsc -watch -p ./",
     "vscode:prepublish": "npm run compile"
   },
@@ -75,7 +75,7 @@
       },
       {
         "command": "codexModelProvider.openDebugLogs",
-        "title": "Codex: Open Debug Logs"
+        "title": "Codex: Open Logs"
       },
       {
         "command": "codexModelProvider.openSettings",

--- a/src/accountUsageStatusBar.ts
+++ b/src/accountUsageStatusBar.ts
@@ -108,7 +108,7 @@ export class CodexAccountUsageStatusBar implements vscode.Disposable {
       });
       this.lastSnapshot = snapshot;
       this.render(snapshot);
-      logger.info('refresh.completed', {
+      logger.debug('refresh.completed', {
         selectedModel: this.selectedModel,
         rateLimitCount: snapshot.limits.length,
         creditBudgetCount: snapshot.creditBudgets.length

--- a/src/accountUsageStatusBar.ts
+++ b/src/accountUsageStatusBar.ts
@@ -3,6 +3,7 @@ import { buildCodexAccountUsageDisplay, fetchCodexAccountUsage, type CodexAccoun
 import type { CodexAuthManager } from './auth/codexAuthManager';
 import { getProviderConfig } from './config';
 import { getApiCredentials } from './secrets';
+import { type CodexLogSink, CodexLogger, createCodexLogger } from './codexLogger';
 
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -13,12 +14,14 @@ export class CodexAccountUsageStatusBar implements vscode.Disposable {
   private lastSnapshot?: CodexAccountUsageSnapshot;
   private refreshInFlight?: Promise<void>;
   private selectedModel = getProviderConfig().model;
+  private readonly logger: CodexLogger;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
-    private readonly outputChannel: vscode.LogOutputChannel,
+    logger: CodexLogger | CodexLogSink,
     private readonly authManager?: CodexAuthManager
   ) {
+    this.logger = logger instanceof CodexLogger ? logger : createCodexLogger(logger, 'account-usage');
     this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 101);
     this.statusBarItem.name = 'Codex Account Limits';
     this.statusBarItem.command = 'codexModelProvider.refreshAccountLimits';
@@ -86,12 +89,14 @@ export class CodexAccountUsageStatusBar implements vscode.Disposable {
   }
 
   private async refreshNow(): Promise<void> {
+    const logger = this.logger.operation('account-usage.refresh');
     const config = getProviderConfig();
     const credentials = await getApiCredentials(this.context, this.authManager);
 
     if (!credentials || credentials.kind !== 'codexAccessToken') {
       this.lastSnapshot = undefined;
       this.statusBarItem.hide();
+      logger.debug('refresh.skipped', { reason: 'credentials-unavailable' });
       return;
     }
 
@@ -103,10 +108,13 @@ export class CodexAccountUsageStatusBar implements vscode.Disposable {
       });
       this.lastSnapshot = snapshot;
       this.render(snapshot);
-    } catch (error) {
-      this.outputChannel.warn('Codex account usage refresh failed', {
-        message: error instanceof Error ? error.message : String(error)
+      logger.info('refresh.completed', {
+        selectedModel: this.selectedModel,
+        rateLimitCount: snapshot.limits.length,
+        creditBudgetCount: snapshot.creditBudgets.length
       });
+    } catch (error) {
+      logger.warn('refresh.failed', { error });
 
       if (this.lastSnapshot) {
         this.render(this.lastSnapshot);

--- a/src/auth/codexAuthManager.ts
+++ b/src/auth/codexAuthManager.ts
@@ -8,6 +8,7 @@ import { CodexOAuthClient, type OAuthTokens } from './codexOAuthClient';
 import { signInWithLoopback } from './codexLoopbackLogin';
 import { signInWithDeviceCode } from './codexDeviceCodeLogin';
 import { AuthRequiredError, type CodexAuthChangeEvent, type CodexAuthStatus, type CodexCredentialRecord, type CodexCredentialSnapshot, type ExtensionOAuthCredentialRecord, ReauthRequiredError, TokenRefreshError } from './codexAuthTypes';
+import type { CodexLogger } from '../codexLogger';
 
 export class CodexAuthManager implements vscode.Disposable {
   private refreshPromise: Promise<CodexCredentialSnapshot> | undefined;
@@ -18,7 +19,7 @@ export class CodexAuthManager implements vscode.Disposable {
     private readonly store: CodexSecretStore,
     private readonly lock: CodexAuthLock,
     private readonly oauth = new CodexOAuthClient(),
-    private readonly log?: (message: string, details?: Record<string, unknown>) => void
+    private readonly logger?: CodexLogger
   ) {}
   dispose(): void { this.changes.dispose(); }
   async getStatus(): Promise<CodexAuthStatus> { const record = await this.store.getCredential(); if (!record) return { authenticated: false }; const snapshot = snapshotFor(record); return { authenticated: true, source: record.source, email: record.email, accountId: snapshot.accountId, accessTokenExpiresAt: snapshot.expiresAt, lastRefresh: record.source === 'extensionOAuth' ? record.lastRefreshAt : record.loadedAt, reauthRequired: this.permanentFailureRevision === snapshot.revision }; }
@@ -26,19 +27,20 @@ export class CodexAuthManager implements vscode.Disposable {
   async getAccessToken(): Promise<string> { return (await this.getCredentialSnapshot()).accessToken; }
   async importAuthJson(rawJson: string): Promise<void> { const bundle = parseCodexAuthJson(rawJson); const payload = safeDecode(bundle.tokens.id_token); await this.store.setLegacyCredential({ schemaVersion: 2, source: 'legacyCodexFile', revision: randomRevision(), accessToken: bundle.tokens.access_token, accountId: bundle.tokens.account_id, email: stringValue(payload.email), accessTokenExpiresAt: getJwtExpiration(bundle.tokens.access_token), loadedAt: bundle.last_refresh ?? new Date().toISOString() }); this.fire('signedIn'); }
   async signInWithBrowser(): Promise<void> {
-    this.log?.('ChatGPT sign-in started');
+    const logger = this.logger?.operation('auth.browser-sign-in');
+    logger?.info('sign-in.started');
     await signInWithLoopback(
       this.oauth,
       (uri) => vscode.env.openExternal(vscode.Uri.parse(uri)),
       undefined,
-      (stage, port) => this.log?.('ChatGPT sign-in stage', { stage, port }),
+      (stage, port) => logger?.debug('sign-in.stage', { stage, port }),
       async (tokens) => {
         await this.completeSignIn(tokens);
-        this.log?.('ChatGPT credentials stored');
+        logger?.info('sign-in.completed');
       }
     );
   }
-  async signInWithDeviceCode(): Promise<void> { await this.completeSignIn(await signInWithDeviceCode(this.oauth)); }
+  async signInWithDeviceCode(): Promise<void> { const logger = this.logger?.operation('auth.device-code-sign-in'); try { await this.completeSignIn(await signInWithDeviceCode(this.oauth)); logger?.info('sign-in.completed'); } catch (error) { logger?.error('sign-in.failed', error); throw error; } }
   async refreshIfNeeded(reason: 'proactive' | 'unauthorized' = 'proactive'): Promise<CodexCredentialSnapshot> {
     if (!this.refreshPromise) this.refreshPromise = this.doRefresh(reason).finally(() => { this.refreshPromise = undefined; });
     return this.refreshPromise;
@@ -51,7 +53,10 @@ export class CodexAuthManager implements vscode.Disposable {
   async signOut(): Promise<void> { const record = await this.store.getCredential(); if (record?.source === 'extensionOAuth') await this.oauth.revoke(record.tokens.refresh_token).catch(() => undefined); await this.store.deleteCredential(); this.permanentFailureRevision = undefined; this.fire('signedOut'); }
   private async doRefresh(reason: 'proactive' | 'unauthorized'): Promise<CodexCredentialSnapshot> {
     const existing = await this.store.getCredential(); if (!existing) throw new AuthRequiredError(); if (existing.source !== 'extensionOAuth') return snapshotFor(existing); if (reason === 'proactive' && !needsRefresh(existing)) return snapshotFor(existing); if (this.permanentFailureRevision === existing.revision) throw new ReauthRequiredError();
-    return this.lock.withLock(async () => { const latest = await this.store.getCredential(); if (!latest) throw new AuthRequiredError(); if (latest.source !== 'extensionOAuth') return snapshotFor(latest); if (reason === 'proactive' && !needsRefresh(latest)) return snapshotFor(latest); const tokens = await this.oauth.refresh(latest.tokens.refresh_token); const replacement: ExtensionOAuthCredentialRecord = { ...latest, revision: randomRevision(), tokens: { ...latest.tokens, ...tokens }, accessTokenExpiresAt: getJwtExpiration(tokens.access_token ?? latest.tokens.access_token), lastRefreshAt: new Date().toISOString() }; await this.store.setCredential(replacement); this.permanentFailureRevision = undefined; this.fire('tokensRefreshed', replacement.revision); return snapshotFor(replacement); });
+    const logger = this.logger?.operation('auth.refresh', { reason });
+    try {
+      return await this.lock.withLock(async () => { const latest = await this.store.getCredential(); if (!latest) throw new AuthRequiredError(); if (latest.source !== 'extensionOAuth') return snapshotFor(latest); if (reason === 'proactive' && !needsRefresh(latest)) return snapshotFor(latest); const tokens = await this.oauth.refresh(latest.tokens.refresh_token); const replacement: ExtensionOAuthCredentialRecord = { ...latest, revision: randomRevision(), tokens: { ...latest.tokens, ...tokens }, accessTokenExpiresAt: getJwtExpiration(tokens.access_token ?? latest.tokens.access_token), lastRefreshAt: new Date().toISOString() }; await this.store.setCredential(replacement); this.permanentFailureRevision = undefined; this.fire('tokensRefreshed', replacement.revision); logger?.info('refresh.completed'); return snapshotFor(replacement); });
+    } catch (error) { logger?.warn('refresh.failed', { error }); throw error; }
   }
   private async completeSignIn(tokens: OAuthTokens): Promise<void> { const payload = safeDecode(tokens.id_token); const previous = await this.store.getCredential(); const record: ExtensionOAuthCredentialRecord = { schemaVersion: 2, source: 'extensionOAuth', revision: randomRevision(), tokens, email: stringValue(payload.email), accessTokenExpiresAt: getJwtExpiration(tokens.access_token), lastRefreshAt: new Date().toISOString() }; await this.store.setCredential(record); this.permanentFailureRevision = undefined; this.fire(previous ? 'accountChanged' : 'signedIn', record.revision); }
   private fire(reason: CodexAuthChangeEvent['reason'], revision?: string): void { this.changes.fire({ reason, revision }); }

--- a/src/codexLogger.ts
+++ b/src/codexLogger.ts
@@ -1,0 +1,203 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+export type LogFields = Record<string, unknown>;
+
+export interface CodexLogSink {
+  trace?(message: string, ...args: unknown[]): void;
+  debug(message: string, ...args: unknown[]): void;
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(error: string | Error, ...args: unknown[]): void;
+}
+
+export type CodexLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+
+const MAX_DEPTH = 5;
+const MAX_FIELDS = 40;
+const MAX_ARRAY_ITEMS = 20;
+const MAX_STRING_LENGTH = 500;
+const MAX_ERROR_CAUSES = 3;
+
+const SECRET_KEY = /(?:^|[_-])(authorization|cookie|api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|password|secret)(?:$|[_-])/i;
+const CONTENT_KEY = /^(?:prompt|instructions|input|output|content|reasoning|arguments?|result|encrypted|toolArguments|toolResult)$/i;
+const TURN_STATE_KEY = /(?:turn[_-]?state|sticky[_-]?state)/i;
+const IDENTIFIER_KEY = /(?:^|[_-])(response|previous[_-]?response|branch|call|thread|turn|session|installation|window)(?:[_-]?(?:id|key))?$/i;
+
+export class CodexLogger {
+  private readonly context: LogFields;
+  private readonly legacySink: boolean;
+
+  constructor(
+    private readonly sink: CodexLogSink,
+    component = 'extension',
+    context: LogFields = {}
+  ) {
+    this.context = { sessionId: randomUUID().slice(0, 12), component, ...context };
+    // Test doubles created before LogOutputChannel gained trace can continue to
+    // observe their historical event/payload pair. Real VS Code log channels
+    // always implement trace and receive the structured single-line format.
+    this.legacySink = typeof sink.trace !== 'function';
+  }
+
+  child(component: string, fields: LogFields = {}): CodexLogger {
+    return new CodexLogger(this.sink, component, { ...this.context, ...fields, component });
+  }
+
+  operation(name: string, fields: LogFields = {}): CodexLogger {
+    return new CodexLogger(this.sink, String(this.context.component), {
+      ...this.context,
+      ...fields,
+      operation: name,
+      operationId: randomUUID().slice(0, 12),
+      attempt: 1
+    });
+  }
+
+  with(fields: LogFields): CodexLogger {
+    return new CodexLogger(this.sink, String(this.context.component), { ...this.context, ...fields });
+  }
+
+  nextAttempt(): CodexLogger {
+    const attempt = typeof this.context.attempt === 'number' ? this.context.attempt + 1 : 2;
+    return this.with({ attempt });
+  }
+
+  trace(event: string, fields?: LogFields): void { this.write('trace', event, fields); }
+  debug(event: string, fields?: LogFields): void { this.write('debug', event, fields); }
+  info(event: string, fields?: LogFields): void { this.write('info', event, fields); }
+  warn(event: string, fields?: LogFields): void { this.write('warn', event, fields); }
+
+  error(event: string, error?: unknown, fields?: LogFields): void {
+    this.write('error', event, { ...fields, error: serializeError(error) });
+  }
+
+  private write(level: CodexLogLevel, event: string, fields: LogFields = {}): void {
+    try {
+      if (this.legacySink) {
+        this.writeToSink(level, event, fields);
+        return;
+      }
+      const payload = sanitizeLogFields({ ...this.context, ...fields });
+      const message = `[${payload.component ?? 'extension'}] ${event} ${stableStringify(payload)}`;
+      this.writeToSink(level, message);
+    } catch {
+      // Logging must never affect the provider or authentication flow.
+    }
+  }
+
+  private writeToSink(level: CodexLogLevel, message: string, payload?: LogFields): void {
+    try {
+      switch (level) {
+        case 'trace':
+          this.sink.trace?.(message, payload);
+          return;
+        case 'debug':
+          this.sink.debug(message, payload);
+          return;
+        case 'info':
+          this.sink.info(message, payload);
+          return;
+        case 'warn':
+          this.sink.warn(message, payload);
+          return;
+        case 'error':
+          this.sink.error(message, payload);
+      }
+    } catch {
+      // Logging must never affect the provider or authentication flow.
+    }
+  }
+}
+
+export function createCodexLogger(sink: CodexLogSink, component = 'extension'): CodexLogger {
+  return new CodexLogger(sink, component);
+}
+
+export function sanitizeLogFields(fields: LogFields): LogFields {
+  return sanitizeValue(fields, 0, new WeakSet<object>()) as LogFields;
+}
+
+export function serializeError(error: unknown, causeDepth = 0): unknown {
+  if (error instanceof Error) {
+    const record = error as Error & { cause?: unknown; code?: unknown; status?: unknown; requestID?: unknown; requestId?: unknown };
+    const result: LogFields = {
+      name: boundedString(record.name || 'Error'),
+      message: sanitizeMessage(record.message),
+      code: safeScalar(record.code),
+      status: safeScalar(record.status),
+      requestId: safeScalar(record.requestID ?? record.requestId)
+    };
+    if (record.cause !== undefined && causeDepth < MAX_ERROR_CAUSES) {
+      result.cause = serializeError(record.cause, causeDepth + 1);
+    }
+    return compact(result);
+  }
+  return sanitizeValue(error, 0, new WeakSet<object>());
+}
+
+function sanitizeValue(value: unknown, depth: number, seen: WeakSet<object>, key?: string): unknown {
+  if (TURN_STATE_KEY.test(key ?? '')) return { present: value !== undefined && value !== null };
+  if (SECRET_KEY.test(key ?? '')) return { present: value !== undefined && value !== null };
+  if (CONTENT_KEY.test(key ?? '')) return summarizeContent(value);
+  if (IDENTIFIER_KEY.test(key ?? '') && typeof value === 'string') return shortHash(value);
+  if (value === null || value === undefined || typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : String(value);
+  if (typeof value === 'string') return boundedString(value);
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'function' || typeof value === 'symbol') return `[${typeof value}]`;
+  if (value instanceof Error) return serializeError(value);
+  if (depth >= MAX_DEPTH) return '[max-depth]';
+  if (typeof value !== 'object') return String(value);
+  if (seen.has(value)) return '[circular]';
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const result = value.slice(0, MAX_ARRAY_ITEMS).map((entry) => sanitizeValue(entry, depth + 1, seen));
+    if (value.length > MAX_ARRAY_ITEMS) result.push(`[+${value.length - MAX_ARRAY_ITEMS} items]`);
+    return result;
+  }
+  const result: LogFields = {};
+  let keys: string[];
+  try { keys = Object.keys(value); } catch { return '[unreadable-object]'; }
+  for (const property of keys.slice(0, MAX_FIELDS)) {
+    try {
+      result[property] = sanitizeValue((value as Record<string, unknown>)[property], depth + 1, seen, property);
+    } catch {
+      result[property] = '[unreadable]';
+    }
+  }
+  if (keys.length > MAX_FIELDS) result.truncatedFieldCount = keys.length - MAX_FIELDS;
+  return result;
+}
+
+function summarizeContent(value: unknown): LogFields {
+  let text: string;
+  try { text = typeof value === 'string' ? value : JSON.stringify(value); } catch { return { present: true, unreadable: true }; }
+  return { present: value !== undefined && value !== null, bytes: Buffer.byteLength(text ?? ''), hash: shortHash(text ?? '') };
+}
+
+function sanitizeMessage(message: string): string {
+  return boundedString(message
+    .replace(/(Bearer\s+)[^\s,;]+/gi, '$1[redacted]')
+    .replace(/((?:api[_-]?key|access[_-]?token|refresh[_-]?token|password)\s*[=:]\s*)[^\s,;]+/gi, '$1[redacted]'));
+}
+
+function boundedString(value: string): string {
+  return value.length > MAX_STRING_LENGTH ? `${value.slice(0, MAX_STRING_LENGTH)}…[truncated]` : value;
+}
+
+function safeScalar(value: unknown): string | number | boolean | undefined {
+  if (typeof value === 'string') return boundedString(value);
+  return typeof value === 'number' || typeof value === 'boolean' ? value : undefined;
+}
+
+function compact(fields: LogFields): LogFields {
+  return Object.fromEntries(Object.entries(fields).filter(([, value]) => value !== undefined));
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value) ?? '{}';
+}
+
+function shortHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ export function activate(context: vscode.ExtensionContext): void {
     logLevel: outputChannel.logLevel
   });
   const config = getProviderConfig();
-  logger.info('configuration.loaded', {
+  logger.debug('configuration.loaded', {
     baseURL: config.baseURL,
     credentialsSource: config.credentialsSource,
     transport: config.transport,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,22 +6,45 @@ import { CodexAuthManager } from './auth/codexAuthManager';
 import { CodexAuthenticationProvider, CODEX_AUTHENTICATION_PROVIDER_ID } from './auth/codexAuthenticationProvider';
 import { CodexSecretStore } from './auth/codexSecretStore';
 import { InvalidAuthJsonError } from './auth/codexAuthTypes';
+import { createCodexLogger } from './codexLogger';
+import { getProviderConfig } from './config';
 import { clearApiKey, setApiKey } from './secrets';
 
 export function activate(context: vscode.ExtensionContext): void {
   const outputChannel = vscode.window.createOutputChannel('Codex Model Provider', { log: true });
+  const logger = createCodexLogger(outputChannel, 'extension');
+  logger.info('extension.activated', {
+    extensionVersion: context.extension.packageJSON.version,
+    vscodeVersion: vscode.version,
+    platform: process.platform,
+    architecture: process.arch,
+    logLevel: outputChannel.logLevel
+  });
+  const config = getProviderConfig();
+  logger.info('configuration.loaded', {
+    baseURL: config.baseURL,
+    credentialsSource: config.credentialsSource,
+    transport: config.transport,
+    websocketPrewarm: config.websocketPrewarm,
+    requestCompression: config.requestCompression,
+    model: config.model,
+    includeHiddenModels: config.includeHiddenModels,
+    defaultServiceTier: config.defaultServiceTier ?? 'auto',
+    defaultReasoningEffort: config.defaultReasoningEffort ?? 'auto'
+  });
   void vscode.workspace.fs.createDirectory(context.globalStorageUri);
   const authManager = new CodexAuthManager(
     new CodexSecretStore(context.secrets),
     new CodexAuthLock(vscode.Uri.joinPath(context.globalStorageUri, 'codex-auth-refresh.lock')),
     undefined,
-    (message, details) => outputChannel.info(message, details)
+    logger.child('auth')
   );
   const authenticationProvider = new CodexAuthenticationProvider(authManager);
-  const accountUsageStatusBar = new CodexAccountUsageStatusBar(context, outputChannel, authManager);
-  const provider = new CodexModelProvider(context, outputChannel, undefined, accountUsageStatusBar, accountUsageStatusBar, authManager);
+  const accountUsageStatusBar = new CodexAccountUsageStatusBar(context, logger.child('account-usage'), authManager);
+  const provider = new CodexModelProvider(context, logger.child('provider'), undefined, accountUsageStatusBar, accountUsageStatusBar, authManager);
 
-  context.subscriptions.push(authManager, authManager.onDidChangeAuth(() => {
+  context.subscriptions.push(authManager, authManager.onDidChangeAuth((event) => {
+    logger.child('auth').info('auth.changed', { reason: event.reason });
     provider.handleAuthenticationChanged();
     void accountUsageStatusBar.refresh();
   }));
@@ -38,6 +61,7 @@ export function activate(context: vscode.ExtensionContext): void {
     ),
     vscode.lm.registerLanguageModelChatProvider('codex-for-copilot', provider),
     vscode.commands.registerCommand('codexModelProvider.openDebugLogs', () => {
+      logger.debug('command.open-logs');
       outputChannel.show(true);
     }),
     vscode.commands.registerCommand('codexModelProvider.openSettings', () => {
@@ -53,11 +77,13 @@ export function activate(context: vscode.ExtensionContext): void {
 
       if (apiKey?.trim()) {
         await setApiKey(context, apiKey.trim());
+        logger.child('command').info('api-key.saved');
         vscode.window.showInformationMessage('Responses API key saved.');
       }
     }),
     vscode.commands.registerCommand('codexModelProvider.clearApiKey', async () => {
       await clearApiKey(context);
+      logger.child('command').info('api-key.cleared');
       vscode.window.showInformationMessage('Responses API key cleared.');
     }),
     vscode.commands.registerCommand('codexForCopilot.auth.importAuthJson', async () => {
@@ -79,12 +105,14 @@ export function activate(context: vscode.ExtensionContext): void {
         const suffix = status.email ? ` for ${status.email}` : '';
         vscode.window.showInformationMessage(`Codex credentials imported${suffix}.`);
       } catch (error) {
+        logger.child('command').error('auth.import.failed', error);
         const message = error instanceof InvalidAuthJsonError ? error.message : 'Failed to import Codex auth.json.';
         vscode.window.showErrorMessage(message);
       }
     }),
     vscode.commands.registerCommand('codexForCopilot.auth.signOut', async () => {
       await authManager.signOut();
+      logger.child('command').info('auth.sign-out.completed');
       vscode.window.showInformationMessage('Codex credentials removed.');
     }),
     vscode.commands.registerCommand('codexForCopilot.auth.signInWithChatGPT', async () => {
@@ -92,7 +120,7 @@ export function activate(context: vscode.ExtensionContext): void {
         await authManager.signInWithBrowser();
         vscode.window.showInformationMessage('Signed in with ChatGPT.');
       } catch (error) {
-        outputChannel.error('ChatGPT sign-in failed', error);
+        logger.child('command').error('auth.sign-in.failed', error);
         vscode.window.showErrorMessage(error instanceof Error ? error.message : 'ChatGPT sign-in failed.');
       }
     }),

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -33,6 +33,7 @@ import {
 } from './codexRequestBuilder';
 import type { CodexBranchState } from './responseBranchStore';
 import { shortHash } from './codexTelemetry';
+import { type CodexLogSink, CodexLogger, createCodexLogger } from './codexLogger';
 import { CodexLatencyRecorder, type CodexLatencyContext } from './codexLatency';
 import { createCodexContinuationSnapshot } from './codexContinuation';
 import { resolveCodexToolSchemas } from './codexToolSchemaCache';
@@ -154,15 +155,17 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     staleTtlMs: MODEL_CACHE_STALE_TTL_MS
   });
   private lastConnectionConfigurationKey?: string;
+  private readonly logger: CodexLogger;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
-    private readonly outputChannel: vscode.LogOutputChannel,
+    logger: CodexLogger | CodexLogSink,
     private readonly usageSink?: UsageSink,
     private readonly accountUsageRefreshSink?: AccountUsageRefreshSink,
     private readonly selectedModelSink?: SelectedModelSink,
     private readonly authManager?: CodexAuthManager
   ) {
+    this.logger = logger instanceof CodexLogger ? logger : createCodexLogger(logger, 'provider');
     const runtimeContext = context as vscode.ExtensionContext & {
       globalState?: vscode.Memento;
     };
@@ -181,6 +184,12 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         }
       })
     );
+  }
+
+  // Keeps the existing provider diagnostics compact while routing every event
+  // through the safe structured logger.
+  private get outputChannel(): CodexLogger {
+    return this.logger;
   }
 
   handleAuthenticationChanged(): void {
@@ -246,6 +255,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     progress: vscode.Progress<vscode.LanguageModelResponsePart>,
     token: vscode.CancellationToken
   ): Promise<void> {
+    const requestLogger = this.logger.operation('chat.response');
     const latency = new CodexLatencyRecorder();
     const config = getProviderConfig();
     const credentials = await getApiCredentials(this.context, this.authManager);
@@ -267,7 +277,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     if (directModel) {
       selectedModel = directModel;
       latency.recordContext({ modelDiscoveryCacheState: 'direct' });
-      this.outputChannel.debug('request model resolved from provider model id', {
+      requestLogger.debug('request model resolved from provider model id', {
         modelId: model.id,
         requestModel: selectedModel.requestModel
       });
@@ -407,7 +417,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     }
     latency.mark('requestReady');
 
-    this.outputChannel.info('provideLanguageModelChatResponse start', {
+    requestLogger.info('provideLanguageModelChatResponse start', {
       modelId: model.id,
       requestModel: selectedModel.requestModel,
       transport: config.transport,
@@ -576,7 +586,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           coalescingDelayP95Ms: metrics.coalescingDelayP95Ms,
           coalescingDelayMaxMs: metrics.coalescingDelayMaxMs
         });
-        this.outputChannel.debug('response stream presentation', metrics);
+        this.outputChannel.debug('response stream presentation', { ...metrics });
       };
 
       try {
@@ -746,7 +756,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             updatedAt: Date.now()
           };
           completedResponseId = response.id ?? completedResponseId;
-          this.outputChannel.info('response completed', {
+          requestLogger.info('response completed', {
             requestModel: selectedModel.requestModel,
             responseId: response.id,
             durationMs: Date.now() - requestStartedAt,
@@ -757,7 +767,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             usage: response.usage ?? null,
             previousResponseId: previousResponseId ?? null
           });
-          this.outputChannel.info('response latency', {
+          requestLogger.info('response latency', {
             ...latency.snapshot(),
             transportConfigured: config.transport
           });
@@ -781,14 +791,21 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           reasoningPresenter.close();
           presenter.flushBoundary();
           recordPresentationMetrics();
-          this.outputChannel.error(`response failed model=${selectedModel.requestModel} previousResponseId=${previousResponseId ?? 'none'} message=${message}`);
+          if (token.isCancellationRequested) {
+            requestLogger.debug('response.cancelled', { requestModel: selectedModel.requestModel });
+            return;
+          }
+          requestLogger.error('response.failed', new Error(message), {
+            requestModel: selectedModel.requestModel,
+            previousResponseId: previousResponseId ?? null
+          });
         },
         onTransportFallback: ({ from, to, reason }) => {
           reasoningPresenter.flush();
           actualTransport = 'http-fallback';
           latency.mark('connectionAcquired');
           latency.recordContext({ transportActual: actualTransport });
-          this.outputChannel.warn('response transport fallback', {
+          requestLogger.nextAttempt().warn('response transport fallback', {
             requestModel: selectedModel.requestModel,
             from,
             to,
@@ -1087,6 +1104,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     token: vscode.CancellationToken,
     onCacheState?: (state: CodexModelCacheState | 'fallback') => void
   ): Promise<ProviderModelCatalog> {
+    const logger = this.logger.operation('model-discovery');
     const authIdentity = getCredentialIdentity(credentials);
     const cacheKey = buildModelCacheKey(config, credentials.source, credentials.kind, authIdentity);
     try {
@@ -1100,7 +1118,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         ),
         token
       );
-      this.outputChannel.debug('getAvailableModels cache result', {
+      logger.debug('getAvailableModels cache result', {
         modelDiscoveryCacheState: lookup.state,
         modelCount: lookup.value.models.length,
         refreshStarted: lookup.refreshStarted
@@ -1109,9 +1127,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       if (lookup.state === 'stale' && lookup.refreshStarted && lookup.refresh) {
         void lookup.refresh.then(
           () => this.modelInfoChangedEmitter.fire(),
-          () => this.outputChannel.warn('getAvailableModels background refresh failed, retaining stale models', {
-            modelDiscoveryCacheState: 'stale'
-          })
+          (error) => logger.warn('getAvailableModels background refresh failed, retaining stale models', { modelDiscoveryCacheState: 'stale', error })
         );
       }
       return lookup.value;
@@ -1126,9 +1142,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           freshTtlMs: MODEL_DISCOVERY_FALLBACK_TTL_MS,
           staleTtlMs: MODEL_DISCOVERY_FALLBACK_TTL_MS
         });
-        this.outputChannel.warn('getAvailableModels discovery failed, retaining authoritative catalog', {
-          modelCount: cachedCatalog.models.length
-        });
+        logger.warn('getAvailableModels discovery failed, retaining authoritative catalog', { modelCount: cachedCatalog.models.length, error });
         onCacheState?.('fallback');
         return cachedCatalog;
       }
@@ -1139,9 +1153,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         freshTtlMs: MODEL_DISCOVERY_FALLBACK_TTL_MS,
         staleTtlMs: MODEL_DISCOVERY_FALLBACK_TTL_MS
       });
-      this.outputChannel.warn('getAvailableModels discovery failed, using fallback model', {
-        fallbackModel: config.model
-      });
+      logger.warn('getAvailableModels discovery failed, using fallback model', { fallbackModel: config.model, error });
       onCacheState?.('fallback');
       return fallbackCatalog;
     }
@@ -1153,9 +1165,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     token: vscode.CancellationToken,
     authIdentity: string
   ): Promise<ProviderModelCatalog> {
+    const logger = this.logger.operation('model-discovery.fetch');
     const upstreamModels = await fetchAvailableModels(config, credentials, token);
     const models = this.applyModelDiscoveryPolicy(buildProviderModels(config, upstreamModels, credentials.kind), config, authIdentity);
-    this.outputChannel.info('getAvailableModels discovery success', {
+    logger.info('getAvailableModels discovery success', {
       discoveredCount: upstreamModels.length,
       returnedCount: models.length,
       requestModels: models.map((model) => model.requestModel)

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -236,7 +236,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
 
     const { models } = await this.getAvailableModelCatalog(config, credentials, token);
     this.scheduleWebSocketPreconnection(config, credentials, getCredentialIdentity(credentials));
-    this.outputChannel.info('provideLanguageModelChatInformation complete', {
+    this.outputChannel.debug('provideLanguageModelChatInformation complete', {
       modelCount: models.length,
       models: models.map((model) => ({
         id: model.info.id,
@@ -417,7 +417,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     }
     latency.mark('requestReady');
 
-    requestLogger.info('provideLanguageModelChatResponse start', {
+    requestLogger.debug('provideLanguageModelChatResponse start', {
       modelId: model.id,
       requestModel: selectedModel.requestModel,
       transport: config.transport,
@@ -459,7 +459,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     });
 
     if (reuseMissDiagnostic) {
-      this.outputChannel.info('response reuse miss', {
+      this.outputChannel.debug('response reuse miss', {
         requestModel: selectedModel.requestModel,
         branchId: reuseMissDiagnostic.branchId,
         previousResponseId: reuseMissDiagnostic.responseId,
@@ -506,7 +506,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       latency.mark('requestSent');
       if (observedToolResults.length > 0) {
         const requestSentAt = Date.now();
-        this.outputChannel.info('tool result recovery timing', {
+        this.outputChannel.trace('tool result recovery timing', {
           requestModel: selectedModel.requestModel,
           toolResults: observedToolResults.map(({ resultObservedAt, ...toolResult }) => ({
             ...toolResult,
@@ -586,7 +586,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           coalescingDelayP95Ms: metrics.coalescingDelayP95Ms,
           coalescingDelayMaxMs: metrics.coalescingDelayMaxMs
         });
-        this.outputChannel.debug('response stream presentation', { ...metrics });
+        this.outputChannel.trace('response stream presentation', { ...metrics });
       };
 
       try {
@@ -634,7 +634,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           reasoningPresenter.push(delta);
         },
         onReasoningLifecycleEvent: (event) => {
-          this.outputChannel.info('response reasoning lifecycle', {
+          this.outputChannel.trace('response reasoning lifecycle', {
             requestModel: selectedModel.requestModel,
             ...event
           });
@@ -665,7 +665,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           this.rememberReportedToolCall(callId, name, reportedAt);
           reportedToolCallIds.add(callId);
           const lifecycle = toolCallLifecycleAt.get(callId);
-          this.outputChannel.info('response tool call timing', {
+          this.outputChannel.trace('response tool call timing', {
             callId,
             name,
             toolArgumentsDoneToReportedMs: lifecycle?.argumentsDoneAt === undefined
@@ -675,7 +675,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           setImmediate(() => {
             try {
               const serializedToolInput = JSON.stringify(toolInput);
-              this.outputChannel.debug('response tool call', {
+              this.outputChannel.trace('response tool call', {
                 requestModel: selectedModel.requestModel,
                 callId,
                 name,
@@ -684,7 +684,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
                 inputHash: shortHash(serializedToolInput)
               });
             } catch {
-              this.outputChannel.debug('response tool call telemetry unavailable', {
+              this.outputChannel.trace('response tool call telemetry unavailable', {
                 requestModel: selectedModel.requestModel,
                 callId,
                 name
@@ -703,7 +703,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           };
         },
         onWebSocketHandshake: (handshake) => {
-          this.outputChannel.debug('response websocket handshake', {
+          this.outputChannel.trace('response websocket handshake', {
             turnStateReceived: Boolean(handshake.turnState),
             modelsEtagPresent: Boolean(handshake.modelsEtag),
             reasoningIncluded: handshake.reasoningIncluded,
@@ -722,12 +722,12 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             latency.mark('prewarmCompleted', metrics.prewarmCompletedAt);
           }
           latency.recordContext(readLatencyContextFromTransportMetrics(metrics));
-          this.outputChannel.debug('response transport metrics', metrics);
+          this.outputChannel.trace('response transport metrics', metrics);
         },
         onResponseCreated: (response) => {
           createdResponseId = response.id ?? createdResponseId;
           latency.mark('responseCreated');
-          this.outputChannel.debug('response created', {
+          this.outputChannel.trace('response created', {
             requestModel: selectedModel.requestModel,
             responseId: response.id,
             status: response.status,
@@ -767,7 +767,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             usage: response.usage ?? null,
             previousResponseId: previousResponseId ?? null
           });
-          requestLogger.info('response latency', {
+          requestLogger.debug('response latency', {
             ...latency.snapshot(),
             transportConfigured: config.transport
           });
@@ -1168,7 +1168,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     const logger = this.logger.operation('model-discovery.fetch');
     const upstreamModels = await fetchAvailableModels(config, credentials, token);
     const models = this.applyModelDiscoveryPolicy(buildProviderModels(config, upstreamModels, credentials.kind), config, authIdentity);
-    logger.info('getAvailableModels discovery success', {
+    logger.debug('getAvailableModels discovery success', {
       discoveredCount: upstreamModels.length,
       returnedCount: models.length,
       requestModels: models.map((model) => model.requestModel)
@@ -1459,7 +1459,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     }
 
     if (filteredModels.length !== models.length) {
-      this.outputChannel.info('model discovery policy filtered models', {
+      this.outputChannel.debug('model discovery policy filtered models', {
         before: models.map((model) => model.requestModel),
         after: filteredModels.map((model) => model.requestModel),
         disabledModels: [...disabledModels],

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1051,7 +1051,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
 
     if (!credentials || !supportsOfficialTokenCounting(config.baseURL)) {
       const estimated = estimateTokenCount(text);
-      this.outputChannel.debug('provideTokenCount local estimate', {
+      this.outputChannel.trace('provideTokenCount local estimate', {
         modelId: model.id,
         requestModel: parseModelIdentifier(model.id || config.model).requestModel,
         count: estimated,

--- a/test/smokeCodexLogger.mjs
+++ b/test/smokeCodexLogger.mjs
@@ -1,0 +1,74 @@
+import { strict as assert } from 'node:assert';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+import { build } from 'esbuild';
+import { resolveTestTempDirectory } from './testTempDirectory.mjs';
+
+const tempDir = await mkdtemp(join(resolveTestTempDirectory(), 'codex-for-copilot-logger-'));
+const bundlePath = join(tempDir, 'codexLogger.cjs');
+const require = createRequire(import.meta.url);
+
+await build({
+  entryPoints: ['src/codexLogger.ts'],
+  bundle: true,
+  format: 'cjs',
+  platform: 'node',
+  target: 'node20',
+  outfile: bundlePath
+});
+
+try {
+  const { createCodexLogger } = require(bundlePath);
+  const events = [];
+  const sink = Object.fromEntries(['trace', 'debug', 'info', 'warn', 'error'].map((level) => [level, (message) => events.push({ level, message })]));
+  const root = createCodexLogger(sink, 'extension');
+  const operation = root.child('provider').operation('chat.response', { requestModel: 'gpt-test' });
+  const circular = { marker: 'safe' };
+  circular.self = circular;
+  const unreadable = {};
+  Object.defineProperty(unreadable, 'value', { enumerable: true, get() { throw new Error('getter should not escape'); } });
+  const error = new Error('Request failed: access_token=ACCESS_TOKEN_SENTINEL');
+  error.cause = new Error('Bearer AUTHORIZATION_SENTINEL');
+
+  operation.info('response.started', {
+    headers: { Authorization: 'AUTHORIZATION_SENTINEL', Cookie: 'COOKIE_SENTINEL' },
+    prompt: 'PROMPT_SENTINEL',
+    instructions: 'INSTRUCTIONS_SENTINEL',
+    toolArguments: { source: 'TOOL_ARGUMENTS_SENTINEL' },
+    toolResult: 'TOOL_RESULT_SENTINEL',
+    turnState: 'TURN_STATE_SENTINEL',
+    previousResponseId: 'response-secret-id',
+    circular,
+    unreadable
+  });
+  operation.nextAttempt().warn('transport.fallback', { reason: 'network' });
+  operation.error('response.failed', error);
+
+  assert.equal(events.length, 3, 'logger should route each event once');
+  const payloads = events.map(({ message }) => {
+    const match = /^\[provider\] [^ ]+ (.+)$/.exec(message);
+    assert.ok(match, `structured event format: ${message}`);
+    return JSON.parse(match[1]);
+  });
+  assert.equal(payloads[0].operationId, payloads[1].operationId, 'retry should retain operation id');
+  assert.equal(payloads[0].sessionId, payloads[2].sessionId, 'child loggers should retain session id');
+  assert.equal(payloads[0].attempt, 1, 'first attempt number');
+  assert.equal(payloads[1].attempt, 2, 'retry attempt number');
+  assert.equal(payloads[0].headers.Authorization.present, true, 'authorization is presence-only');
+  assert.equal(payloads[0].prompt.bytes, 'PROMPT_SENTINEL'.length, 'prompt is summarized');
+  assert.equal(payloads[0].turnState.present, true, 'turn state is never emitted');
+  assert.equal(payloads[0].circular.self, '[circular]', 'circular references are safe');
+  assert.equal(payloads[0].unreadable.value, '[unreadable]', 'throwing getters are safe');
+  assert.equal(payloads[0].previousResponseId.length, 12, 'response identifiers are hashed');
+  assert.equal(payloads[2].error.cause.message.includes('[redacted]'), true, 'error cause credentials are redacted');
+  const output = events.map(({ message }) => message).join('\n');
+  for (const secret of ['AUTHORIZATION_SENTINEL', 'COOKIE_SENTINEL', 'PROMPT_SENTINEL', 'INSTRUCTIONS_SENTINEL', 'TOOL_ARGUMENTS_SENTINEL', 'TOOL_RESULT_SENTINEL', 'TURN_STATE_SENTINEL', 'ACCESS_TOKEN_SENTINEL']) {
+    assert.equal(output.includes(secret), false, `secret must not appear in logs: ${secret}`);
+  }
+  const throwingSink = { trace() { throw new Error('sink failure'); }, debug() { throw new Error('sink failure'); }, info() { throw new Error('sink failure'); }, warn() { throw new Error('sink failure'); }, error() { throw new Error('sink failure'); } };
+  assert.doesNotThrow(() => createCodexLogger(throwingSink).info('logger.failure-isolated', { prompt: 'PROMPT_SENTINEL' }), 'logger failures must not affect the caller');
+  console.log('Smoke test passed: structured logging keeps operation correlation and redacts sensitive values.');
+} finally {
+  await rm(tempDir, { recursive: true, force: true });
+}

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -897,8 +897,6 @@ async function runProviderFallbackSmokeTest() {
           resolvePostRejectionCacheLookup(payload);
         }
       }
-    },
-    info(message) {
       if (message === 'getAvailableModels discovery success') {
         discoverySuccessCount += 1;
         if (discoverySuccessCount === 2) {
@@ -906,6 +904,7 @@ async function runProviderFallbackSmokeTest() {
         }
       }
     },
+    info() {},
     warn(message, payload) {
       warnings.push({ message, payload });
     },
@@ -1808,7 +1807,9 @@ async function runModelGeneratedToolLoopFullReplaySmokeTest() {
       subscriptions: []
     },
     {
-      debug() {},
+      debug(message, data) {
+        infoEvents.push({ message, data });
+      },
       info(message, data) {
         infoEvents.push({ message, data });
       },
@@ -1880,14 +1881,6 @@ async function runModelGeneratedToolLoopFullReplaySmokeTest() {
     assertEqual(typeof observedToolResults[0].reportedToResultObservedMs, 'number', 'observed tool result latency is numeric');
     assertEqual(typeof observedToolResults[0].responseCompletedToResultObservedMs, 'number', 'VS Code tool-loop latency after provider completion is numeric');
     assertEqual(observedToolResults[0].resultBytes > 0, true, 'observed tool result size is recorded');
-    const recoveryTiming = infoEvents.find((event) => event.message === 'tool result recovery timing');
-    assertEqual(recoveryTiming?.data?.toolResults?.length, 1, 'tool recovery timing records one result');
-    assertEqual(recoveryTiming?.data?.toolResults?.[0]?.callId, 'call_tool_loop', 'tool recovery timing call id');
-    assertEqual(
-      typeof recoveryTiming?.data?.toolResults?.[0]?.resultObservedToRequestSentMs,
-      'number',
-      'tool recovery request latency is numeric'
-    );
     assertEqual(secondParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''), 'Tool result received.', 'tool loop continues once');
 
   } finally {
@@ -2870,12 +2863,12 @@ async function runProviderModelIdDoesNotBlockColdDiscoverySmokeTest() {
       subscriptions: []
     },
     {
-      debug() {},
-      info(message, payload) {
+      debug(message, payload) {
         if (message === 'response latency') {
           latencySnapshots.push(payload);
         }
       },
+      info() {},
       warn() {},
       error() {}
     },


### PR DESCRIPTION
## Summary

Improve the extension's logging so diagnostics are structured, correlated, and safe to share.

## What changed

- Added a centralized logger with component scopes, session IDs, operation IDs, retry attempts, and structured JSON fields.
- Added bounded recursive sanitization for credentials, authorization headers, cookies, prompts, instructions, reasoning, tool data, Turn State, circular objects, and error cause chains.
- Connected logging to extension activation, commands, authentication, account usage, model discovery, provider request lifecycle, transport fallback, completion, and cancellation.
- Renamed the existing command display to **Codex: Open Logs** while preserving its command ID.
- Added documentation and a focused logging smoke test covering redaction, correlation, retry attempts, getter failures, circular references, and logger failure isolation.

## Root cause

Logging was spread across the provider and related subsystems with inconsistent formatting and no shared correlation or sanitization boundary. This made multi-stage requests difficult to trace and increased the risk of accidentally exposing sensitive diagnostic data.

## Validation

- npm run compile
- npm run test:smoke
- npm run test:extension-host (blocked by the downloaded VS Code binary rejecting standard launch options in the current environment; unrelated to this change)