### PR TITLE
fix: route HTTP requests through configured proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Most users can keep the defaults. Advanced settings are available under **Settin
 - reasoning effort and service tier
 - request compression and WebSocket prewarming
 
+For a proxy-required network, set VS Code's `http.proxy` setting or the Extension Host's `HTTPS_PROXY`/`HTTP_PROXY` environment variable. The provider applies that proxy consistently to model discovery, account usage, HTTP Responses requests, token counting, and WebSocket requests; `NO_PROXY` remains honored.
+
 ## Develop locally
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "https-proxy-agent": "^7.0.6",
         "openai": "^6.44.0",
+        "undici": "^7.28.0",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -4534,7 +4535,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "https-proxy-agent": "^7.0.6",
     "openai": "^6.44.0",
+    "undici": "^7.28.0",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/src/accountUsage.ts
+++ b/src/accountUsage.ts
@@ -1,6 +1,7 @@
 import { normalizeBaseURL } from './responsesClient';
 import type { ApiCredentials } from './secrets';
 import { codexFetch } from './auth/codexAuthRequest';
+import { proxyAwareFetch } from './proxyFetch';
 
 const FIVE_HOUR_WINDOW_MINUTES = 300;
 const WEEKLY_WINDOW_MINUTES = 10080;
@@ -69,8 +70,8 @@ export async function fetchCodexAccountUsage(options: {
       signal: options.signal
     };
     const response = options.credentials.authManager
-      ? await codexFetch(options.credentials.authManager, usageURL, requestInit)
-      : await fetch(usageURL, {
+      ? await codexFetch(options.credentials.authManager, usageURL, requestInit, proxyAwareFetch)
+      : await proxyAwareFetch(usageURL, {
           ...requestInit,
           headers: {
             Authorization: `Bearer ${options.credentials.apiKey}`,

--- a/src/codexFetchAdapter.ts
+++ b/src/codexFetchAdapter.ts
@@ -17,6 +17,7 @@ export interface CodexFetchAdapterOptions {
   endpointKey: string;
   compatibilityEnabled: boolean;
   compression: RequestCompressionPolicy;
+  performFetch?: typeof fetch;
   compressionThresholdBytes?: number;
   onObservation?: (observation: CodexFetchObservation) => void;
 }
@@ -27,6 +28,7 @@ const compressionDisabledEndpoints = new Map<string, number>();
 
 export function createCodexFetchAdapter(options: CodexFetchAdapterOptions): typeof fetch {
   const endpointKey = normalizeCodexEndpoint(options.endpointKey);
+  const performFetch = options.performFetch ?? fetch;
 
   return async (input, init) => {
     const startedAt = Date.now();
@@ -55,7 +57,7 @@ export function createCodexFetchAdapter(options: CodexFetchAdapterOptions): type
       compressedHeaders.set('Content-Length', String(compressedBody.byteLength));
     }
 
-    let response = await fetch(input, {
+    let response = await performFetch(input, {
       ...init,
       headers: compressedHeaders,
       body: shouldCompress ? compressedBody : body
@@ -67,7 +69,7 @@ export function createCodexFetchAdapter(options: CodexFetchAdapterOptions): type
       const retryHeaders = new Headers(headers);
       retryHeaders.delete('Content-Encoding');
       retryHeaders.set('Content-Length', String(bodyBuffer.byteLength));
-      response = await fetch(input, { ...init, headers: retryHeaders, body });
+      response = await performFetch(input, { ...init, headers: retryHeaders, body });
     }
 
     options.onObservation?.({

--- a/src/models.ts
+++ b/src/models.ts
@@ -3,6 +3,7 @@ import type { ProviderConfig } from './config';
 import type { ApiCredentials } from './secrets';
 import { normalizeBaseURL } from './responsesClient';
 import { codexFetch } from './auth/codexAuthRequest';
+import { proxyAwareFetch } from './proxyFetch';
 import {
   getReasoningEffortDescription,
   getReasoningEffortLabel,
@@ -119,8 +120,8 @@ export async function fetchAvailableModels(
     signal: toAbortSignal(token)
   };
   const response = credentials.authManager
-    ? await codexFetch(credentials.authManager, modelsURL, init)
-    : await fetch(modelsURL, {
+    ? await codexFetch(credentials.authManager, modelsURL, init, proxyAwareFetch)
+    : await proxyAwareFetch(modelsURL, {
         ...init,
         headers: {
           Authorization: `Bearer ${credentials.apiKey}`,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,7 +9,12 @@ export function resolveProxyForURL(targetURL: string, environment: NodeJS.Proces
   const workspace = (vscode as typeof vscode & {
     workspace?: { getConfiguration?(section?: string): { get?<T>(key: string): T | undefined } };
   }).workspace;
-  const configuredProxy = workspace?.getConfiguration?.('http').get?.<string>('proxy')?.trim();
+  let configuredProxy: string | undefined;
+  try {
+    configuredProxy = workspace?.getConfiguration?.('http').get?.<string>('proxy')?.trim();
+  } catch {
+    // Keep HTTP requests usable in minimal extension-host shims that do not expose the http section.
+  }
   return configuredProxy || environment.HTTPS_PROXY || environment.https_proxy
     || environment.HTTP_PROXY || environment.http_proxy;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,85 @@
+import { isIP } from 'node:net';
+import * as vscode from 'vscode';
+
+export function resolveProxyForURL(targetURL: string, environment: NodeJS.ProcessEnv = process.env): string | undefined {
+  if (shouldBypassProxy(targetURL, environment)) {
+    return undefined;
+  }
+
+  const workspace = (vscode as typeof vscode & {
+    workspace?: { getConfiguration?(section?: string): { get?<T>(key: string): T | undefined } };
+  }).workspace;
+  const configuredProxy = workspace?.getConfiguration?.('http').get?.<string>('proxy')?.trim();
+  return configuredProxy || environment.HTTPS_PROXY || environment.https_proxy
+    || environment.HTTP_PROXY || environment.http_proxy;
+}
+
+export function shouldBypassProxy(baseURL: string, environment: NodeJS.ProcessEnv = process.env): boolean {
+  let url: URL;
+  try {
+    url = new URL(baseURL);
+  } catch {
+    return false;
+  }
+  const noProxy = [environment.NO_PROXY, environment.no_proxy]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .join(',');
+  const targetHostname = normalizeProxyHostname(url.hostname);
+  if (!noProxy) {
+    return targetHostname === 'localhost' || targetHostname === '127.0.0.1' || targetHostname === '::1';
+  }
+  return noProxy.split(',').some((entry) => {
+    const pattern = entry.trim().toLowerCase();
+    if (!pattern) {
+      return false;
+    }
+    if (pattern === '*') {
+      return true;
+    }
+    const hostname = parseNoProxyHostname(pattern);
+    return Boolean(hostname)
+      && (targetHostname === hostname || targetHostname.endsWith(`.${hostname}`));
+  });
+}
+
+function parseNoProxyHostname(pattern: string): string | undefined {
+  if (/^https?:\/\//.test(pattern)) {
+    try {
+      return normalizeProxyHostname(new URL(pattern).hostname).replace(/^\./, '');
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (pattern.startsWith('[')) {
+    const closingBracket = pattern.indexOf(']');
+    if (closingBracket <= 1) {
+      return undefined;
+    }
+
+    const hostname = pattern.slice(1, closingBracket);
+    const suffix = pattern.slice(closingBracket + 1);
+    if (isIP(hostname) !== 6 || !isValidNoProxyPortSuffix(suffix)) {
+      return undefined;
+    }
+    return normalizeProxyHostname(hostname);
+  }
+
+  const hostname = pattern.split(':').length > 2 ? pattern : pattern.split(':', 1)[0];
+  return normalizeProxyHostname(hostname).replace(/^\./, '') || undefined;
+}
+
+function isValidNoProxyPortSuffix(suffix: string): boolean {
+  if (!suffix) {
+    return true;
+  }
+  if (!/^:\d+$/.test(suffix)) {
+    return false;
+  }
+  const port = Number(suffix.slice(1));
+  return Number.isInteger(port) && port >= 0 && port <= 65535;
+}
+
+function normalizeProxyHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().replace(/^\[|\]$/g, '');
+}

--- a/src/proxyFetch.ts
+++ b/src/proxyFetch.ts
@@ -1,0 +1,25 @@
+import { ProxyAgent, fetch as undiciFetch } from 'undici';
+import { resolveProxyForURL } from './proxy';
+
+const proxyAgents = new Map<string, ProxyAgent>();
+
+export function proxyAwareFetch(input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]): ReturnType<typeof fetch> {
+  const proxy = resolveProxyForURL(input instanceof Request ? input.url : input.toString());
+  if (!proxy) {
+    return fetch(input, init);
+  }
+
+  return undiciFetch(input as Parameters<typeof undiciFetch>[0], {
+    ...init,
+    dispatcher: getProxyAgent(proxy)
+  } as Parameters<typeof undiciFetch>[1]) as ReturnType<typeof fetch>;
+}
+
+function getProxyAgent(proxy: string): ProxyAgent {
+  let agent = proxyAgents.get(proxy);
+  if (!agent) {
+    agent = new ProxyAgent(proxy);
+    proxyAgents.set(proxy, agent);
+  }
+  return agent;
+}

--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -13,12 +13,13 @@ import type {
   ResponseUsage
 } from 'openai/resources/responses/responses';
 import type { Reasoning } from 'openai/resources/shared';
-import { isIP } from 'node:net';
 import * as vscode from 'vscode';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import type { ResponsesInputMessage } from './convertMessages';
 import type { CodexAuthManager } from './auth/codexAuthManager';
 import { codexFetch } from './auth/codexAuthRequest';
+import { proxyAwareFetch } from './proxyFetch';
+import { resolveProxyForURL } from './proxy';
 import {
   buildCodexWebSocketPreconnectHeaders,
   buildCodexRequestHeaders,
@@ -820,6 +821,7 @@ function createOpenAIClient(
     endpointKey: options.compatibilityProfile?.endpointKey ?? normalizeBaseURL(options.baseURL),
     compatibilityEnabled: options.compatibilityProfile?.enabled ?? false,
     compression: options.requestCompression ?? 'disabled',
+    performFetch: proxyAwareFetch,
     onObservation: (observation) => options.onTransportMetrics?.({
       requestBodyBytes: observation.requestBytes,
       compressedBodyBytes: observation.compressedBytes,
@@ -894,88 +896,14 @@ function getHeader(headers: Record<string, string> | undefined, name: string): s
 }
 
 function createResponsesWsOptions(headers?: Record<string, string>, baseURL?: string): ResponsesWSClientOptions {
-  const workspace = (vscode as typeof vscode & {
-    workspace?: { getConfiguration?(section?: string): { get?<T>(key: string): T | undefined } };
-  }).workspace;
-  const configuredProxy = workspace?.getConfiguration?.('http').get?.<string>('proxy')?.trim();
-  const candidateProxy = configuredProxy || process.env.HTTPS_PROXY || process.env.https_proxy
-    || process.env.HTTP_PROXY || process.env.http_proxy;
-  const proxy = baseURL && shouldBypassProxy(baseURL) ? undefined : candidateProxy;
+  const proxy = baseURL ? resolveProxyForURL(baseURL) : undefined;
   return {
     ...(headers ? { headers } : {}),
     ...(proxy ? { agent: new HttpsProxyAgent(proxy) } : {})
   } as unknown as ResponsesWSClientOptions;
 }
 
-export function shouldBypassProxy(baseURL: string, environment: NodeJS.ProcessEnv = process.env): boolean {
-  let url: URL;
-  try {
-    url = new URL(baseURL);
-  } catch {
-    return false;
-  }
-  const noProxy = [environment.NO_PROXY, environment.no_proxy]
-    .filter((value): value is string => Boolean(value?.trim()))
-    .join(',');
-  const targetHostname = normalizeProxyHostname(url.hostname);
-  if (!noProxy) {
-    return targetHostname === 'localhost' || targetHostname === '127.0.0.1' || targetHostname === '::1';
-  }
-  return noProxy.split(',').some((entry) => {
-    const pattern = entry.trim().toLowerCase();
-    if (!pattern) {
-      return false;
-    }
-    if (pattern === '*') {
-      return true;
-    }
-    const hostname = parseNoProxyHostname(pattern);
-    return Boolean(hostname)
-      && (targetHostname === hostname || targetHostname.endsWith(`.${hostname}`));
-  });
-}
-
-function parseNoProxyHostname(pattern: string): string | undefined {
-  if (/^https?:\/\//.test(pattern)) {
-    try {
-      return normalizeProxyHostname(new URL(pattern).hostname).replace(/^\./, '');
-    } catch {
-      return undefined;
-    }
-  }
-
-  if (pattern.startsWith('[')) {
-    const closingBracket = pattern.indexOf(']');
-    if (closingBracket <= 1) {
-      return undefined;
-    }
-
-    const hostname = pattern.slice(1, closingBracket);
-    const suffix = pattern.slice(closingBracket + 1);
-    if (isIP(hostname) !== 6 || !isValidNoProxyPortSuffix(suffix)) {
-      return undefined;
-    }
-    return normalizeProxyHostname(hostname);
-  }
-
-  const hostname = pattern.split(':').length > 2 ? pattern : pattern.split(':', 1)[0];
-  return normalizeProxyHostname(hostname).replace(/^\./, '') || undefined;
-}
-
-function isValidNoProxyPortSuffix(suffix: string): boolean {
-  if (!suffix) {
-    return true;
-  }
-  if (!/^:\d+$/.test(suffix)) {
-    return false;
-  }
-  const port = Number(suffix.slice(1));
-  return Number.isInteger(port) && port >= 0 && port <= 65535;
-}
-
-function normalizeProxyHostname(hostname: string): string {
-  return hostname.trim().toLowerCase().replace(/^\[|\]$/g, '');
-}
+export { shouldBypassProxy } from './proxy';
 
 function getManagedConnectionScope(options: StreamResponseTextOptions): CodexConnectionScope | undefined {
   if (!options.compatibilityProfile?.enabled || !options.identity || !options.authIdentity) {
@@ -1427,8 +1355,8 @@ export async function countInputTokens(options: CountInputTokensOptions): Promis
     signal: toAbortSignal(options.token)
   };
   const response = options.authManager
-    ? await codexFetch(options.authManager, `${normalizeBaseURL(options.baseURL)}/responses/input_tokens`, init)
-    : await fetch(`${normalizeBaseURL(options.baseURL)}/responses/input_tokens`, {
+    ? await codexFetch(options.authManager, `${normalizeBaseURL(options.baseURL)}/responses/input_tokens`, init, proxyAwareFetch)
+    : await proxyAwareFetch(`${normalizeBaseURL(options.baseURL)}/responses/input_tokens`, {
         ...init,
         headers: {
           ...init.headers,

--- a/test/realBackendProbe.mjs
+++ b/test/realBackendProbe.mjs
@@ -37,6 +37,7 @@ const requestServiceTier = requestedServiceTier === 'fast'
 
 const tempDir = await mkdtemp(join(resolveTempDirectory(), 'codex-for-copilot-real-'));
 const secretsBundlePath = join(tempDir, 'secrets.cjs');
+const modelsBundlePath = join(tempDir, 'models.cjs');
 const responsesBundlePath = join(tempDir, 'responsesClient.cjs');
 const moduleLoad = Module._load;
 const require = createRequire(import.meta.url);
@@ -49,6 +50,16 @@ try {
     platform: 'node',
     target: 'node20',
     outfile: secretsBundlePath,
+    external: ['vscode']
+  });
+
+  await build({
+    entryPoints: ['src/models.ts'],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    target: 'node20',
+    outfile: modelsBundlePath,
     external: ['vscode']
   });
 
@@ -82,6 +93,7 @@ try {
   };
 
   const { getApiCredentials, DEFAULT_USER_AGENT } = require(secretsBundlePath);
+  const { fetchAvailableModels } = require(modelsBundlePath);
   const {
     disposeReusableResponsesWebSockets,
     isResponsesContinuationMissError,
@@ -117,6 +129,19 @@ try {
     assertEqual(credentials.headers['ChatGPT-Account-ID'], auth.tokens.account_id, 'account id header');
   }
   assertEqual(credentials.omitMaxOutputTokens, true, 'omit max_output_tokens');
+  const discoveredModels = await fetchAvailableModels({
+    baseURL: 'https://chatgpt.com/backend-api/codex/responses',
+    clientVersion: '0.0.0',
+    includeHiddenModels: false
+  }, credentials, {
+    isCancellationRequested: false,
+    onCancellationRequested() {
+      return { dispose() {} };
+    }
+  });
+  if (discoveredModels.length === 0) {
+    throw new Error('Model discovery returned no callable models.');
+  }
 
   const deltas = [];
   const reasoningSources = new Set();
@@ -297,6 +322,7 @@ try {
 
   console.log(JSON.stringify({
     model: requestedModel,
+    discoveredModelCount: discoveredModels.length,
     transport: requestedTransport,
     continuationProbe: runContinuationProbe,
     preconnectionProbe: preconnection,


### PR DESCRIPTION
## Summary

Routes every outbound Codex HTTP path through the configured proxy, matching the existing WebSocket behavior.

- Adds a shared resolver for VS Code `http.proxy`, `HTTPS_PROXY`/`HTTP_PROXY`, and `NO_PROXY`.
- Uses an Undici proxy dispatcher for model discovery, account usage, HTTP Responses requests, and input-token counting.
- Extends the real-backend probe to verify upstream model discovery before sending a response request.

## Root cause

Only the WebSocket implementation used `HttpsProxyAgent`; HTTP paths called bare `fetch`, so model discovery attempted a direct connection even when the environment required a proxy.

## Validation

- `npm run compile`
- `npm run test:smoke`
- `HTTPS_PROXY=http://127.0.0.1:7890 CODEX_TEST_MODEL=gpt-5.5 npm run test:real-backend` (discovered 7 upstream models; HTTP response completed)