### PR TITLE
fix: update undici security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "https-proxy-agent": "^7.0.6",
         "openai": "^6.44.0",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -4532,9 +4532,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "https-proxy-agent": "^7.0.6",
     "openai": "^6.44.0",
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "ws": "^8.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- raise the direct `undici` dependency from 7.28.0 to 7.29.0
- refresh the lockfile to the patched release
- keep proxy-aware HTTP behavior and the Node runtime floor unchanged

## Why

`undici` is a shipped runtime dependency used by `proxyAwareFetch`. Version 7.29.0 contains the published fixes for the advisories affecting 7.28.0.

## Validation

- `npm audit --omit=dev` (0 vulnerabilities)
- `npm run check`
- `npm run compile`
- `npm run test:smoke`
- `npm run test:extension-host`
- focused Responses/provider proxy-path smoke tests