### PR TITLE
ci: update action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,13 +69,13 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout released version
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.release.outputs.tag }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary

- update `actions/checkout` from v4 to v7
- update `actions/setup-node` from v4 to v7
- retain Node.js 22 for project builds and tests

## Why

The v4 actions use the deprecated Node 20 action runtime and are currently forced onto Node 24 by GitHub-hosted runners. The v7 releases are Node 24-native.

## Validation

- both workflow files parse as YAML
- `npm run check`
- `npm run compile`
- `npm run test:smoke`
- verified both v7 action releases exist