### PR TITLE
fix: report nested connection causes

### DIFF
--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -1436,7 +1436,7 @@ function normalizeResponsesError(error: unknown, baseURL: string): Error {
   }
 
   if (error instanceof APIConnectionError) {
-    const causeMessage = getCauseMessage(error);
+    const causeMessage = getDeepestCauseSummary(error);
     return new Error(
       `Connection failure while contacting ${endpoint}. The OpenAI SDK automatically retried transient connection errors, but the request still failed.${causeMessage ? ` Root cause: ${causeMessage}` : ''}`,
       { cause: error }
@@ -1500,21 +1500,46 @@ function formatStatusAndRequestId(error: Pick<APIError, 'status' | 'requestID'>)
   return `${status}${requestId}`;
 }
 
-function getCauseMessage(error: Error & { cause?: unknown }): string | undefined {
-  const cause = error.cause;
-  if (!cause) {
-    return undefined;
+function getDeepestCauseSummary(error: Error & { cause?: unknown }): string | undefined {
+  let cause = readOwnErrorProperty(error, 'cause');
+  const seen = new WeakSet<object>();
+  let summary: string | undefined;
+
+  for (let depth = 0; depth < MAX_ERROR_TRAVERSAL_DEPTH; depth += 1) {
+    if (cause === undefined || cause === null || cause === UNREADABLE_ERROR_PROPERTY) {
+      break;
+    }
+
+    if (typeof cause === 'string') {
+      summary = cause.trim() || summary;
+      break;
+    }
+
+    if (typeof cause !== 'object') {
+      break;
+    }
+
+    if (seen.has(cause)) {
+      break;
+    }
+    seen.add(cause);
+
+    const message = readOwnErrorProperty(cause, 'message');
+    const code = readOwnErrorProperty(cause, 'code');
+    const messageText = typeof message === 'string' ? message.trim() : '';
+    const codeText = typeof code === 'string' || typeof code === 'number' ? String(code).trim() : '';
+    if (messageText) {
+      summary = codeText && !messageText.toLowerCase().includes(codeText.toLowerCase())
+        ? `${messageText} (${codeText})`
+        : messageText;
+    } else if (codeText) {
+      summary = codeText;
+    }
+
+    cause = readOwnErrorProperty(cause, 'cause');
   }
 
-  if (cause instanceof Error && cause.message.trim()) {
-    return cause.message.trim();
-  }
-
-  if (typeof cause === 'string' && cause.trim()) {
-    return cause.trim();
-  }
-
-  return undefined;
+  return summary;
 }
 
 async function safeReadResponseBody(response: Response): Promise<string> {

--- a/test/smokeResponsesClient.mjs
+++ b/test/smokeResponsesClient.mjs
@@ -44,6 +44,7 @@ const {
 
 try {
   runContinuationMissClassifierSmokeTest(isResponsesContinuationMissPayload);
+  await runNestedConnectionCauseSmokeTest(streamResponseText);
   await runHttpTransportSmokeTest(streamResponseText);
   await runHttpContinuationMissSmokeTest(streamResponseText, isResponsesContinuationMissError);
   await runFunctionCallArgumentsDoneSmokeTest(streamResponseText);
@@ -64,6 +65,47 @@ try {
   disposeReusableResponsesWebSockets();
   Module._load = moduleLoad;
   await rm(tempDir, { recursive: true, force: true });
+}
+
+async function runNestedConnectionCauseSmokeTest(streamResponseText) {
+  const originalFetch = globalThis.fetch;
+  let requestCount = 0;
+  let capturedError;
+  const dnsError = Object.assign(new Error('getaddrinfo ENOTFOUND chatgpt.invalid'), {
+    code: 'ENOTFOUND'
+  });
+
+  globalThis.fetch = async () => {
+    requestCount += 1;
+    throw new TypeError('fetch failed', { cause: dnsError });
+  };
+
+  try {
+    await streamResponseText({
+      baseURL: 'https://chatgpt.invalid/backend-api/codex/responses',
+      apiKey: 'test-api-key',
+      headers: createHeaders(),
+      transport: 'http',
+      omitMaxOutputTokens: true,
+      model: 'gpt-5.5',
+      instructions: 'Smoke test instructions',
+      input: [{ role: 'user', content: 'Ping' }],
+      maxOutputTokens: 32,
+      token: createCancellationToken(),
+      onTextDelta() {}
+    });
+  } catch (error) {
+    capturedError = error;
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assertEqual(requestCount, 3, 'connection failure uses the SDK retry budget');
+  assertEqual(
+    capturedError?.message,
+    'Connection failure while contacting https://chatgpt.invalid/backend-api/codex/responses. The OpenAI SDK automatically retried transient connection errors, but the request still failed. Root cause: getaddrinfo ENOTFOUND chatgpt.invalid',
+    'connection failure reports the deepest useful cause'
+  );
 }
 
 function runContinuationMissClassifierSmokeTest(isContinuationMissPayload) {


### PR DESCRIPTION
## Summary

- traverse bounded, cycle-safe connection-error cause chains
- surface the deepest useful DNS, TLS, proxy, or socket cause instead of only `fetch failed`
- add deterministic SDK retry and `ENOTFOUND` regression coverage

## Validation

- `npm run check`
- `npm run compile`
- `npm run test:smoke`
- `npm run test:extension-host`
- focused `smokeResponsesClient.mjs`
- zero LSP diagnostics and clean diff check