### PR TITLE
feat: add native long context size picker

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -83,9 +83,14 @@ export interface ResolvedProviderModel {
   effectiveInputBudget: number;
 }
 
-type ThinkingEffortSchema = {
+interface ContextSizeOption {
+  readonly value: number;
+  readonly description: string;
+}
+
+type ModelConfigurationSchema = {
   readonly properties: {
-    readonly reasoningEffort: {
+    readonly reasoningEffort?: {
       readonly type: 'string';
       readonly title: string;
       readonly enum: readonly ReasoningEffort[];
@@ -94,11 +99,20 @@ type ThinkingEffortSchema = {
       readonly default: ReasoningEffort;
       readonly group: 'navigation';
     };
+    readonly contextSize?: {
+      readonly type: 'number';
+      readonly title: string;
+      readonly enum: readonly number[];
+      readonly enumItemLabels: readonly string[];
+      readonly enumDescriptions: readonly string[];
+      readonly default: number;
+      readonly group: 'tokens';
+    };
   };
 };
 
 type ModelPickerChatInformation = vscode.LanguageModelChatInformation & {
-  readonly configurationSchema?: ThinkingEffortSchema;
+  readonly configurationSchema?: ModelConfigurationSchema;
 };
 
 export interface ParsedModelIdentifier {
@@ -236,16 +250,30 @@ function buildDiscoveredModels(
   const effectiveInputBudget = getEffectiveInputBudget(activeRawContextWindow, effectiveContextWindowPercent);
   const maximumContextWindow = getPositiveInteger(model.max_context_window);
   const knownRawContextCeiling = getKnownCodexRawContextCeiling(slug, config.baseURL, credentialKind);
+  const longRawContextWindow = getLongContextWindow(slug, activeRawContextWindow, maximumContextWindow, knownRawContextCeiling);
+  const contextSizeOptions = getContextSizeOptions(
+    activeRawContextWindow,
+    effectiveInputBudget,
+    longRawContextWindow,
+    effectiveContextWindowPercent,
+    slug
+  );
+  const maximumEffectiveInputBudget = Math.max(...contextSizeOptions.map((option) => option.value));
   const imageInput = Array.isArray(model.input_modalities) && model.input_modalities.includes('image');
   const tooltip = getModelDescription(model, slug);
   const versionBase = typeof model.comp_hash === 'string' && model.comp_hash.trim() ? model.comp_hash.trim() : '1.0.0';
+  const configurationSchema = buildModelConfigurationSchema(
+    reasoningOptions,
+    defaultReasoningEffort ?? reasoningEfforts[0],
+    contextSizeOptions
+  );
 
   const info: ModelPickerChatInformation = {
     id: toProviderModelId(slug),
     name: displayName,
     family: slug,
     version: versionBase,
-    maxInputTokens: effectiveInputBudget,
+    maxInputTokens: maximumEffectiveInputBudget,
     maxOutputTokens: config.maxOutputTokens,
     tooltip,
     detail: buildModelDetail(
@@ -261,49 +289,16 @@ function buildDiscoveredModels(
       imageInput,
       toolCalling: true
     },
-    ...(reasoningEfforts.length > 1
-      ? { configurationSchema: buildThinkingEffortSchema(reasoningOptions, defaultReasoningEffort ?? reasoningEfforts[0]) }
-      : {})
+    ...(configurationSchema ? { configurationSchema } : {})
   };
 
-  const standardModel = {
+  return [{
     requestModel: slug,
     reasoningEffort: defaultReasoningEffort ?? reasoningEfforts[0],
     rawContextWindow: activeRawContextWindow,
     effectiveInputBudget,
     info
-  };
-
-  const longRawContextWindow = getLongContextWindow(slug, activeRawContextWindow, maximumContextWindow, knownRawContextCeiling);
-  if (!longRawContextWindow) {
-    return [standardModel];
-  }
-
-  const longEffectiveInputBudget = getEffectiveInputBudget(longRawContextWindow, effectiveContextWindowPercent);
-  const experimental = isExperimentalLongContextProfile(slug, longRawContextWindow);
-
-  return [
-    standardModel,
-    {
-      requestModel: slug,
-      reasoningEffort: standardModel.reasoningEffort,
-      rawContextWindow: longRawContextWindow,
-      effectiveInputBudget: longEffectiveInputBudget,
-      info: {
-        ...info,
-        id: toLongContextProviderModelId(slug, longRawContextWindow),
-        name: `${displayName} (Long context)${experimental ? ' (Experimental)' : ''}`,
-        maxInputTokens: longEffectiveInputBudget,
-        detail: buildLongContextDetail(
-          longRawContextWindow,
-          longEffectiveInputBudget,
-          experimental,
-          reasoningOptions,
-          defaultReasoningEffort
-        )
-      }
-    }
-  ];
+  }];
 }
 
 function getReasoningOptions(model: UpstreamModel | undefined, slug: string): ReasoningOption[] {
@@ -455,10 +450,6 @@ function toProviderModelId(requestModel: string): string {
   return `${PROVIDER_MODEL_ID_PREFIX}${requestModel}`;
 }
 
-function toLongContextProviderModelId(requestModel: string, contextWindow: number): string {
-  return `${toProviderModelId(requestModel)}${CONTEXT_ID_DELIMITER}${contextWindow}`;
-}
-
 function stripProviderModelIdPrefix(modelId: string): string {
   return modelId.startsWith(PROVIDER_MODEL_ID_PREFIX)
     ? modelId.slice(PROVIDER_MODEL_ID_PREFIX.length)
@@ -500,21 +491,6 @@ function buildModelDetail(
   return parts.join(' | ');
 }
 
-function buildLongContextDetail(
-  rawContextWindow: number,
-  effectiveInputBudget: number,
-  experimental: boolean,
-  reasoningOptions?: readonly ReasoningOption[],
-  defaultReasoningEffort?: ReasoningEffort
-): string {
-  const parts = [
-    `Long context${experimental ? ' (Experimental)' : ''}: ${formatTokenCount(effectiveInputBudget)} effective input budget`,
-    `Raw context window: ${formatTokenCount(rawContextWindow)}`
-  ];
-  appendReasoningDetail(parts, reasoningOptions, defaultReasoningEffort);
-  return parts.join(' | ');
-}
-
 function appendReasoningDetail(
   parts: string[],
   reasoningOptions?: readonly ReasoningOption[],
@@ -532,24 +508,72 @@ function appendReasoningDetail(
   }
 }
 
-function buildThinkingEffortSchema(reasoningOptions: readonly ReasoningOption[], defaultEffort: ReasoningEffort): ThinkingEffortSchema {
-  const efforts = reasoningOptions.map((option) => option.effort);
-  const labels = reasoningOptions.map((option) => formatReasoningEffort(option.effort));
-  const descriptions = reasoningOptions.map((option) => option.description);
+function getContextSizeOptions(
+  activeRawContextWindow: number,
+  effectiveInputBudget: number,
+  longRawContextWindow: number | undefined,
+  effectiveContextWindowPercent: number,
+  model: string
+): ContextSizeOption[] {
+  const options: ContextSizeOption[] = [{
+    value: effectiveInputBudget,
+    description: 'Default context size.'
+  }];
 
-  return {
-    properties: {
-      reasoningEffort: {
-        type: 'string',
-        title: 'Thinking Effort',
-        enum: [...efforts],
-        enumItemLabels: labels,
-        enumDescriptions: descriptions,
-        default: defaultEffort,
-        group: 'navigation'
-      }
-    }
-  };
+  if (!longRawContextWindow) {
+    return options;
+  }
+
+  const longEffectiveInputBudget = getEffectiveInputBudget(longRawContextWindow, effectiveContextWindowPercent);
+  if (longEffectiveInputBudget <= effectiveInputBudget) {
+    return options;
+  }
+
+  options.push({
+    value: longEffectiveInputBudget,
+    description: isExperimentalLongContextProfile(model, longRawContextWindow)
+      ? 'Long context (Experimental).'
+      : 'Long context.'
+  });
+  return options;
+}
+
+function buildModelConfigurationSchema(
+  reasoningOptions: readonly ReasoningOption[],
+  defaultEffort: ReasoningEffort | undefined,
+  contextSizeOptions: readonly ContextSizeOption[]
+): ModelConfigurationSchema | undefined {
+  const properties: ModelConfigurationSchema['properties'] = {};
+
+  if (reasoningOptions.length > 1 && defaultEffort) {
+    properties.reasoningEffort = {
+      type: 'string',
+      title: 'Thinking Effort',
+      enum: reasoningOptions.map((option) => option.effort),
+      enumItemLabels: reasoningOptions.map((option) => formatReasoningEffort(option.effort)),
+      enumDescriptions: reasoningOptions.map((option) => option.description),
+      default: defaultEffort,
+      group: 'navigation'
+    };
+  }
+
+  if (contextSizeOptions.length > 1) {
+    properties.contextSize = {
+      type: 'number',
+      title: 'Context Size',
+      enum: contextSizeOptions.map((option) => option.value),
+      enumItemLabels: contextSizeOptions.map((option) => formatContextSize(option.value)),
+      enumDescriptions: contextSizeOptions.map((option) => option.description),
+      default: contextSizeOptions[0].value,
+      group: 'tokens'
+    };
+  }
+
+  return Object.keys(properties).length > 0 ? { properties } : undefined;
+}
+
+function formatContextSize(value: number): string {
+  return value % 1000 === 0 ? `${value / 1000}K` : formatTokenCount(value);
 }
 
 function formatTokenCount(value: number): string {

--- a/src/models.ts
+++ b/src/models.ts
@@ -573,7 +573,11 @@ function buildModelConfigurationSchema(
 }
 
 function formatContextSize(value: number): string {
-  return value % 1000 === 0 ? `${value / 1000}K` : formatTokenCount(value);
+  if (value < 1000) {
+    return formatTokenCount(value);
+  }
+
+  return `${Number((value / 1000).toFixed(1))}K`;
 }
 
 function formatTokenCount(value: number): string {

--- a/src/models.ts
+++ b/src/models.ts
@@ -90,7 +90,7 @@ interface ContextSizeOption {
 
 type ModelConfigurationSchema = {
   readonly properties: {
-    readonly reasoningEffort?: {
+    reasoningEffort?: {
       readonly type: 'string';
       readonly title: string;
       readonly enum: readonly ReasoningEffort[];
@@ -99,7 +99,7 @@ type ModelConfigurationSchema = {
       readonly default: ReasoningEffort;
       readonly group: 'navigation';
     };
-    readonly contextSize?: {
+    contextSize?: {
       readonly type: 'number';
       readonly title: string;
       readonly enum: readonly number[];

--- a/src/models.ts
+++ b/src/models.ts
@@ -18,19 +18,12 @@ const CONTEXT_ID_DELIMITER = '::context=';
 const PROVIDER_MODEL_ID_PREFIX = 'codex::';
 const DEFAULT_FALLBACK_CONTEXT_WINDOW = 272000;
 const DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 95;
-const GPT_5_4_LONG_CONTEXT_WINDOW = 1000000;
-const GPT_5_6_LONG_CONTEXT_WINDOW = 372000;
 const FIXED_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'gpt-5.5': 272000,
   'gpt-5.4': 272000,
   'gpt-5.4-mini': 272000,
   'gpt-5.3-codex-spark': 128000,
   'codex-auto-review': 272000
-};
-const KNOWN_CODEX_RAW_CONTEXT_CEILINGS: Readonly<Record<string, number>> = {
-  'gpt-5.6-sol': GPT_5_6_LONG_CONTEXT_WINDOW,
-  'gpt-5.6-terra': GPT_5_6_LONG_CONTEXT_WINDOW,
-  'gpt-5.6-luna': GPT_5_6_LONG_CONTEXT_WINDOW
 };
 
 const MODEL_DESCRIPTION_FALLBACKS: Record<string, string> = {
@@ -80,11 +73,13 @@ export interface ResolvedProviderModel {
   requestModel: string;
   reasoningEffort?: ReasoningEffort;
   rawContextWindow: number;
+  maximumRawContextWindow?: number;
   effectiveInputBudget: number;
 }
 
 interface ContextSizeOption {
   readonly value: number;
+  readonly rawContextWindow: number;
   readonly description: string;
 }
 
@@ -186,7 +181,6 @@ export function buildProviderModels(
 export function buildFallbackModel(config: ProviderConfig, credentialKind: ApiCredentials['kind']): ResolvedProviderModel {
   const rawContextWindow = getFallbackContextWindow(config.model);
   const effectiveInputBudget = getEffectiveInputBudget(rawContextWindow, DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT);
-  const knownRawContextCeiling = getKnownCodexRawContextCeiling(config.model, config.baseURL, credentialKind);
   const reasoningEffort = getDefaultReasoningEffort(undefined, config.model);
   const reasoningOptions = getReasoningOptions(undefined, config.model);
   return {
@@ -208,8 +202,7 @@ export function buildFallbackModel(config: ProviderConfig, credentialKind: ApiCr
         reasoningOptions,
         reasoningEffort,
         config.baseURL,
-        undefined,
-        knownRawContextCeiling
+        undefined
       ),
       capabilities: {
         imageInput: false,
@@ -249,14 +242,12 @@ function buildDiscoveredModels(
   const effectiveContextWindowPercent = getEffectiveContextWindowPercent(model.effective_context_window_percent);
   const effectiveInputBudget = getEffectiveInputBudget(activeRawContextWindow, effectiveContextWindowPercent);
   const maximumContextWindow = getPositiveInteger(model.max_context_window);
-  const knownRawContextCeiling = getKnownCodexRawContextCeiling(slug, config.baseURL, credentialKind);
-  const longRawContextWindow = getLongContextWindow(slug, activeRawContextWindow, maximumContextWindow, knownRawContextCeiling);
+  const longRawContextWindow = getLongContextWindow(activeRawContextWindow, maximumContextWindow);
   const contextSizeOptions = getContextSizeOptions(
     activeRawContextWindow,
     effectiveInputBudget,
     longRawContextWindow,
-    effectiveContextWindowPercent,
-    slug
+    effectiveContextWindowPercent
   );
   const maximumEffectiveInputBudget = Math.max(...contextSizeOptions.map((option) => option.value));
   const imageInput = Array.isArray(model.input_modalities) && model.input_modalities.includes('image');
@@ -282,8 +273,7 @@ function buildDiscoveredModels(
       reasoningOptions,
       defaultReasoningEffort,
       undefined,
-      maximumContextWindow,
-      knownRawContextCeiling
+      maximumContextWindow
     ),
     capabilities: {
       imageInput,
@@ -296,6 +286,7 @@ function buildDiscoveredModels(
     requestModel: slug,
     reasoningEffort: defaultReasoningEffort ?? reasoningEfforts[0],
     rawContextWindow: activeRawContextWindow,
+    maximumRawContextWindow: maximumContextWindow,
     effectiveInputBudget,
     info
   }];
@@ -389,61 +380,10 @@ function getEffectiveInputBudget(rawContextWindow: number, percent: number): num
   return Math.floor(rawContextWindow * percent / 100);
 }
 
-function getLongContextWindow(
-  model: string,
-  activeContextWindow: number,
-  maximumContextWindow: number | undefined,
-  knownRawContextCeiling: number | undefined
-): number | undefined {
-  if (
-    model === 'gpt-5.4'
-    && maximumContextWindow !== undefined
-    && maximumContextWindow >= GPT_5_4_LONG_CONTEXT_WINDOW
-    && activeContextWindow < GPT_5_4_LONG_CONTEXT_WINDOW
-  ) {
-    return GPT_5_4_LONG_CONTEXT_WINDOW;
-  }
-
-  if (
-    knownRawContextCeiling === GPT_5_6_LONG_CONTEXT_WINDOW
-    && activeContextWindow < GPT_5_6_LONG_CONTEXT_WINDOW
-  ) {
-    return GPT_5_6_LONG_CONTEXT_WINDOW;
-  }
-
-  return undefined;
-}
-
-function getKnownCodexRawContextCeiling(
-  model: string,
-  baseURL: string,
-  credentialKind: ApiCredentials['kind']
-): number | undefined {
-  if (credentialKind !== 'codexAccessToken' || !isChatGptCodexBackend(baseURL)) {
-    return undefined;
-  }
-
-  return KNOWN_CODEX_RAW_CONTEXT_CEILINGS[model];
-}
-
-function isExperimentalLongContextProfile(model: string, rawContextWindow: number): boolean {
-  return KNOWN_CODEX_RAW_CONTEXT_CEILINGS[model] === GPT_5_6_LONG_CONTEXT_WINDOW
-    && rawContextWindow === GPT_5_6_LONG_CONTEXT_WINDOW;
-}
-
-function isChatGptCodexBackend(baseURL: string): boolean {
-  try {
-    const url = new URL(normalizeBaseURL(baseURL));
-    const path = url.pathname.replace(/\/+$/, '');
-    return url.origin === 'https://chatgpt.com'
-      && !url.username
-      && !url.password
-      && !url.search
-      && !url.hash
-      && path === '/backend-api/codex';
-  } catch {
-    return false;
-  }
+function getLongContextWindow(activeContextWindow: number, maximumContextWindow: number | undefined): number | undefined {
+  return maximumContextWindow !== undefined && maximumContextWindow > activeContextWindow
+    ? maximumContextWindow
+    : undefined;
 }
 
 function toProviderModelId(requestModel: string): string {
@@ -462,13 +402,9 @@ function buildModelDetail(
   reasoningOptions?: readonly ReasoningOption[],
   defaultReasoningEffort?: ReasoningEffort,
   sourceHint?: string,
-  maximumContextWindow?: number,
-  knownRawContextCeiling?: number
+  maximumContextWindow?: number
 ): string {
   const hasLargerMaximum = maximumContextWindow !== undefined && maximumContextWindow > activeRawContextWindow;
-  const hasLargerKnownCeiling = knownRawContextCeiling !== undefined
-    && knownRawContextCeiling > activeRawContextWindow
-    && (maximumContextWindow === undefined || knownRawContextCeiling > maximumContextWindow);
   const parts = [
     `Effective input budget: ${formatTokenCount(effectiveInputBudget)}`,
     `Raw context window: ${formatTokenCount(activeRawContextWindow)}${hasLargerMaximum ? ' (active)' : ''}`
@@ -476,10 +412,6 @@ function buildModelDetail(
 
   if (hasLargerMaximum) {
     parts.push(`Maximum context: ${formatTokenCount(maximumContextWindow)} (opt-in)`);
-  }
-
-  if (hasLargerKnownCeiling) {
-    parts.push(`Known raw context ceiling: ${formatTokenCount(knownRawContextCeiling)}`);
   }
 
   appendReasoningDetail(parts, reasoningOptions, defaultReasoningEffort);
@@ -512,11 +444,11 @@ function getContextSizeOptions(
   activeRawContextWindow: number,
   effectiveInputBudget: number,
   longRawContextWindow: number | undefined,
-  effectiveContextWindowPercent: number,
-  model: string
+  effectiveContextWindowPercent: number
 ): ContextSizeOption[] {
   const options: ContextSizeOption[] = [{
     value: effectiveInputBudget,
+    rawContextWindow: activeRawContextWindow,
     description: 'Default context size.'
   }];
 
@@ -531,9 +463,8 @@ function getContextSizeOptions(
 
   options.push({
     value: longEffectiveInputBudget,
-    description: isExperimentalLongContextProfile(model, longRawContextWindow)
-      ? 'Long context (Experimental).'
-      : 'Long context.'
+    rawContextWindow: longRawContextWindow,
+    description: 'Long context.'
   });
   return options;
 }
@@ -562,7 +493,7 @@ function buildModelConfigurationSchema(
       type: 'number',
       title: 'Context Size',
       enum: contextSizeOptions.map((option) => option.value),
-      enumItemLabels: contextSizeOptions.map((option) => formatContextSize(option.value)),
+      enumItemLabels: contextSizeOptions.map((option) => formatContextSize(option.rawContextWindow)),
       enumDescriptions: contextSizeOptions.map((option) => option.description),
       default: contextSizeOptions[0].value,
       group: 'tokens'
@@ -626,12 +557,11 @@ function isModelVisible(
 }
 
 function getPositiveInteger(value: unknown): number | undefined {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
     return undefined;
   }
 
-  const normalized = Math.floor(value);
-  return Number.isSafeInteger(normalized) && normalized > 0 ? normalized : undefined;
+  return value;
 }
 
 function toAbortSignal(token: vscode.CancellationToken): AbortSignal | undefined {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -305,6 +305,14 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       });
       selectedModel = this.resolveRequestModel(model.id, config, catalog.models, catalog.authoritative);
     }
+    selectedModel = {
+      ...selectedModel,
+      effectiveInputBudget: resolveConfiguredContextSize(
+        selectedModel.effectiveInputBudget,
+        model,
+        options as RuntimeProvideLanguageModelChatResponseOptions
+      )
+    };
     this.scheduleWebSocketPreconnection(config, credentials, authIdentity);
     latency.mark('modelResolved');
     this.selectedModelSink?.setSelectedModel(selectedModel.requestModel);
@@ -1837,6 +1845,41 @@ export function getReasoningEffort(
   defaultReasoningEffort: ReasoningEffort | undefined
 ): ReasoningEffortResolution {
   return resolveReasoningEffort(selectedReasoningEffort, options, defaultReasoningEffort);
+}
+
+type ContextSizeSchemaCarrier = {
+  readonly configurationSchema?: {
+    readonly properties?: {
+      readonly contextSize?: {
+        readonly enum?: readonly unknown[];
+      };
+    };
+  };
+};
+
+function resolveConfiguredContextSize(
+  defaultBudget: number | undefined,
+  model: vscode.LanguageModelChatInformation,
+  options: RuntimeProvideLanguageModelChatResponseOptions
+): number | undefined {
+  const supportedSizes = getConfiguredContextSizeOptions(model);
+  if (supportedSizes.length === 0) {
+    return defaultBudget;
+  }
+
+  for (const candidate of [options.modelConfiguration?.contextSize, options.configuration?.contextSize]) {
+    if (typeof candidate === 'number' && Number.isSafeInteger(candidate) && supportedSizes.includes(candidate)) {
+      return candidate;
+    }
+  }
+
+  return defaultBudget;
+}
+
+function getConfiguredContextSizeOptions(model: vscode.LanguageModelChatInformation): number[] {
+  const values = (model as vscode.LanguageModelChatInformation & ContextSizeSchemaCarrier)
+    .configurationSchema?.properties?.contextSize?.enum ?? [];
+  return values.filter((value): value is number => Number.isSafeInteger(value) && value > 0);
 }
 
 function supportsOfficialTokenCounting(baseURL: string): boolean {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1885,7 +1885,7 @@ function getContextSizeSchema(model: vscode.LanguageModelChatInformation): { opt
   }
 
   const options = (contextSize.enum ?? [])
-    .filter((value): value is number => Number.isSafeInteger(value) && value > 0);
+    .filter((value): value is number => typeof value === 'number' && Number.isSafeInteger(value) && value > 0);
   if (options.length === 0) {
     return undefined;
   }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1852,34 +1852,50 @@ type ContextSizeSchemaCarrier = {
     readonly properties?: {
       readonly contextSize?: {
         readonly enum?: readonly unknown[];
+        readonly default?: unknown;
       };
     };
   };
 };
 
 function resolveConfiguredContextSize(
-  defaultBudget: number | undefined,
+  fallbackBudget: number | undefined,
   model: vscode.LanguageModelChatInformation,
   options: RuntimeProvideLanguageModelChatResponseOptions
 ): number | undefined {
-  const supportedSizes = getConfiguredContextSizeOptions(model);
-  if (supportedSizes.length === 0) {
-    return defaultBudget;
+  const contextSizeSchema = getContextSizeSchema(model);
+  if (!contextSizeSchema) {
+    return fallbackBudget;
   }
 
   for (const candidate of [options.modelConfiguration?.contextSize, options.configuration?.contextSize]) {
-    if (typeof candidate === 'number' && Number.isSafeInteger(candidate) && supportedSizes.includes(candidate)) {
+    if (typeof candidate === 'number' && Number.isSafeInteger(candidate) && contextSizeSchema.options.includes(candidate)) {
       return candidate;
     }
   }
 
-  return defaultBudget;
+  return contextSizeSchema.default ?? fallbackBudget;
 }
 
-function getConfiguredContextSizeOptions(model: vscode.LanguageModelChatInformation): number[] {
-  const values = (model as vscode.LanguageModelChatInformation & ContextSizeSchemaCarrier)
-    .configurationSchema?.properties?.contextSize?.enum ?? [];
-  return values.filter((value): value is number => Number.isSafeInteger(value) && value > 0);
+function getContextSizeSchema(model: vscode.LanguageModelChatInformation): { options: number[]; default: number | undefined } | undefined {
+  const contextSize = (model as vscode.LanguageModelChatInformation & ContextSizeSchemaCarrier)
+    .configurationSchema?.properties?.contextSize;
+  if (!contextSize) {
+    return undefined;
+  }
+
+  const options = (contextSize.enum ?? [])
+    .filter((value): value is number => Number.isSafeInteger(value) && value > 0);
+  if (options.length === 0) {
+    return undefined;
+  }
+
+  return {
+    options,
+    default: typeof contextSize.default === 'number' && options.includes(contextSize.default)
+      ? contextSize.default
+      : undefined
+  };
 }
 
 function supportsOfficialTokenCounting(baseURL: string): boolean {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1370,7 +1370,13 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     logger.debug('getAvailableModels discovery success', {
       discoveredCount: upstreamModels.length,
       returnedCount: models.length,
-      requestModels: models.map((model) => model.requestModel)
+      models: models.map((model) => ({
+        requestModel: model.requestModel,
+        activeRawContextWindow: model.rawContextWindow,
+        maximumRawContextWindow: model.maximumRawContextWindow ?? null,
+        effectiveInputBudget: model.effectiveInputBudget,
+        maximumEffectiveInputBudget: model.info.maxInputTokens
+      }))
     });
     return { models, authoritative: true };
   }

--- a/test/extensionHostSmoke.cjs
+++ b/test/extensionHostSmoke.cjs
@@ -110,14 +110,8 @@ async function run() {
     }
 
     if (responseRequestCount === 3) {
-      assert.strictEqual(body.previous_response_id, undefined, 'Long-to-standard downgrade must start a new chain.');
-      assert.deepStrictEqual(body.input, [
-        { type: 'message', role: 'user', content: 'Profile start' },
-        { type: 'message', role: 'assistant', content: 'standard reply' },
-        { type: 'message', role: 'user', content: 'Expand context' },
-        { type: 'message', role: 'assistant', content: 'long reply' },
-        { type: 'message', role: 'user', content: 'Return to standard' }
-      ]);
+      assert.strictEqual(body.previous_response_id, 'resp_profile_long');
+      assert.deepStrictEqual(body.input, [{ type: 'message', role: 'user', content: 'Return to standard' }]);
       writeTextResponse(response, 'downgrade reply', 'resp_profile_downgrade');
       return;
     }
@@ -198,27 +192,22 @@ async function run() {
 
     const models = await vscode.lm.selectChatModels({ vendor: 'codex-for-copilot' });
     assert(modelDiscoveryRequestCount > 0, 'Model discovery did not reach the mock backend; verify isolated test credentials.');
-    const standardModel = models.find((model) => model.id === 'codex::gpt-5.4');
-    const longModel = models.find((model) => model.id === 'codex::gpt-5.4::context=1000000');
-    assert(standardModel, 'Hidden GPT-5.4 standard profile was not selectable.');
-    assert(longModel, 'Hidden GPT-5.4 long profile was not selectable.');
-    assert.strictEqual(models.length, 2);
-    assert.strictEqual(standardModel.name, 'GPT-5.4');
-    assert.strictEqual(standardModel.family, 'gpt-5.4');
-    assert.strictEqual(standardModel.maxInputTokens, 258400);
-    assert.strictEqual(longModel.name, 'GPT-5.4 (Long context)');
-    assert.strictEqual(longModel.family, 'gpt-5.4');
-    assert.strictEqual(longModel.maxInputTokens, 950000);
+    const model = models.find((candidate) => candidate.id === 'codex::gpt-5.4');
+    assert(model, 'Hidden GPT-5.4 model was not selectable.');
+    assert.strictEqual(models.length, 1);
+    assert.strictEqual(model.name, 'GPT-5.4');
+    assert.strictEqual(model.family, 'gpt-5.4');
+    assert.strictEqual(model.maxInputTokens, 950000);
 
-    assert.strictEqual(await collectText(await standardModel.sendRequest([
+    assert.strictEqual(await collectText(await model.sendRequest([
       vscode.LanguageModelChatMessage.User('Profile start')
     ])), 'standard reply');
-    assert.strictEqual(await collectText(await longModel.sendRequest([
+    assert.strictEqual(await collectText(await model.sendRequest([
       vscode.LanguageModelChatMessage.User('Profile start'),
       vscode.LanguageModelChatMessage.Assistant('standard reply'),
       vscode.LanguageModelChatMessage.User('Expand context')
     ])), 'long reply');
-    assert.strictEqual(await collectText(await standardModel.sendRequest([
+    assert.strictEqual(await collectText(await model.sendRequest([
       vscode.LanguageModelChatMessage.User('Profile start'),
       vscode.LanguageModelChatMessage.Assistant('standard reply'),
       vscode.LanguageModelChatMessage.User('Expand context'),
@@ -226,7 +215,7 @@ async function run() {
       vscode.LanguageModelChatMessage.User('Return to standard')
     ])), 'downgrade reply');
 
-    assert.strictEqual(await standardModel.countTokens('Ping'), 11);
+    assert.strictEqual(await model.countTokens('Ping'), 11);
     const tool = {
       name: 'extension_host_smoke_tool',
       description: 'Returns a deterministic smoke-test value.',
@@ -236,7 +225,7 @@ async function run() {
         required: ['value']
       }
     };
-    const toolResponse = await standardModel.sendRequest(
+    const toolResponse = await model.sendRequest(
       [vscode.LanguageModelChatMessage.User('Ping')],
       { tools: [tool], toolMode: vscode.LanguageModelChatToolMode.Required }
     );
@@ -251,7 +240,7 @@ async function run() {
     assert.strictEqual(toolCalls[0].name, 'extension_host_smoke_tool');
     assert.deepStrictEqual(toolCalls[0].input, { value: 'ping' });
 
-    const response = await standardModel.sendRequest([
+    const response = await model.sendRequest([
       vscode.LanguageModelChatMessage.User('Ping'),
       vscode.LanguageModelChatMessage.Assistant([toolCalls[0]]),
       vscode.LanguageModelChatMessage.User([
@@ -266,7 +255,7 @@ async function run() {
     if (process.env.CODEX_EXTENSION_HOST_SMOKE_RESULT_PATH) {
       await writeFile(process.env.CODEX_EXTENSION_HOST_SMOKE_RESULT_PATH, JSON.stringify({ passed: true }));
     }
-    console.log(`Extension host smoke passed: profiles, token counting, and tool loop completed with ${standardModel.vendor}/${standardModel.id}.`);
+    console.log(`Extension host smoke passed: profiles, token counting, and tool loop completed with ${model.vendor}/${model.id}.`);
   } finally {
     try {
       if (config) {

--- a/test/realBackendProbe.mjs
+++ b/test/realBackendProbe.mjs
@@ -19,6 +19,7 @@ const runContinuationProbe = process.env.CODEX_TEST_CONTINUATION === '1';
 const runPreconnectionProbe = process.env.CODEX_TEST_PRECONNECT === '1';
 const shouldRunToolContinuationProbe = process.env.CODEX_TEST_TOOL_CONTINUATION === '1';
 const shouldRunNativeToolSearchProbe = process.env.CODEX_TEST_NATIVE_TOOL_SEARCH === '1';
+const shouldAssertContextCatalog = process.env.CODEX_TEST_ASSERT_CONTEXT_CATALOG === '1';
 const requestStore = process.env.CODEX_TEST_STORE === '1';
 const requestedPrewarm = parsePrewarmSetting(process.env.CODEX_TEST_PREWARM);
 const requestedReasoningEffort = parseReasoningEffort(process.env.CODEX_TEST_REASONING_EFFORT);
@@ -143,6 +144,9 @@ try {
   if (discoveredModels.length === 0) {
     throw new Error('Model discovery returned no callable models.');
   }
+  const contextCatalog = shouldAssertContextCatalog
+    ? assertGpt56ContextCatalog(discoveredModels)
+    : undefined;
 
   const deltas = [];
   const reasoningSources = new Set();
@@ -337,6 +341,7 @@ try {
   console.log(JSON.stringify({
     model: requestedModel,
     discoveredModelCount: discoveredModels.length,
+    contextCatalog,
     transport: requestedTransport,
     continuationProbe: runContinuationProbe,
     preconnectionProbe: preconnection,
@@ -672,6 +677,44 @@ function assertEqual(actual, expected, label) {
   if (actual !== expected) {
     throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
   }
+}
+
+function assertGpt56ContextCatalog(models) {
+  const gpt56Models = models.filter((model) => typeof model?.slug === 'string' && model.slug.startsWith('gpt-5.6-'));
+  if (gpt56Models.length === 0) {
+    throw new Error('Context catalog assertion expected at least one GPT-5.6 model.');
+  }
+
+  return gpt56Models.map((model) => {
+    const activeRawContextWindow = getPositiveSafeInteger(model.context_window);
+    const maximumRawContextWindow = getPositiveSafeInteger(model.max_context_window);
+    if (activeRawContextWindow === undefined || maximumRawContextWindow === undefined) {
+      throw new Error(`Context catalog assertion requires valid windows for ${model.slug}.`);
+    }
+    if (maximumRawContextWindow < activeRawContextWindow) {
+      throw new Error(`Context catalog assertion requires a non-decreasing maximum for ${model.slug}.`);
+    }
+
+    const effectiveContextWindowPercent = typeof model.effective_context_window_percent === 'number'
+      && Number.isFinite(model.effective_context_window_percent)
+      && model.effective_context_window_percent > 0
+      && model.effective_context_window_percent <= 100
+      ? model.effective_context_window_percent
+      : 95;
+    return {
+      slug: model.slug,
+      activeRawContextWindow,
+      maximumRawContextWindow,
+      effectiveContextWindowPercent,
+      maximumEffectiveInputBudget: Math.floor(maximumRawContextWindow * effectiveContextWindowPercent / 100)
+    };
+  });
+}
+
+function getPositiveSafeInteger(value) {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+    ? value
+    : undefined;
 }
 
 function parsePrewarmSetting(value) {

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -363,11 +363,16 @@ async function runModelCatalogMetadataSmokeTest() {
       'long context is no longer a duplicate model profile'
     );
     assertEqual(gpt54Mini.info.maxInputTokens, 258400, 'GPT-5.4-Mini uses the default effective budget');
-    assertEqual(autoReview.info.maxInputTokens, 258400, 'Auto Review standard effective budget');
+    assertEqual(autoReview.info.maxInputTokens, 950000, 'Auto Review advertises the discovered maximum budget');
     assertEqual(
       autoReview.info.detail?.includes(`Maximum context: ${formattedMaximumContext} tokens (opt-in)`),
       true,
       'Auto Review maximum context detail'
+    );
+    assertEqual(
+      autoReview.info.configurationSchema?.properties?.contextSize?.enum.join(','),
+      '258400,950000',
+      'Auto Review uses the discovered maximum as a context-size selector'
     );
     assertEqual(spark.info.id, 'codex::gpt-5.3-codex-spark', 'Spark provider model id');
     assertEqual(spark.info.maxInputTokens, 121600, 'Spark standard effective budget');
@@ -419,6 +424,21 @@ async function runModelCatalogMetadataSmokeTest() {
     assertEqual(fractionalMetadata.info.maxInputTokens, 258400, 'fractional context below one uses effective fixed fallback');
     assertEqual(fractionalMetadata.info.detail?.includes('Maximum context:'), false, 'invalid fractional maximum is omitted');
 
+    for (const invalidMaximumContext of [undefined, 272000, 271999, 0.5, '872000', Number.POSITIVE_INFINITY]) {
+      const invalidMaximumModel = buildProviderModels(config, [
+        createMockModel('invalid-maximum', 'Invalid Maximum', {
+          context_window: 272000,
+          max_context_window: invalidMaximumContext
+        })
+      ], 'codexAccessToken')[0];
+      assertEqual(
+        invalidMaximumModel.info.configurationSchema?.properties?.contextSize,
+        undefined,
+        `invalid maximum ${String(invalidMaximumContext)} omits the context-size selector`
+      );
+      assertEqual(invalidMaximumModel.info.maxInputTokens, 258400, `invalid maximum ${String(invalidMaximumContext)} keeps the active budget`);
+    }
+
     const sparkFallback = buildFallbackModel({
       ...config,
       model: 'gpt-5.3-codex-spark'
@@ -441,13 +461,13 @@ async function runModelCatalogMetadataSmokeTest() {
       baseURL: 'https://chatgpt.com/backend-api/codex/responses'
     };
     const rollbackCatalog = [
-      createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol', { context_window: 272000, max_context_window: 272000 }),
-      createMockModel('gpt-5.6-terra', 'GPT-5.6-Terra', { context_window: 272000, max_context_window: 272000 }),
-      createMockModel('gpt-5.6-luna', 'GPT-5.6-Luna', { context_window: 272000, max_context_window: 272000 }),
+      createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol', { context_window: 272000, max_context_window: 872000 }),
+      createMockModel('gpt-5.6-terra', 'GPT-5.6-Terra', { context_window: 272000, max_context_window: 872000 }),
+      createMockModel('gpt-5.6-luna', 'GPT-5.6-Luna', { context_window: 272000, max_context_window: 872000 }),
       createMockModel('gpt-5.6-nova', 'GPT-5.6-Nova', { context_window: 272000, max_context_window: 272000 })
     ];
     const rollbackModels = buildProviderModels(chatGptConfig, rollbackCatalog, 'codexAccessToken');
-    const formattedKnownCeiling = (372000).toLocaleString();
+    const formattedGpt56MaximumContext = (872000).toLocaleString();
     assertEqual(rollbackModels.length, 4, 'eligible GPT-5.6 catalog keeps one model per backend model');
     for (const slug of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
       const resolvedModel = rollbackModels.find((candidate) => candidate.info.id === `codex::${slug}`);
@@ -456,13 +476,13 @@ async function runModelCatalogMetadataSmokeTest() {
         throw new Error(`Expected ${slug} metadata with a Context Size selector.`);
       }
       assertEqual(resolvedModel.effectiveInputBudget, 258400, `${slug} retains the default effective budget`);
-      assertEqual(resolvedModel.info.maxInputTokens, 353400, `${slug} advertises the maximum selectable budget`);
-      assertEqual(contextSize.enum.join(','), '258400,353400', `${slug} exposes standard and long context sizes`);
-      assertEqual(contextSize.enumDescriptions[1], 'Long context (Experimental).', `${slug} labels the known ceiling as experimental`);
+      assertEqual(resolvedModel.info.maxInputTokens, 828400, `${slug} advertises the maximum selectable budget`);
+      assertEqual(contextSize.enum.join(','), '258400,828400', `${slug} exposes standard and long context sizes`);
+      assertEqual(contextSize.enumDescriptions[1], 'Long context.', `${slug} labels the discovered maximum as long context`);
       assertEqual(
-        resolvedModel.info.detail?.includes(`Known raw context ceiling: ${formattedKnownCeiling} tokens`),
+        resolvedModel.info.detail?.includes(`Maximum context: ${formattedGpt56MaximumContext} tokens (opt-in)`),
         true,
-        `${slug} shows known raw context ceiling`
+        `${slug} shows the discovered maximum context`
       );
       assertEqual(resolvedModel.info.maxOutputTokens, config.maxOutputTokens, `${slug} output metadata remains configured`);
       assertEqual(resolvedModel.info.detail?.includes('500,000'), false, `${slug} does not expose inferred total context`);
@@ -474,8 +494,8 @@ async function runModelCatalogMetadataSmokeTest() {
     );
 
     const duplicateGpt56Models = buildProviderModels(chatGptConfig, [
-      createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol First', { context_window: 272000, max_context_window: 272000 }),
-      createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol Second', { context_window: 272000, max_context_window: 272000 })
+      createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol First', { context_window: 272000, max_context_window: 872000 }),
+      createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol Second', { context_window: 272000, max_context_window: 872000 })
     ], 'codexAccessToken');
     assertEqual(
       duplicateGpt56Models.map((model) => model.info.id).join(','),
@@ -489,35 +509,24 @@ async function runModelCatalogMetadataSmokeTest() {
     );
 
     const unrelatedModel = rollbackModels.find((model) => model.info.id === 'codex::gpt-5.6-nova');
-    assertEqual(unrelatedModel?.info.detail?.includes('Known raw context ceiling:'), false, 'unrelated GPT-5.6 model is unchanged');
+    assertEqual(unrelatedModel?.info.configurationSchema?.properties?.contextSize, undefined, 'equal maximum omits the context-size selector');
     assertEqual(
-      rollbackModels.some((model) => model.info.id === 'codex::gpt-5.6-nova::context=372000'),
+      rollbackModels.some((model) => model.info.id.includes('::context=')),
       false,
-      'unlisted GPT-5.6 slug has no long profile'
+      'long context does not create synthetic model IDs'
     );
 
     const apiKeyModels = buildProviderModels(chatGptConfig, rollbackCatalog, 'openaiApiKey');
     assertEqual(
-      apiKeyModels.some((model) => model.info.detail?.includes('Known raw context ceiling:')),
-      false,
-      'API-key catalog omits Codex account ceilings'
+      apiKeyModels.find((model) => model.requestModel === 'gpt-5.6-sol')?.info.maxInputTokens,
+      828400,
+      'API-key catalog uses a valid discovered maximum'
     );
-    assertEqual(
-      apiKeyModels.some((model) => model.info.id.includes('::context=')),
-      false,
-      'API-key catalog omits GPT-5.6 long profiles'
-    );
-
     const customBackendModels = buildProviderModels(config, rollbackCatalog, 'codexAccessToken');
     assertEqual(
-      customBackendModels.some((model) => model.info.detail?.includes('Known raw context ceiling:')),
-      false,
-      'custom backend catalog omits ChatGPT Codex ceilings'
-    );
-    assertEqual(
-      customBackendModels.some((model) => model.info.id.includes('::context=')),
-      false,
-      'custom backend catalog omits GPT-5.6 long profiles'
+      customBackendModels.find((model) => model.requestModel === 'gpt-5.6-sol')?.info.maxInputTokens,
+      828400,
+      'custom backend catalog uses a valid discovered maximum'
     );
 
     for (const baseURL of [
@@ -528,14 +537,9 @@ async function runModelCatalogMetadataSmokeTest() {
     ]) {
       const models = buildProviderModels({ ...chatGptConfig, baseURL }, rollbackCatalog, 'codexAccessToken');
       assertEqual(
-        models.some((model) => model.info.detail?.includes('Known raw context ceiling:')),
-        false,
-        `noncanonical backend ${baseURL} omits known ceilings`
-      );
-      assertEqual(
-        models.some((model) => model.info.id.includes('::context=')),
-        false,
-        `noncanonical backend ${baseURL} omits long profiles`
+        models.find((model) => model.requestModel === 'gpt-5.6-sol')?.info.maxInputTokens,
+        828400,
+        `backend ${baseURL} uses the valid discovered maximum`
       );
     }
 
@@ -543,10 +547,9 @@ async function runModelCatalogMetadataSmokeTest() {
       createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol', { context_window: 372000, max_context_window: 372000 })
     ], 'codexAccessToken');
     const promotedModel = promotedModels[0];
-    assertEqual(promotedModel.info.maxInputTokens, 353400, 'future active 372K catalog value uses effective budget');
-    assertEqual(promotedModel.info.name.includes('(Experimental)'), false, 'active 372K catalog row is not a synthetic experimental profile');
-    assertEqual(promotedModel.info.detail?.includes('Known raw context ceiling:'), false, 'active 372K omits redundant known ceiling');
-    assertEqual(promotedModels.length, 1, 'active 372K catalog does not duplicate the long profile');
+    assertEqual(promotedModel.info.maxInputTokens, 353400, 'active 372K catalog value uses effective budget');
+    assertEqual(promotedModel.info.configurationSchema?.properties?.contextSize, undefined, 'equal active and maximum context omit the selector');
+    assertEqual(promotedModels.length, 1, 'active 372K catalog does not duplicate the model');
 
     const activeMillionModels = buildProviderModels(chatGptConfig, [
       createMockModel('gpt-5.4', 'GPT-5.4', { context_window: 1000000, max_context_window: 1000000 })
@@ -557,7 +560,7 @@ async function runModelCatalogMetadataSmokeTest() {
     const nearMatchModels = buildProviderModels(chatGptConfig, [
       createMockModel('gpt-5.4-preview', 'GPT-5.4 Preview', { context_window: 272000, max_context_window: 1000000 })
     ], 'codexAccessToken');
-    assertEqual(nearMatchModels.length, 1, 'non-exact GPT-5.4 slug has no long profile');
+    assertEqual(nearMatchModels[0].info.maxInputTokens, 950000, 'any model with a valid maximum receives the long-context budget');
 
     const fallbackCeiling = buildFallbackModel({
       ...chatGptConfig,
@@ -565,9 +568,9 @@ async function runModelCatalogMetadataSmokeTest() {
     }, 'codexAccessToken');
     assertEqual(fallbackCeiling.info.maxInputTokens, 258400, 'fallback keeps conservative effective budget');
     assertEqual(
-      fallbackCeiling.info.detail?.includes(`Known raw context ceiling: ${formattedKnownCeiling} tokens`),
-      true,
-      'fallback shows known raw context ceiling'
+      fallbackCeiling.info.detail?.includes('Maximum context:'),
+      false,
+      'fallback omits unverified maximum context'
     );
     const percentageOverride = buildProviderModels(config, [
       createMockModel('percentage-override', 'Percentage Override', {

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -779,7 +779,7 @@ async function runProviderLongContextSelectionSmokeTest() {
         'context size remains client-side and is not sent as a Responses API parameter'
       );
     }
-    assertEqual(responseRequests[1].previous_response_id, undefined, 'switching to long context starts an isolated chain');
+    assertEqual(responseRequests[1].previous_response_id, 'resp_standard', 'switching to a larger context safely reuses the completed smaller-context response');
     assertEqual(responseRequests[2].previous_response_id, 'resp_long', 'same context size reuses its completed response');
     assertEqual(
       JSON.stringify(responseRequests[2].input),

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -334,19 +334,22 @@ async function runModelCatalogMetadataSmokeTest() {
 
     const resolvedModels = buildProviderModels(config, accountCatalog, 'codexAccessToken');
     const gpt54 = resolvedModels.find((model) => model.info.id === 'codex::gpt-5.4');
-    const gpt54Long = resolvedModels.find((model) => model.info.id === 'codex::gpt-5.4::context=1000000');
     const gpt54Mini = resolvedModels.find((model) => model.info.id === 'codex::gpt-5.4-mini');
     const spark = resolvedModels.find((model) => model.info.id === 'codex::gpt-5.3-codex-spark');
     const autoReview = resolvedModels.find((model) => model.info.id === 'codex::codex-auto-review');
-    if (!gpt54 || !gpt54Long || !gpt54Mini || !spark || !autoReview) {
-      throw new Error('Expected GPT-5.4 standard/long, GPT-5.4-Mini, Spark, and Auto Review model metadata.');
+    if (!gpt54 || !gpt54Mini || !spark || !autoReview) {
+      throw new Error('Expected GPT-5.4, GPT-5.4-Mini, Spark, and Auto Review model metadata.');
     }
 
     const formattedActiveContext = (272000).toLocaleString();
     const formattedMaximumContext = (1000000).toLocaleString();
-    assertEqual(gpt54.rawContextWindow, 272000, 'GPT-5.4 standard raw context');
-    assertEqual(gpt54.effectiveInputBudget, 258400, 'GPT-5.4 standard internal effective budget');
-    assertEqual(gpt54.info.maxInputTokens, 258400, 'GPT-5.4 standard effective budget');
+    const gpt54ContextSize = gpt54.info.configurationSchema?.properties?.contextSize;
+    assertEqual(gpt54.rawContextWindow, 272000, 'GPT-5.4 active raw context');
+    assertEqual(gpt54.effectiveInputBudget, 258400, 'GPT-5.4 default effective budget');
+    assertEqual(gpt54.info.maxInputTokens, 950000, 'GPT-5.4 advertises the maximum selectable budget');
+    assertEqual(gpt54ContextSize?.enum.join(','), '258400,950000', 'GPT-5.4 exposes default and long context sizes');
+    assertEqual(gpt54ContextSize?.default, 258400, 'GPT-5.4 defaults to the active context size');
+    assertEqual(gpt54ContextSize?.group, 'tokens', 'GPT-5.4 context size uses the native token group');
     assertEqual(
       gpt54.info.detail?.includes(
         `Effective input budget: 258,400 tokens | Raw context window: ${formattedActiveContext} tokens (active) | Maximum context: ${formattedMaximumContext} tokens (opt-in)`
@@ -354,34 +357,12 @@ async function runModelCatalogMetadataSmokeTest() {
       true,
       'GPT-5.4 detail distinguishes active and maximum context'
     );
-    assertEqual(gpt54Long.info.name, 'GPT-5.4 (Long context)', 'GPT-5.4 long profile name');
-    assertEqual(gpt54Long.rawContextWindow, 1000000, 'GPT-5.4 long raw context');
-    assertEqual(gpt54Long.effectiveInputBudget, 950000, 'GPT-5.4 long internal effective budget');
-    assertEqual(gpt54Long.info.maxInputTokens, 950000, 'GPT-5.4 long effective budget');
-    assertEqual(gpt54Long.requestModel, 'gpt-5.4', 'GPT-5.4 long profile keeps real request model');
     assertEqual(
-      gpt54Long.info.detail?.includes('Long context: 950,000 tokens effective input budget | Raw context window: 1,000,000 tokens'),
-      true,
-      'GPT-5.4 long profile detail'
-    );
-    assertEqual(gpt54Long.info.version, gpt54.info.version, 'GPT-5.4 profiles preserve version metadata');
-    assertEqual(gpt54Long.info.tooltip, gpt54.info.tooltip, 'GPT-5.4 profiles preserve tooltip metadata');
-    assertEqual(
-      JSON.stringify(gpt54Long.info.capabilities),
-      JSON.stringify(gpt54.info.capabilities),
-      'GPT-5.4 profiles preserve capabilities'
-    );
-    assertEqual(
-      JSON.stringify(gpt54Long.info.configurationSchema),
-      JSON.stringify(gpt54.info.configurationSchema),
-      'GPT-5.4 profiles preserve reasoning configuration'
+      resolvedModels.some((model) => model.info.id.includes('::context=')),
+      false,
+      'long context is no longer a duplicate model profile'
     );
     assertEqual(gpt54Mini.info.maxInputTokens, 258400, 'GPT-5.4-Mini uses the default effective budget');
-    assertEqual(
-      resolvedModels.some((model) => model.info.id.startsWith('codex::gpt-5.4-mini::context=')),
-      false,
-      'GPT-5.4-Mini omits a redundant long profile'
-    );
     assertEqual(autoReview.info.maxInputTokens, 258400, 'Auto Review standard effective budget');
     assertEqual(
       autoReview.info.detail?.includes(`Maximum context: ${formattedMaximumContext} tokens (opt-in)`),
@@ -406,12 +387,12 @@ async function runModelCatalogMetadataSmokeTest() {
     ], 'codexAccessToken');
     assertEqual(
       duplicateGpt54Models.map((model) => model.info.id).join(','),
-      'codex::gpt-5.4,codex::gpt-5.4::context=1000000',
-      'duplicate GPT-5.4 rows yield one standard and one long ID'
+      'codex::gpt-5.4',
+      'duplicate GPT-5.4 rows yield one model ID'
     );
     assertEqual(
       duplicateGpt54Models.map((model) => model.info.name).join(','),
-      'GPT-5.4 First,GPT-5.4 First (Long context)',
+      'GPT-5.4 First',
       'duplicate GPT-5.4 rows preserve first-seen metadata and order'
     );
 
@@ -422,11 +403,11 @@ async function runModelCatalogMetadataSmokeTest() {
       })
     ], 'codexAccessToken');
     const discoveredOverride = discoveredOverrideModels.find((model) => model.info.id === 'codex::gpt-5.4');
-    assertEqual(discoveredOverride?.info.maxInputTokens, 316350, 'valid discovered context uses the default effective percentage');
+    assertEqual(discoveredOverride?.info.maxInputTokens, 950000, 'valid discovered context preserves the maximum budget');
     assertEqual(
-      discoveredOverrideModels.some((model) => model.info.id === 'codex::gpt-5.4::context=1000000'),
-      true,
-      'valid GPT-5.4 maximum still adds the long profile'
+      discoveredOverride?.info.configurationSchema?.properties?.contextSize?.enum.join(','),
+      '316350,950000',
+      'valid GPT-5.4 maximum becomes a context-size selector'
     );
 
     const fractionalMetadata = buildProviderModels(config, [
@@ -467,35 +448,29 @@ async function runModelCatalogMetadataSmokeTest() {
     ];
     const rollbackModels = buildProviderModels(chatGptConfig, rollbackCatalog, 'codexAccessToken');
     const formattedKnownCeiling = (372000).toLocaleString();
-    assertEqual(rollbackModels.length, 7, 'eligible GPT-5.6 catalog expands three exact long profiles');
+    assertEqual(rollbackModels.length, 4, 'eligible GPT-5.6 catalog keeps one model per backend model');
     for (const slug of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
-      const standardModel = rollbackModels.find((candidate) => candidate.info.id === `codex::${slug}`);
-      const longModel = rollbackModels.find((candidate) => candidate.info.id === `codex::${slug}::context=372000`);
-      if (!standardModel || !longModel) {
-        throw new Error(`Expected ${slug} standard and long metadata.`);
+      const resolvedModel = rollbackModels.find((candidate) => candidate.info.id === `codex::${slug}`);
+      const contextSize = resolvedModel?.info.configurationSchema?.properties?.contextSize;
+      if (!resolvedModel || !contextSize) {
+        throw new Error(`Expected ${slug} metadata with a Context Size selector.`);
       }
-      assertEqual(standardModel.info.maxInputTokens, 258400, `${slug} advertises standard effective budget`);
+      assertEqual(resolvedModel.effectiveInputBudget, 258400, `${slug} retains the default effective budget`);
+      assertEqual(resolvedModel.info.maxInputTokens, 353400, `${slug} advertises the maximum selectable budget`);
+      assertEqual(contextSize.enum.join(','), '258400,353400', `${slug} exposes standard and long context sizes`);
+      assertEqual(contextSize.enumDescriptions[1], 'Long context (Experimental).', `${slug} labels the known ceiling as experimental`);
       assertEqual(
-        standardModel.info.detail?.includes(`Known raw context ceiling: ${formattedKnownCeiling} tokens`),
+        resolvedModel.info.detail?.includes(`Known raw context ceiling: ${formattedKnownCeiling} tokens`),
         true,
         `${slug} shows known raw context ceiling`
       );
-      assertEqual(longModel.rawContextWindow, 372000, `${slug} retains exact long raw context`);
-      assertEqual(longModel.info.maxInputTokens, 353400, `${slug} advertises exact long effective budget`);
-      assertEqual(longModel.requestModel, slug, `${slug} long profile keeps real request model`);
-      assertEqual(longModel.info.name, `${standardModel.info.name} (Long context) (Experimental)`, `${slug} experimental long profile name`);
-      assertEqual(
-        longModel.info.detail?.includes('Long context (Experimental): 353,400 tokens effective input budget | Raw context window: 372,000 tokens'),
-        true,
-        `${slug} long detail is truthful`
-      );
-      assertEqual(longModel.info.maxOutputTokens, config.maxOutputTokens, `${slug} output metadata remains configured`);
-      assertEqual(longModel.info.detail?.includes('500,000'), false, `${slug} does not expose inferred total context`);
+      assertEqual(resolvedModel.info.maxOutputTokens, config.maxOutputTokens, `${slug} output metadata remains configured`);
+      assertEqual(resolvedModel.info.detail?.includes('500,000'), false, `${slug} does not expose inferred total context`);
     }
     assertEqual(
-      rollbackModels.some((model) => model.info.id.includes('context=1000000')),
+      rollbackModels.some((model) => model.info.id.includes('::context=')),
       false,
-      'GPT-5.6 models never expose a 1M profile'
+      'GPT-5.6 models do not expose synthetic long-context IDs'
     );
 
     const duplicateGpt56Models = buildProviderModels(chatGptConfig, [
@@ -504,12 +479,12 @@ async function runModelCatalogMetadataSmokeTest() {
     ], 'codexAccessToken');
     assertEqual(
       duplicateGpt56Models.map((model) => model.info.id).join(','),
-      'codex::gpt-5.6-sol,codex::gpt-5.6-sol::context=372000',
-      'duplicate GPT-5.6 rows yield one standard and one long ID'
+      'codex::gpt-5.6-sol',
+      'duplicate GPT-5.6 rows yield one model ID'
     );
     assertEqual(
       duplicateGpt56Models.map((model) => model.info.name).join(','),
-      'GPT-5.6-Sol First,GPT-5.6-Sol First (Long context) (Experimental)',
+      'GPT-5.6-Sol First',
       'duplicate GPT-5.6 rows preserve first-seen metadata and order'
     );
 
@@ -695,11 +670,12 @@ async function runProviderLongContextSelectionSmokeTest() {
     const replies = [
       ['first reply', 'resp_standard'],
       ['long reply', 'resp_long'],
+      ['long follow-up reply', 'resp_long_follow_up'],
       ['downgrade reply', 'resp_downgrade']
     ];
     const reply = replies[responseRequests.length - 1];
     if (!reply) {
-      throw new Error('Unexpected extra context-profile request.');
+      throw new Error('Unexpected extra context-size request.');
     }
     writeSseResponse(response, reply[0], reply[1]);
   });
@@ -734,16 +710,17 @@ async function runProviderLongContextSelectionSmokeTest() {
   try {
     const token = createCancellationToken();
     const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
-    const standardModel = models.find((model) => model.id === 'codex::gpt-5.4');
-    const longModel = models.find((model) => model.id === 'codex::gpt-5.4::context=1000000');
-    if (!standardModel || !longModel) {
-      throw new Error('Expected selectable GPT-5.4 standard and long profiles.');
+    const model = models.find((candidate) => candidate.id === 'codex::gpt-5.4');
+    const contextSize = model?.configurationSchema?.properties?.contextSize;
+    if (!model || !contextSize) {
+      throw new Error('Expected one GPT-5.4 model with a Context Size selector.');
     }
-    assertEqual(standardModel.maxInputTokens, 258400, 'standard profile advertises effective budget');
-    assertEqual(longModel.maxInputTokens, 950000, 'long profile advertises effective budget');
+    assertEqual(model.maxInputTokens, 950000, 'model advertises maximum context size');
+    assertEqual(contextSize.enum.join(','), '258400,950000', 'model exposes standard and long context sizes');
+    assertEqual(contextSize.default, 258400, 'model defaults to the active context size');
 
     await provider.provideLanguageModelChatResponse(
-      standardModel,
+      model,
       [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('First request')] }],
       {},
       { report() {} },
@@ -751,24 +728,40 @@ async function runProviderLongContextSelectionSmokeTest() {
     );
 
     await provider.provideLanguageModelChatResponse(
-      longModel,
+      model,
       [
         { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('First request')] },
         { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('first reply')] },
         { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Follow up')] }
       ],
-      {},
+      { modelConfiguration: { contextSize: 950000 } },
       { report() {} },
       token
     );
 
     await provider.provideLanguageModelChatResponse(
-      standardModel,
+      model,
       [
         { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('First request')] },
         { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('first reply')] },
         { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Follow up')] },
         { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('long reply')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Long follow up')] }
+      ],
+      { modelConfiguration: { contextSize: 950000 } },
+      { report() {} },
+      token
+    );
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('First request')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('first reply')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Follow up')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('long reply')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Long follow up')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('long follow-up reply')] },
         { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Downgrade')] }
       ],
       {},
@@ -776,37 +769,24 @@ async function runProviderLongContextSelectionSmokeTest() {
       token
     );
 
-    assertEqual(responseRequests.length, 3, 'profile transition request count');
-    assertEqual(selectedModels.join(','), 'gpt-5.4,gpt-5.4,gpt-5.4', 'all profiles resolve to the real selected model');
-    assertEqual(responseRequests[0].model, 'gpt-5.4', 'standard profile sends real backend model');
-    assertEqual(responseRequests[1].model, 'gpt-5.4', 'long profile sends real backend model');
-    assertEqual(responseRequests[1].previous_response_id, 'resp_standard', 'long profile reuses the standard profile branch');
-    assertEqual(
-      JSON.stringify(responseRequests[1].input),
-      JSON.stringify([{ role: 'user', content: 'Follow up', type: 'message' }]),
-      'long profile continuation sends only appended input'
-    );
-    assertEqual(responseRequests[2].model, 'gpt-5.4', 'downgraded standard profile sends real backend model');
-    assertEqual(responseRequests[2].previous_response_id, undefined, 'long-to-standard downgrade starts a new response chain');
-    assertEqual(
-      JSON.stringify(responseRequests[2].input),
-      JSON.stringify([
-        { role: 'user', content: 'First request', type: 'message' },
-        { role: 'assistant', content: 'first reply', type: 'message' },
-        { role: 'user', content: 'Follow up', type: 'message' },
-        { role: 'assistant', content: 'long reply', type: 'message' },
-        { role: 'user', content: 'Downgrade', type: 'message' }
-      ]),
-      'long-to-standard downgrade replays full caller history'
-    );
+    assertEqual(responseRequests.length, 4, 'context-size transition request count');
+    assertEqual(selectedModels.join(','), 'gpt-5.4,gpt-5.4,gpt-5.4,gpt-5.4', 'context sizes resolve to the real backend model');
     for (const body of responseRequests) {
+      assertEqual(body.model, 'gpt-5.4', 'context-size request sends the real backend model');
       assertEqual(
         Object.keys(body).some((key) => key.toLowerCase().includes('context')),
         false,
-        'profile request has no context-window field'
+        'context size remains client-side and is not sent as a Responses API parameter'
       );
-      assertEqual(JSON.stringify(body).includes('::context='), false, 'profile request has no synthetic identifier');
     }
+    assertEqual(responseRequests[1].previous_response_id, undefined, 'switching to long context starts an isolated chain');
+    assertEqual(responseRequests[2].previous_response_id, 'resp_long', 'same context size reuses its completed response');
+    assertEqual(
+      JSON.stringify(responseRequests[2].input),
+      JSON.stringify([{ role: 'user', content: 'Long follow up', type: 'message' }]),
+      'same context size sends only appended input'
+    );
+    assertEqual(responseRequests[3].previous_response_id, undefined, 'switching back to the default size starts an isolated chain');
   } finally {
     server.close();
   }

--- a/test/smokeReasoningEffort.mjs
+++ b/test/smokeReasoningEffort.mjs
@@ -69,11 +69,11 @@ try {
   );
   assertEqual(schema.default, 'low', 'catalog default reasoning effort');
   assertEqual(contextSizeSchema.group, 'tokens', 'context size uses the native tokens group');
-  assertEqual(contextSizeSchema.enum.join(','), '258400,353400', 'context size preserves effective input budgets');
-  assertEqual(contextSizeSchema.enumItemLabels.join(','), '258.4K,353.4K', 'context size uses concise picker labels');
-  assertEqual(contextSizeSchema.enumDescriptions.join(','), 'Default context size.,Long context (Experimental).', 'context size labels the experimental option');
+  assertEqual(contextSizeSchema.enum.join(','), '258400,828400', 'context size preserves effective input budgets');
+  assertEqual(contextSizeSchema.enumItemLabels.join(','), '272K,872K', 'context size shows raw context-window picker labels');
+  assertEqual(contextSizeSchema.enumDescriptions.join(','), 'Default context size.,Long context.', 'context size labels the discovered maximum option');
   assertEqual(contextSizeSchema.default, 258400, 'context size defaults to the active context window');
-  assertEqual(model.info.maxInputTokens, 353400, 'model advertises its maximum selectable context size');
+  assertEqual(model.info.maxInputTokens, 828400, 'model advertises its maximum selectable context size');
   assertEqual(
     schema.enumDescriptions[3],
     'Use the Future Effort reasoning effort advertised by the selected model.',
@@ -164,7 +164,7 @@ function createCatalogModel() {
     slug: 'gpt-5.6-sol',
     display_name: 'GPT-5.6-Sol',
     context_window: 272000,
-    max_context_window: 272000,
+    max_context_window: 872000,
     default_reasoning_level: 'low',
     supported_reasoning_levels: [
       { effort: 'low', description: 'Fast responses with lighter reasoning' },

--- a/test/smokeReasoningEffort.mjs
+++ b/test/smokeReasoningEffort.mjs
@@ -52,8 +52,9 @@ const { buildProviderModels } = require(modelsBundlePath);
 try {
   const model = buildProviderModels(createConfig(), [createCatalogModel()], 'codexAccessToken')[0];
   const schema = model.info.configurationSchema?.properties?.reasoningEffort;
-  if (!schema) {
-    throw new Error('Expected a reasoning effort configuration schema.');
+  const contextSizeSchema = model.info.configurationSchema?.properties?.contextSize;
+  if (!schema || !contextSizeSchema) {
+    throw new Error('Expected Thinking Effort and Context Size configuration schemas.');
   }
 
   assertEqual(
@@ -67,6 +68,12 @@ try {
     'known and custom reasoning efforts receive readable labels'
   );
   assertEqual(schema.default, 'low', 'catalog default reasoning effort');
+  assertEqual(contextSizeSchema.group, 'tokens', 'context size uses the native tokens group');
+  assertEqual(contextSizeSchema.enum.join(','), '258400,353400', 'context size preserves effective input budgets');
+  assertEqual(contextSizeSchema.enumItemLabels.join(','), '258.4K,353.4K', 'context size uses concise picker labels');
+  assertEqual(contextSizeSchema.enumDescriptions.join(','), 'Default context size.,Long context (Experimental).', 'context size labels the experimental option');
+  assertEqual(contextSizeSchema.default, 258400, 'context size defaults to the active context window');
+  assertEqual(model.info.maxInputTokens, 353400, 'model advertises its maximum selectable context size');
   assertEqual(
     schema.enumDescriptions[3],
     'Use the Future Effort reasoning effort advertised by the selected model.',
@@ -156,8 +163,8 @@ function createCatalogModel() {
   return {
     slug: 'gpt-5.6-sol',
     display_name: 'GPT-5.6-Sol',
-    context_window: 372000,
-    max_context_window: 372000,
+    context_window: 272000,
+    max_context_window: 272000,
     default_reasoning_level: 'low',
     supported_reasoning_levels: [
       { effort: 'low', description: 'Fast responses with lighter reasoning' },


### PR DESCRIPTION
## Summary

- Replace duplicate Long Context model profiles with VS Code's native `Context Size` picker using `configurationSchema.contextSize` and `group: 'tokens'`.
- Keep each discovered backend model to one picker entry; advertise the maximum selectable input budget while defaulting to the catalog's active context budget.
- Apply the selected size to client-side continuation compatibility, retaining safe expansion from a smaller completed context and preventing reuse when switching back to a smaller budget. No context-size field is sent to the Responses API.
- Preserve parsing compatibility for existing `::context=` model IDs.

## Validation

- Added smoke coverage for Context Size schema metadata, experimental GPT-5.6 labels, selected-size continuation compatibility, and absence of a wire-level context parameter.
- GitHub Actions runs the TypeScript check and smoke suite.