### PR TITLE
feat: add configurable Codex protocol profiles

### DIFF
--- a/docs/codex-cli-parity.md
+++ b/docs/codex-cli-parity.md
@@ -3,7 +3,7 @@
 Protocol baseline:
 
 - Codex For Copilot: `2987db25dc15b79cd22dc2ccc08f4c44b7db1351`
-- `openai/codex`: `72b41c55fb32f62373e070d6ac0cde7ba563989b`
+- `openai/codex`: `711a5f8b3a6eb40134146ae9ec22fdcdda5e3170`
 - WebSocket beta: `responses_websockets=2026-02-06`
 
 ## Baseline checklist
@@ -31,7 +31,11 @@ Protocol baseline:
 
 Protocol constants are centralized in `src/codexProtocol.ts` and carry the upstream commit reference.
 
-The final upstream recheck found no changes between the initial `4df8027a…` snapshot and `72b41c55…` in the inspected Responses transport, request, metadata, or header files.
+The current baseline follows upstream `CodexResponsesMetadata`: the full turn
+metadata object is canonical in `client_metadata["x-codex-turn-metadata"]`, while
+flat client metadata and direct HTTP/WebSocket headers are compatibility
+projections. The direct turn-metadata header deliberately excludes
+`tool_namespaces_info`, whose size is bounded only by the selected tool catalog.
 
 ## Implemented
 
@@ -41,6 +45,27 @@ The final upstream recheck found no changes between the initial `4df8027a…` sn
 - Per-session automatic HTTP fallback, bounded connection/capability caches, connection-limit retry, continuation recovery without duplicate visible output, and credential/config invalidation.
 - SDK custom-fetch timing and optional Zstandard request compression with one safe uncompressed retry.
 - Focused protocol, identity, request, turn, HTTP, WebSocket, fallback, and compression smoke tests plus an opt-in real-backend benchmark.
+- Canonical metadata snapshots with agent name, turn start time, parent/root turn
+  hierarchy, and Native Tool Search namespace/function inventory.
+- Safe user overrides for headers, flat client metadata, and turn metadata;
+  credentials, transport invariants, WebSocket security fields, and Turn State
+  remain protected. `Codex: Show Effective Protocol` writes a redacted view of
+  the most recent effective projection to the extension log.
+
+## Protocol profiles and overrides
+
+`codexModelProvider.protocolProfile` defaults to `auto`. `auto` and
+`codexCompatible` enable the Codex projection only for the official ChatGPT Codex
+endpoint with Codex credentials; `minimal` disables it. `custom` is an explicit
+opt-in for HTTPS-compatible gateways.
+
+Overrides are applied to the canonical snapshot before the body/header
+projections are created. Safe mode accepts extra metadata and non-protected
+headers. `allowUnsafeProtocolOverrides` additionally permits generated identity
+fields to be replaced for protocol testing, but it never permits settings to
+replace authentication, account identity, `x-codex-turn-state`, HTTP transport
+invariants, or `Sec-WebSocket-*` fields. Extra client metadata follows upstream's
+16-entry, 64-byte key, and 128-byte string-value limits.
 
 ## Latency and continuation behavior
 

--- a/docs/codex-transport-architecture.md
+++ b/docs/codex-transport-architecture.md
@@ -1,15 +1,19 @@
 # Codex transport architecture
 
-The compatibility profile is enabled only when both conditions are true:
+The default `auto` compatibility profile is enabled only when both conditions are true:
 
 1. The credential is a ChatGPT Codex access token.
 2. The endpoint is `https://chatgpt.com/backend-api/codex`.
 
 API-key and third-party endpoints keep the standard OpenAI SDK request path.
+`minimal` explicitly disables the projection. `custom` is an advanced opt-in for
+HTTPS gateways that intentionally implement the Codex wire contract.
 
 ## Modules
 
-- `codexProtocol.ts` owns the upstream commit marker, header names, WebSocket beta value, backend feature gate, metadata serialization, and response-header parsing.
+- `codexProtocol.ts` owns the upstream commit marker, canonical protocol snapshot,
+  safe override policy, body/header projections, WebSocket beta value, backend
+  feature gate, redacted effective-protocol diagnostic, and response-header parsing.
 - `codexIdentity.ts` owns installation, extension-host window, synthetic session/thread, fork parent, and turn identifiers.
 - `codexRequestBuilder.ts` creates the shared HTTP/WebSocket Responses request and the strict non-input request fingerprint.
 - `codexWebSocketSession.ts` is the only module that reaches the SDK Node WebSocket adapter. It serializes streams, captures upgrade headers and metadata events, enforces idle timeout, retains raw output items, prewarms, and creates incremental frames.
@@ -27,6 +31,7 @@ API-key and third-party endpoints keep the standard OpenAI SDK request path.
 | Session/thread | One synthetic append-only history branch |
 | Parent thread | Only a history fork with a non-empty matching prefix |
 | Turn | New user input; retained for tool results, retries, and recovery |
+| Parent/root turn | Derived from the synthetic append-only turn chain |
 | Turn State | One turn only; cleared before the next user turn |
 
 `prompt_cache_key` is the synthetic thread ID. The credential identity contains only account/source data and an irreversible token hash, so refreshed credentials cannot reuse an old connection.
@@ -48,4 +53,4 @@ Existing configuration keeps `transport: auto`. The two new settings default to 
 - `codexModelProvider.websocketPrewarm`
 - `codexModelProvider.requestCompression`
 
-No Codex-specific identity, beta header, prewarm, Turn State, or compression behavior is sent to ordinary OpenAI API keys or third-party endpoints.
+No Codex-specific identity, beta header, prewarm, Turn State, or compression behavior is sent to ordinary OpenAI API keys or third-party endpoints unless the user explicitly selects the advanced `custom` protocol profile for an HTTPS gateway.

--- a/package.json
+++ b/package.json
@@ -111,6 +111,10 @@
         "title": "Codex: Show Native Tool Search Status"
       },
       {
+        "command": "codexModelProvider.showEffectiveProtocol",
+        "title": "Codex: Show Effective Protocol"
+      },
+      {
         "command": "codexForCopilot.auth.importAuthJson",
         "title": "Codex for Copilot: Import Codex auth.json"
       },
@@ -197,6 +201,77 @@
             "disabled"
           ],
           "description": "Controls Zstandard compression for large ChatGPT Codex Responses requests."
+        },
+        "codexModelProvider.protocolProfile": {
+          "type": "string",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "codexCompatible",
+            "minimal",
+            "custom"
+          ],
+          "enumDescriptions": [
+            "Enable Codex protocol fields only for the official ChatGPT Codex endpoint with Codex credentials.",
+            "Use the current Codex-compatible projection on the official ChatGPT Codex endpoint.",
+            "Do not add Codex-specific headers or client metadata.",
+            "Enable the Codex-compatible projection for an explicitly configured HTTPS endpoint."
+          ],
+          "description": "Controls when Codex protocol compatibility fields are generated.",
+          "tags": [
+            "advanced"
+          ]
+        },
+        "codexModelProvider.headerOverrides": {
+          "type": "object",
+          "default": {},
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Additional or replacement request headers. Authentication, transport invariants, and Turn State are always protected; generated identity headers require unsafe overrides.",
+          "tags": [
+            "advanced"
+          ]
+        },
+        "codexModelProvider.clientMetadataOverrides": {
+          "type": "object",
+          "default": {},
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 128
+          },
+          "description": "Extra flat Responses client_metadata string values. Up to 16 entries are accepted; Codex-owned keys require unsafe overrides.",
+          "tags": [
+            "advanced"
+          ]
+        },
+        "codexModelProvider.turnMetadataOverrides": {
+          "type": "object",
+          "default": {},
+          "description": "Extra fields merged into the canonical x-codex-turn-metadata snapshot. Codex-owned identity and tool fields require unsafe overrides.",
+          "tags": [
+            "advanced"
+          ]
+        },
+        "codexModelProvider.omitGeneratedHeaders": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "Generated header names to omit. Protected credentials and transport headers cannot be omitted.",
+          "tags": [
+            "advanced"
+          ]
+        },
+        "codexModelProvider.allowUnsafeProtocolOverrides": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow advanced overrides of generated Codex identity fields. Credentials, WebSocket security headers, transport invariants, and Turn State remain protected.",
+          "tags": [
+            "advanced"
+          ]
         },
         "codexModelProvider.nativeToolSearch": {
           "type": "string",

--- a/src/codexIdentity.ts
+++ b/src/codexIdentity.ts
@@ -22,20 +22,25 @@ export class CodexIdentityManager {
   async createThread(parentThreadId?: string): Promise<CodexRequestIdentity> {
     const installationId = await this.getInstallationId();
     const sessionId = randomUUID();
+    const turnId = randomUUID();
     return {
       installationId,
       sessionId,
       threadId: randomUUID(),
-      turnId: randomUUID(),
+      turnId,
+      rootTurnId: turnId,
       windowId: this.windowId,
       ...(parentThreadId ? { parentThreadId } : {})
     };
   }
 
   createNextTurn(identity: CodexRequestIdentity): CodexRequestIdentity {
+    const turnId = randomUUID();
     return {
       ...identity,
-      turnId: randomUUID(),
+      turnId,
+      parentTurnId: identity.turnId,
+      rootTurnId: identity.rootTurnId ?? identity.turnId,
       windowId: this.windowId
     };
   }

--- a/src/codexProtocol.ts
+++ b/src/codexProtocol.ts
@@ -1,7 +1,8 @@
 import type { ApiCredentials } from './secrets';
+import type { CodexToolPlan } from './nativeToolSearch/nativeToolTypes';
 
-// Protocol baseline: openai/codex@72b41c55fb32f62373e070d6ac0cde7ba563989b.
-export const CODEX_PROTOCOL_UPSTREAM_COMMIT = '72b41c55fb32f62373e070d6ac0cde7ba563989b';
+// Protocol baseline: openai/codex@711a5f8b3a6eb40134146ae9ec22fdcdda5e3170.
+export const CODEX_PROTOCOL_UPSTREAM_COMMIT = '711a5f8b3a6eb40134146ae9ec22fdcdda5e3170';
 export const CODEX_RESPONSES_WEBSOCKET_BETA = 'responses_websockets=2026-02-06';
 
 export const CodexHeader = {
@@ -9,6 +10,7 @@ export const CodexHeader = {
   beta: 'OpenAI-Beta',
   installationId: 'x-codex-installation-id',
   parentThreadId: 'x-codex-parent-thread-id',
+  routingHint: 'x-codex-routing-hint',
   requestId: 'x-client-request-id',
   sessionId: 'session-id',
   threadId: 'thread-id',
@@ -37,23 +39,74 @@ export interface CodexRequestIdentity {
   turnId: string;
   windowId: string;
   parentThreadId?: string;
+  parentTurnId?: string;
+  rootTurnId?: string;
 }
 
-export interface CodexTurnMetadata {
+export interface CodexToolFunctionMetadata {
+  name: string;
+  direct: boolean;
+  code_mode_name: string | null;
+  deferred: boolean;
+  source: { kind: 'harness' };
+}
+
+export interface CodexToolNamespaceMetadata {
+  name: string;
+  functions: Record<string, CodexToolFunctionMetadata>;
+}
+
+export interface CodexTurnMetadata extends Record<string, unknown> {
   installation_id: string;
   session_id: string;
   thread_id: string;
   turn_id: string;
   window_id: string;
   parent_thread_id: string | null;
+  parent_turn_id?: string;
+  root_turn_id?: string;
+  agent_name: string;
+  turn_started_at_unix_ms: number;
+  tool_namespaces_info?: Record<string, CodexToolNamespaceMetadata>;
   request_kind: 'turn' | 'prewarm';
   source: 'vscode-language-model-provider';
 }
+
+export type CodexProtocolProfileName = 'auto' | 'codexCompatible' | 'minimal' | 'custom';
+
+export interface CodexProtocolSettings {
+  profile: CodexProtocolProfileName;
+  headerOverrides: Record<string, string>;
+  clientMetadataOverrides: Record<string, string>;
+  turnMetadataOverrides: Record<string, unknown>;
+  omitGeneratedHeaders: string[];
+  allowUnsafeProtocolOverrides: boolean;
+}
+
+export interface CodexProtocolSnapshot {
+  identity: CodexRequestIdentity;
+  requestKind: CodexTurnMetadata['request_kind'];
+  turnMetadata: CodexTurnMetadata;
+  clientMetadata: Record<string, string>;
+  compatibilityTurnMetadata: string;
+  settings: CodexProtocolSettings;
+}
+
+export interface CodexEffectiveProtocolDiagnostic {
+  profile: CodexProtocolProfileName;
+  headers?: Record<string, string>;
+  clientMetadata: Record<string, string>;
+  turnMetadata: Record<string, unknown>;
+}
+
+let lastEffectiveProtocol: CodexEffectiveProtocolDiagnostic | undefined;
+let lastEffectiveProtocolIdentityKey: string | undefined;
 
 export interface CodexDynamicHeaderContext {
   credentialsHeaders?: Record<string, string>;
   identity: CodexRequestIdentity;
   turnMetadata: string;
+  snapshot?: CodexProtocolSnapshot;
   turnState?: string;
   extensionVersion: string;
   userAgent: string;
@@ -63,13 +116,15 @@ export interface CodexWebSocketPreconnectHeaderContext {
   credentialsHeaders?: Record<string, string>;
   extensionVersion: string;
   userAgent: string;
+  settings?: CodexProtocolSettings;
 }
 
 export type CodexTransportKind = 'http' | 'websocket';
 
 export function getCodexCompatibilityProfile(
   baseURL: string,
-  credentials: Pick<ApiCredentials, 'kind'>
+  credentials: Pick<ApiCredentials, 'kind'>,
+  selectedProfile: CodexProtocolProfileName = 'auto'
 ): CodexCompatibilityProfile {
   const normalized = normalizeCodexEndpoint(baseURL);
   let url: URL;
@@ -79,10 +134,15 @@ export function getCodexCompatibilityProfile(
     return { enabled: false, endpointKey: normalized };
   }
 
-  const enabled = credentials.kind === 'codexAccessToken'
+  const isCodexEndpoint = credentials.kind === 'codexAccessToken'
     && url.protocol === 'https:'
     && url.hostname.toLowerCase() === 'chatgpt.com'
     && /^\/backend-api\/codex(?:\/|$)/.test(url.pathname);
+  const enabled = selectedProfile === 'minimal'
+    ? false
+    : selectedProfile === 'custom'
+      ? url.protocol === 'https:'
+      : isCodexEndpoint;
   return {
     enabled,
     endpointKey: `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, '')}`
@@ -93,6 +153,7 @@ export function buildCodexRequestHeaders(
   context: CodexDynamicHeaderContext,
   transport: CodexTransportKind
 ): Record<string, string> {
+  const snapshot = context.snapshot;
   const headers: Record<string, string> = {
     ...context.credentialsHeaders,
     'User-Agent': context.userAgent,
@@ -103,7 +164,7 @@ export function buildCodexRequestHeaders(
     [CodexHeader.threadId]: context.identity.threadId,
     [CodexHeader.installationId]: context.identity.installationId,
     [CodexHeader.windowId]: context.identity.windowId,
-    [CodexHeader.turnMetadata]: context.turnMetadata
+    [CodexHeader.turnMetadata]: snapshot?.compatibilityTurnMetadata ?? context.turnMetadata
   };
 
   if (context.identity.parentThreadId) {
@@ -112,11 +173,28 @@ export function buildCodexRequestHeaders(
   if (context.turnState) {
     headers[CodexHeader.turnState] = context.turnState;
   }
+  if (snapshot) {
+    applyGeneratedHeaderOmissions(headers, snapshot.settings);
+    applyHeaderOverrides(headers, snapshot.settings);
+  }
   if (transport === 'websocket') {
     headers[CodexHeader.beta] = CODEX_RESPONSES_WEBSOCKET_BETA;
   } else {
     headers.Accept = 'text/event-stream';
     headers['Content-Type'] = 'application/json';
+  }
+
+  restoreCredentialHeaders(headers, context.credentialsHeaders);
+  if (context.turnState) {
+    headers[CodexHeader.turnState] = context.turnState;
+  }
+
+  if (snapshot) {
+    lastEffectiveProtocol = {
+      ...createProtocolDiagnostic(snapshot),
+      headers: redactHeaders(headers)
+    };
+    lastEffectiveProtocolIdentityKey = getSnapshotIdentityKey(snapshot);
   }
 
   return headers;
@@ -125,18 +203,27 @@ export function buildCodexRequestHeaders(
 export function buildCodexWebSocketPreconnectHeaders(
   context: CodexWebSocketPreconnectHeaderContext
 ): Record<string, string> {
-  return {
+  const headers = {
     ...context.credentialsHeaders,
     'User-Agent': context.userAgent,
     originator: 'codex-for-copilot',
     version: context.extensionVersion,
     [CodexHeader.beta]: CODEX_RESPONSES_WEBSOCKET_BETA
   };
+  if (context.settings) {
+    applyGeneratedHeaderOmissions(headers, context.settings);
+    applyHeaderOverrides(headers, context.settings);
+  }
+  headers[CodexHeader.beta] = CODEX_RESPONSES_WEBSOCKET_BETA;
+  restoreCredentialHeaders(headers, context.credentialsHeaders);
+  return headers;
 }
 
 export function createCodexTurnMetadata(
   identity: CodexRequestIdentity,
-  requestKind: CodexTurnMetadata['request_kind'] = 'turn'
+  requestKind: CodexTurnMetadata['request_kind'] = 'turn',
+  turnStartedAtUnixMs = Date.now(),
+  toolPlan?: CodexToolPlan
 ): CodexTurnMetadata {
   return {
     installation_id: identity.installationId,
@@ -145,9 +232,296 @@ export function createCodexTurnMetadata(
     turn_id: identity.turnId,
     window_id: identity.windowId,
     parent_thread_id: identity.parentThreadId ?? null,
+    ...(identity.parentTurnId ? { parent_turn_id: identity.parentTurnId } : {}),
+    ...(identity.rootTurnId ? { root_turn_id: identity.rootTurnId } : {}),
+    agent_name: 'codex-for-copilot',
+    turn_started_at_unix_ms: turnStartedAtUnixMs,
+    ...buildToolNamespacesMetadata(toolPlan),
     request_kind: requestKind,
     source: 'vscode-language-model-provider'
   };
+}
+
+export function buildCodexProtocolSnapshot(options: {
+  identity: CodexRequestIdentity;
+  requestKind?: CodexTurnMetadata['request_kind'];
+  turnStartedAtUnixMs?: number;
+  toolPlan?: CodexToolPlan;
+  settings?: Partial<CodexProtocolSettings>;
+}): CodexProtocolSnapshot {
+  const requestKind = options.requestKind ?? 'turn';
+  const settings = normalizeCodexProtocolSettings(options.settings);
+  const generated = createCodexTurnMetadata(
+    options.identity,
+    requestKind,
+    options.turnStartedAtUnixMs,
+    options.toolPlan
+  );
+  const turnMetadata = mergeMetadataOverrides(generated, settings.turnMetadataOverrides, settings.allowUnsafeProtocolOverrides);
+  const fullTurnMetadata = stableSerializeCodexMetadata(turnMetadata);
+  const compatibilityTurnMetadata = stableSerializeCodexMetadata({
+    ...turnMetadata,
+    tool_namespaces_info: undefined
+  } as CodexTurnMetadata);
+  const generatedClientMetadata: Record<string, string> = {
+    [CodexHeader.installationId]: String(turnMetadata.installation_id),
+    session_id: String(turnMetadata.session_id),
+    thread_id: String(turnMetadata.thread_id),
+    turn_id: String(turnMetadata.turn_id),
+    [CodexHeader.windowId]: String(turnMetadata.window_id),
+    [CodexHeader.turnMetadata]: fullTurnMetadata,
+    ...(turnMetadata.parent_thread_id
+      ? { [CodexHeader.parentThreadId]: String(turnMetadata.parent_thread_id) }
+      : {}),
+    ...(turnMetadata.parent_turn_id ? { parent_turn_id: String(turnMetadata.parent_turn_id) } : {}),
+    ...(turnMetadata.root_turn_id ? { root_turn_id: String(turnMetadata.root_turn_id) } : {})
+  };
+  const clientMetadata = mergeClientMetadataOverrides(
+    generatedClientMetadata,
+    settings.clientMetadataOverrides,
+    settings.allowUnsafeProtocolOverrides
+  );
+  const snapshot = { identity: options.identity, requestKind, turnMetadata, clientMetadata, compatibilityTurnMetadata, settings };
+  const previousHeaders = lastEffectiveProtocolIdentityKey === getSnapshotIdentityKey(snapshot)
+    ? lastEffectiveProtocol?.headers
+    : undefined;
+  lastEffectiveProtocol = {
+    ...createProtocolDiagnostic(snapshot),
+    ...(previousHeaders ? { headers: previousHeaders } : {})
+  };
+  lastEffectiveProtocolIdentityKey = getSnapshotIdentityKey(snapshot);
+  return snapshot;
+}
+
+export function getLastEffectiveCodexProtocol(): CodexEffectiveProtocolDiagnostic | undefined {
+  return lastEffectiveProtocol ? structuredClone(lastEffectiveProtocol) : undefined;
+}
+
+export function buildCodexClientMetadataProjection(
+  snapshot: CodexProtocolSnapshot,
+  websocketRequestStartedAt?: number
+): Record<string, string> {
+  return {
+    ...snapshot.clientMetadata,
+    ...(websocketRequestStartedAt === undefined
+      ? {}
+      : { 'x-codex-ws-stream-request-start-ms': String(websocketRequestStartedAt) })
+  };
+}
+
+export function normalizeCodexProtocolSettings(
+  settings: Partial<CodexProtocolSettings> | undefined
+): CodexProtocolSettings {
+  return {
+    profile: settings?.profile ?? 'auto',
+    headerOverrides: { ...settings?.headerOverrides },
+    clientMetadataOverrides: { ...settings?.clientMetadataOverrides },
+    turnMetadataOverrides: { ...settings?.turnMetadataOverrides },
+    omitGeneratedHeaders: [...(settings?.omitGeneratedHeaders ?? [])],
+    allowUnsafeProtocolOverrides: settings?.allowUnsafeProtocolOverrides === true
+  };
+}
+
+const RESERVED_METADATA_KEYS = new Set([
+  'installation_id', 'session_id', 'thread_id', 'turn_id', 'window_id', 'request_kind',
+  'parent_thread_id', 'parent_turn_id', 'root_turn_id', 'agent_name',
+  'tool_namespaces_info', 'turn_started_at_unix_ms', CodexHeader.installationId,
+  CodexHeader.windowId, CodexHeader.parentThreadId, CodexHeader.turnMetadata
+]);
+
+const ALWAYS_PROTECTED_HEADERS = new Set([
+  'authorization', 'chatgpt-account-id', 'host', 'content-length', 'connection', 'upgrade',
+  'openai-beta', 'accept', 'content-type', CodexHeader.turnState
+].map((value) => value.toLowerCase()));
+
+const SAFE_PROTECTED_HEADERS = new Set([
+  CodexHeader.requestId, CodexHeader.sessionId, CodexHeader.threadId, CodexHeader.installationId,
+  CodexHeader.windowId, CodexHeader.parentThreadId, CodexHeader.turnMetadata
+].map((value) => value.toLowerCase()));
+
+function buildToolNamespacesMetadata(toolPlan: CodexToolPlan | undefined): Partial<CodexTurnMetadata> {
+  if (!toolPlan || toolPlan.mode !== 'native-hosted') {
+    return {};
+  }
+  const namespaces: Record<string, CodexToolNamespaceMetadata> = {};
+  for (const tool of toolPlan.responseTools) {
+    if (tool.type === 'function') {
+      addToolFunctionMetadata(namespaces, 'functions', tool.name, true, false);
+    } else if (tool.type === 'namespace') {
+      for (const nested of tool.tools) {
+        addToolFunctionMetadata(namespaces, tool.name, nested.name, true, nested.defer_loading === true);
+      }
+    } else if (tool.type === 'tool_search') {
+      addToolFunctionMetadata(namespaces, 'tool_search', 'tool_search_tool', true, false);
+    }
+  }
+  return Object.keys(namespaces).length > 0 ? { tool_namespaces_info: namespaces } : {};
+}
+
+function addToolFunctionMetadata(
+  namespaces: Record<string, CodexToolNamespaceMetadata>,
+  namespaceName: string,
+  functionName: string,
+  direct: boolean,
+  deferred: boolean
+): void {
+  const namespace = namespaces[namespaceName] ??= { name: namespaceName, functions: {} };
+  namespace.functions[functionName] = {
+    name: functionName,
+    direct,
+    code_mode_name: null,
+    deferred,
+    source: { kind: 'harness' }
+  };
+}
+
+function mergeMetadataOverrides(
+  generated: CodexTurnMetadata,
+  overrides: Record<string, unknown>,
+  allowUnsafe: boolean
+): CodexTurnMetadata {
+  const accepted = Object.fromEntries(Object.entries(overrides)
+    .filter(([key, value]) => isValidExtraMetadata(key, value) && (allowUnsafe || !RESERVED_METADATA_KEYS.has(key)))
+    .slice(0, 16));
+  return { ...generated, ...accepted } as CodexTurnMetadata;
+}
+
+function mergeClientMetadataOverrides(
+  generated: Record<string, string>,
+  overrides: Record<string, string>,
+  allowUnsafe: boolean
+): Record<string, string> {
+  const accepted = Object.fromEntries(Object.entries(overrides)
+    .filter(([key, value]) => isValidExtraMetadata(key, value) && (allowUnsafe || !RESERVED_METADATA_KEYS.has(key)))
+    .slice(0, 16));
+  return { ...generated, ...accepted };
+}
+
+function isValidExtraMetadata(key: string, value: unknown): boolean {
+  return /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/.test(key)
+    && (typeof value === 'string' ? Buffer.byteLength(value) <= 128 : isJsonValue(value));
+}
+
+function isJsonValue(value: unknown): boolean {
+  if (value === null || typeof value === 'boolean' || typeof value === 'number') {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.every(isJsonValue);
+  }
+  return typeof value === 'object' && Object.values(value as Record<string, unknown>).every(isJsonValue);
+}
+
+function applyGeneratedHeaderOmissions(headers: Record<string, string>, settings: CodexProtocolSettings): void {
+  for (const name of settings.omitGeneratedHeaders) {
+    const normalized = name.toLowerCase();
+    if (ALWAYS_PROTECTED_HEADERS.has(normalized) || (!settings.allowUnsafeProtocolOverrides && SAFE_PROTECTED_HEADERS.has(normalized))) {
+      continue;
+    }
+    deleteHeader(headers, name);
+  }
+}
+
+function applyHeaderOverrides(headers: Record<string, string>, settings: CodexProtocolSettings): void {
+  for (const [name, value] of Object.entries(settings.headerOverrides).slice(0, 32)) {
+    const normalized = name.toLowerCase();
+    if (!isValidHeaderName(name) || !isValidHeaderValue(value)
+      || ALWAYS_PROTECTED_HEADERS.has(normalized)
+      || normalized.startsWith('sec-websocket-')
+      || (!settings.allowUnsafeProtocolOverrides && SAFE_PROTECTED_HEADERS.has(normalized))) {
+      continue;
+    }
+    deleteHeader(headers, name);
+    headers[name] = value;
+  }
+}
+
+function restoreCredentialHeaders(headers: Record<string, string>, credentials: Record<string, string> | undefined): void {
+  for (const [name, value] of Object.entries(credentials ?? {})) {
+    const normalized = name.toLowerCase();
+    if (normalized === 'authorization' || normalized === 'chatgpt-account-id') {
+      deleteHeader(headers, name);
+      headers[name] = value;
+    }
+  }
+}
+
+function deleteHeader(headers: Record<string, string>, name: string): void {
+  const normalized = name.toLowerCase();
+  for (const existing of Object.keys(headers)) {
+    if (existing.toLowerCase() === normalized) {
+      delete headers[existing];
+    }
+  }
+}
+
+function isValidHeaderName(value: string): boolean {
+  return /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(value);
+}
+
+function isValidHeaderValue(value: string): boolean {
+  return typeof value === 'string' && Buffer.byteLength(value) <= 1024 && !/[\r\n]/.test(value);
+}
+
+function createProtocolDiagnostic(snapshot: CodexProtocolSnapshot): CodexEffectiveProtocolDiagnostic {
+  return {
+    profile: snapshot.settings.profile,
+    clientMetadata: redactMetadataRecord(snapshot.clientMetadata),
+    turnMetadata: redactObject(snapshot.turnMetadata) as Record<string, unknown>
+  };
+}
+
+function getSnapshotIdentityKey(snapshot: CodexProtocolSnapshot): string {
+  return `${snapshot.identity.threadId}:${snapshot.identity.turnId}:${snapshot.requestKind}`;
+}
+
+function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(headers).map(([key, value]) => {
+    const normalized = key.toLowerCase();
+    if (normalized === 'authorization' || normalized === 'chatgpt-account-id' || normalized === CodexHeader.turnState) {
+      return [key, '<redacted>'];
+    }
+    if (normalized === CodexHeader.turnMetadata) {
+      return [key, redactSerializedMetadata(value)];
+    }
+    return [key, isIdentityKey(normalized) ? '<redacted:id>' : value];
+  }));
+}
+
+function redactMetadataRecord(metadata: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(metadata).map(([key, value]) => [
+    key,
+    key.toLowerCase() === CodexHeader.turnMetadata
+      ? redactSerializedMetadata(value)
+      : isIdentityKey(key.toLowerCase()) ? '<redacted:id>' : value
+  ]));
+}
+
+function redactSerializedMetadata(value: string): string {
+  try {
+    return stableSerializeCodexMetadata(redactObject(JSON.parse(value)) as CodexTurnMetadata);
+  } catch {
+    return '<redacted:metadata>';
+  }
+}
+
+function redactObject(value: unknown, key?: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactObject(entry));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+      .map(([nestedKey, nested]) => [nestedKey, redactObject(nested, nestedKey)]));
+  }
+  return key && isIdentityKey(key.toLowerCase()) ? '<redacted:id>' : value;
+}
+
+function isIdentityKey(key: string): boolean {
+  return key === 'session_id' || key === 'thread_id' || key === 'turn_id' || key === 'window_id'
+    || key === 'installation_id' || key === 'parent_thread_id' || key === 'parent_turn_id'
+    || key === 'root_turn_id' || key === CodexHeader.sessionId || key === CodexHeader.threadId
+    || key === CodexHeader.requestId || key === CodexHeader.installationId || key === CodexHeader.windowId
+    || key === CodexHeader.parentThreadId;
 }
 
 export function stableSerializeCodexMetadata(metadata: CodexTurnMetadata): string {

--- a/src/codexRequestBuilder.ts
+++ b/src/codexRequestBuilder.ts
@@ -6,9 +6,9 @@ import type { ResponsesInputMessage } from './convertMessages';
 import { resolveCodexToolSchemas } from './codexToolSchemaCache';
 import type { CodexToolPlan } from './nativeToolSearch/nativeToolTypes';
 import {
-  CodexHeader,
-  createCodexTurnMetadata,
-  stableSerializeCodexMetadata,
+  buildCodexClientMetadataProjection,
+  buildCodexProtocolSnapshot,
+  type CodexProtocolSettings,
   type CodexRequestIdentity
 } from './codexProtocol';
 
@@ -41,6 +41,8 @@ export interface CodexRequestBuilderOptions {
   includeEncryptedReasoning?: boolean;
   requestKind?: 'turn' | 'prewarm';
   websocketRequestStartedAt?: number;
+  turnStartedAtUnixMs?: number;
+  protocolSettings?: CodexProtocolSettings;
 }
 
 export type CodexRequestEnvelopeOptions = Omit<
@@ -71,8 +73,17 @@ export function buildCodexResponsesRequestWithMetrics(
   const legacyToolSchemas = options.toolPlan ? undefined : resolveCodexToolSchemas(options.tools);
   const toolPlan = options.toolPlan;
   const tools = toolPlan?.responseTools ?? legacyToolSchemas?.responseTools ?? [];
-  const metadata = options.compatibilityEnabled && options.identity
-    ? buildCodexClientMetadata(options.identity, options.requestKind ?? 'turn', options.websocketRequestStartedAt)
+  const protocolSnapshot = options.compatibilityEnabled && options.identity
+    ? buildCodexProtocolSnapshot({
+        identity: options.identity,
+        requestKind: options.requestKind ?? 'turn',
+        turnStartedAtUnixMs: options.turnStartedAtUnixMs,
+        toolPlan: options.toolPlan,
+        settings: options.protocolSettings
+      })
+    : undefined;
+  const metadata = protocolSnapshot
+    ? buildCodexClientMetadataProjection(protocolSnapshot, options.websocketRequestStartedAt)
     : undefined;
   const compatibilityFields = options.compatibilityEnabled
     ? {
@@ -141,19 +152,10 @@ export function buildCodexClientMetadata(
   requestKind: 'turn' | 'prewarm',
   websocketRequestStartedAt?: number
 ): Record<string, string> {
-  const turnMetadata = stableSerializeCodexMetadata(createCodexTurnMetadata(identity, requestKind));
-  return {
-    [CodexHeader.installationId]: identity.installationId,
-    session_id: identity.sessionId,
-    thread_id: identity.threadId,
-    turn_id: identity.turnId,
-    [CodexHeader.windowId]: identity.windowId,
-    [CodexHeader.turnMetadata]: turnMetadata,
-    ...(identity.parentThreadId ? { [CodexHeader.parentThreadId]: identity.parentThreadId } : {}),
-    ...(websocketRequestStartedAt === undefined
-      ? {}
-      : { 'x-codex-ws-stream-request-start-ms': String(websocketRequestStartedAt) })
-  };
+  return buildCodexClientMetadataProjection(
+    buildCodexProtocolSnapshot({ identity, requestKind }),
+    websocketRequestStartedAt
+  );
 }
 
 export function fingerprintCodexRequest(request: CodexResponsesRequest): string {
@@ -168,10 +170,11 @@ export function fingerprintCodexRequest(request: CodexResponsesRequest): string 
 }
 
 export function fingerprintCodexRequestEnvelope(options: CodexRequestEnvelopeOptions): string {
-  return fingerprintCodexRequest(buildCodexResponsesRequest({
+  const requestFingerprint = fingerprintCodexRequest(buildCodexResponsesRequest({
     ...options,
     input: []
   }));
+  return stableSerialize({ requestFingerprint, protocolSettings: options.protocolSettings ?? null });
 }
 
 export function areCodexRequestsIncrementallyCompatible(

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { normalizeKnownReasoningEffort, type KnownReasoningEffort } from './reasoningEffort';
 import { MAX_NAMESPACE_FUNCTIONS } from './nativeToolSearch/nativeToolPolicy';
+import type { CodexProtocolProfileName, CodexProtocolSettings } from './codexProtocol';
 
 export interface ModelPricing {
   input?: number;
@@ -15,6 +16,7 @@ export interface ProviderConfig {
   transport: 'auto' | 'http' | 'websocket';
   websocketPrewarm: 'auto' | 'enabled' | 'disabled';
   requestCompression: 'auto' | 'enabled' | 'disabled';
+  protocol: CodexProtocolSettings;
   nativeToolSearch: 'auto' | 'enabled' | 'disabled';
   nativeToolSearchMaxToolsPerNamespace: number;
   model: string;
@@ -38,6 +40,14 @@ export function getProviderConfig(): ProviderConfig {
     transport: normalizeTransport(config.get('transport', 'auto')),
     websocketPrewarm: normalizeTriState(config.get('websocketPrewarm', 'auto')),
     requestCompression: normalizeTriState(config.get('requestCompression', 'auto')),
+    protocol: {
+      profile: normalizeProtocolProfile(config.get('protocolProfile', 'auto')),
+      headerOverrides: normalizeStringRecord(config.get('headerOverrides', {}), 32, 1024),
+      clientMetadataOverrides: normalizeStringRecord(config.get('clientMetadataOverrides', {}), 16, 128),
+      turnMetadataOverrides: normalizeJsonRecord(config.get('turnMetadataOverrides', {}), 16),
+      omitGeneratedHeaders: normalizeStringList(config.get('omitGeneratedHeaders', [])),
+      allowUnsafeProtocolOverrides: config.get('allowUnsafeProtocolOverrides', false)
+    },
     nativeToolSearch: normalizeTriState(config.get('nativeToolSearch', 'disabled'), 'disabled'),
     nativeToolSearchMaxToolsPerNamespace: normalizeNativeToolSearchMaxToolsPerNamespace(
       config.get('nativeToolSearchMaxToolsPerNamespace', MAX_NAMESPACE_FUNCTIONS)
@@ -52,6 +62,10 @@ export function getProviderConfig(): ProviderConfig {
     maxOutputTokens: config.get('maxOutputTokens', 8192),
     modelPricingUsdPerMTok: normalizeModelPricing(config.get('modelPricingUsdPerMTok', {}))
   };
+}
+
+function normalizeProtocolProfile(value: unknown): CodexProtocolProfileName {
+  return value === 'codexCompatible' || value === 'minimal' || value === 'custom' ? value : 'auto';
 }
 
 function normalizeTriState(
@@ -148,6 +162,33 @@ function normalizeModelAliases(value: unknown): Record<string, string> {
   }
 
   return aliases;
+}
+
+function normalizeStringRecord(
+  value: unknown,
+  maxEntries: number,
+  maxValueBytes: number
+): Record<string, string> {
+  if (!isObjectRecord(value)) {
+    return {};
+  }
+  const normalized: Record<string, string> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    if (Object.keys(normalized).length >= maxEntries) {
+      break;
+    }
+    if (key.trim().length > 0 && typeof nested === 'string' && Buffer.byteLength(nested) <= maxValueBytes) {
+      normalized[key] = nested;
+    }
+  }
+  return normalized;
+}
+
+function normalizeJsonRecord(value: unknown, maxEntries: number): Record<string, unknown> {
+  if (!isObjectRecord(value)) {
+    return {};
+  }
+  return Object.fromEntries(Object.entries(value).slice(0, maxEntries));
 }
 
 function normalizePricingNumber(value: unknown): number | undefined {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import {
   restoreVSCodeToolGrouping
 } from './nativeToolSearch/nativeToolGroupingBridge';
 import { getNativeToolSearchRuntimeStatus } from './nativeToolSearch/nativeToolSearchStatus';
+import { getLastEffectiveCodexProtocol } from './codexProtocol';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const outputChannel = vscode.window.createOutputChannel('Codex Model Provider', { log: true });
@@ -194,9 +195,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         await vscode.commands.executeCommand('workbench.action.openSettings', 'codexModelProvider.nativeToolSearch');
       }
     }),
+    vscode.commands.registerCommand('codexModelProvider.showEffectiveProtocol', () => {
+      const diagnostic = getLastEffectiveCodexProtocol();
+      if (!diagnostic) {
+        void vscode.window.showInformationMessage('No Codex-compatible request has run since this extension activated.');
+        return;
+      }
+      logger.info('protocol.effective', { ...diagnostic });
+      outputChannel.show(true);
+    }),
     vscode.commands.registerCommand('codexModelProvider.manage', async () => {
       const action = await vscode.window.showQuickPick(
-        ['Sign in with ChatGPT', 'Sign in with Device Code', 'Show Auth Status', 'Sign Out', 'Import Codex auth.json', 'Refresh Account Limits', 'Enable Native Tool Search', 'Use VS Code Virtual Tool Groups', 'Show Native Tool Search Status', 'Open Debug Logs', 'Set API Key', 'Clear API Key', 'Open Settings'],
+        ['Sign in with ChatGPT', 'Sign in with Device Code', 'Show Auth Status', 'Sign Out', 'Import Codex auth.json', 'Refresh Account Limits', 'Enable Native Tool Search', 'Use VS Code Virtual Tool Groups', 'Show Native Tool Search Status', 'Show Effective Protocol', 'Open Debug Logs', 'Set API Key', 'Clear API Key', 'Open Settings'],
         { title: 'Codex' }
       );
 
@@ -218,6 +228,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         await vscode.commands.executeCommand('codexModelProvider.restoreVSCodeToolGrouping');
       } else if (action === 'Show Native Tool Search Status') {
         await vscode.commands.executeCommand('codexModelProvider.showNativeToolSearchStatus');
+      } else if (action === 'Show Effective Protocol') {
+        await vscode.commands.executeCommand('codexModelProvider.showEffectiveProtocol');
       } else if (action === 'Open Debug Logs') {
         await vscode.commands.executeCommand('codexModelProvider.openDebugLogs');
       } else if (action === 'Set API Key') {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -285,7 +285,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
 
     const authIdentity = getCredentialIdentity(credentials);
     this.handleConnectionConfiguration(config, authIdentity);
-    const compatibilityProfile = getCodexCompatibilityProfile(config.baseURL, credentials);
+    const compatibilityProfile = getCodexCompatibilityProfile(config.baseURL, credentials, config.protocol.profile);
     const modelCacheKey = buildModelCacheKey(config, credentials.source, credentials.kind, authIdentity);
     const cachedCatalog = this.modelCache.peek(modelCacheKey);
     const directModel = cachedCatalog?.authoritative
@@ -395,7 +395,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       omitMaxOutputTokens: credentials.omitMaxOutputTokens,
       maxOutputTokens: config.maxOutputTokens,
       textVerbosity: 'medium',
-      includeEncryptedReasoning: true
+      includeEncryptedReasoning: true,
+      protocolSettings: config.protocol
     };
     const toolSchemas = toolPlan;
     latency.recordContext({
@@ -480,7 +481,9 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         sessionId: requestIdentity.sessionId,
         threadId: requestIdentity.threadId,
         windowId: requestIdentity.windowId,
-        parentThreadId: requestIdentity.parentThreadId
+        parentThreadId: requestIdentity.parentThreadId,
+        parentTurnId: requestIdentity.parentTurnId,
+        rootTurnId: requestIdentity.rootTurnId
       },
       turn: {
         id: requestIdentity.turnId,
@@ -690,6 +693,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         authIdentity,
         extensionVersion: getExtensionVersion(this.context),
         userAgent: buildCodexUserAgent(getExtensionVersion(this.context)),
+        protocolSettings: config.protocol,
+        turnStartedAtUnixMs: branchState.turn.startedAt,
         websocketPrewarm: config.websocketPrewarm,
         requestCompression: config.requestCompression,
         previousResponseId,
@@ -1171,7 +1176,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       authIdentity,
       transport: config.transport,
       websocketPrewarm: config.websocketPrewarm,
-      requestCompression: config.requestCompression
+      requestCompression: config.requestCompression,
+      protocol: config.protocol
     });
     if (this.lastConnectionConfigurationKey && this.lastConnectionConfigurationKey !== key) {
       disposeReusableResponsesWebSockets();
@@ -1189,7 +1195,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       return;
     }
     this.handleConnectionConfiguration(config, authIdentity);
-    const compatibilityProfile = getCodexCompatibilityProfile(config.baseURL, credentials);
+    const compatibilityProfile = getCodexCompatibilityProfile(config.baseURL, credentials, config.protocol.profile);
     const started = compatibilityProfile.enabled && preconnectCodexResponsesWebSocket({
       baseURL: config.baseURL,
       apiKey: credentials.apiKey,
@@ -1197,7 +1203,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       compatibilityProfile,
       authIdentity,
       extensionVersion: getExtensionVersion(this.context),
-      userAgent: buildCodexUserAgent(getExtensionVersion(this.context))
+      userAgent: buildCodexUserAgent(getExtensionVersion(this.context)),
+      protocolSettings: config.protocol
     });
     if (started) {
       this.outputChannel.debug('response WebSocket preconnection started', {

--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -23,9 +23,9 @@ import { resolveProxyForURL } from './proxy';
 import {
   buildCodexWebSocketPreconnectHeaders,
   buildCodexRequestHeaders,
-  createCodexTurnMetadata,
-  stableSerializeCodexMetadata,
+  buildCodexProtocolSnapshot,
   type CodexCompatibilityProfile,
+  type CodexProtocolSettings,
   type CodexRequestIdentity
 } from './codexProtocol';
 import {
@@ -117,6 +117,8 @@ export interface StreamResponseTextOptions {
   authIdentity?: string;
   extensionVersion?: string;
   userAgent?: string;
+  protocolSettings?: CodexProtocolSettings;
+  turnStartedAtUnixMs?: number;
   websocketPrewarm?: 'auto' | 'enabled' | 'disabled';
   requestCompression?: RequestCompressionPolicy;
   previousResponseId?: string;
@@ -173,6 +175,7 @@ export interface PreconnectCodexResponsesWebSocketOptions {
   authIdentity: string;
   extensionVersion?: string;
   userAgent?: string;
+  protocolSettings?: CodexProtocolSettings;
   onConnected?: CodexWebSocketPreconnectionObserver['onConnected'];
   onError?: CodexWebSocketPreconnectionObserver['onError'];
 }
@@ -219,7 +222,8 @@ export function preconnectCodexResponsesWebSocket(options: PreconnectCodexRespon
   const headers = buildCodexWebSocketPreconnectHeaders({
     credentialsHeaders: options.headers,
     extensionVersion: options.extensionVersion ?? '0.0.0',
-    userAgent: options.userAgent ?? `codex-for-copilot/${options.extensionVersion ?? '0.0.0'}`
+    userAgent: options.userAgent ?? `codex-for-copilot/${options.extensionVersion ?? '0.0.0'}`,
+    settings: options.protocolSettings
   });
 
   try {
@@ -874,7 +878,9 @@ function createRequestBuilderOptions(options: StreamResponseTextOptions): CodexR
     omitMaxOutputTokens: options.omitMaxOutputTokens,
     maxOutputTokens: options.maxOutputTokens,
     textVerbosity: 'medium',
-    includeEncryptedReasoning: true
+    includeEncryptedReasoning: true,
+    protocolSettings: options.protocolSettings,
+    turnStartedAtUnixMs: options.turnStartedAtUnixMs
   };
 }
 
@@ -882,11 +888,18 @@ function buildDynamicHeaders(options: StreamResponseTextOptions, transport: 'htt
   if (!options.compatibilityProfile?.enabled || !options.identity) {
     return { ...options.headers };
   }
-  const metadata = stableSerializeCodexMetadata(createCodexTurnMetadata(options.identity));
+  const snapshot = buildCodexProtocolSnapshot({
+    identity: options.identity,
+    turnStartedAtUnixMs: options.turnStartedAtUnixMs,
+    toolPlan: options.toolPlan,
+    settings: options.protocolSettings
+  });
+  const metadata = snapshot.compatibilityTurnMetadata;
   return buildCodexRequestHeaders({
     credentialsHeaders: options.headers,
     identity: options.identity,
     turnMetadata: metadata,
+    snapshot,
     turnState: options.turnState,
     extensionVersion: options.extensionVersion ?? '0.0.0',
     userAgent: options.userAgent ?? `codex-for-copilot/${options.extensionVersion ?? '0.0.0'}`

--- a/test/smokeCodexProtocol.mjs
+++ b/test/smokeCodexProtocol.mjs
@@ -4,6 +4,7 @@ const loaded = await loadBundled('src/codexProtocol.ts');
 try {
   const {
     CODEX_RESPONSES_WEBSOCKET_BETA,
+    buildCodexProtocolSnapshot,
     buildCodexRequestHeaders,
     createCodexTurnMetadata,
     getCodexCompatibilityProfile,
@@ -16,7 +17,8 @@ try {
     turnId: '44444444-4444-4444-8444-444444444444',
     windowId: '55555555-5555-4555-8555-555555555555'
   };
-  const metadata = stableSerializeCodexMetadata(createCodexTurnMetadata(identity));
+  const turnStartedAtUnixMs = 1_787_000_000_000;
+  const metadata = stableSerializeCodexMetadata(createCodexTurnMetadata(identity, 'turn', turnStartedAtUnixMs));
   const headers = buildCodexRequestHeaders({
     credentialsHeaders: { 'ChatGPT-Account-ID': 'acct-test' },
     identity,
@@ -29,9 +31,62 @@ try {
   assertEqual(headers.originator, 'codex-for-copilot', 'truthful originator');
   assertEqual(headers['session-id'], identity.sessionId, 'session header');
   assertEqual(headers['x-codex-turn-state'], undefined, 'turn state omitted initially');
-  assertEqual(metadata, stableSerializeCodexMetadata(createCodexTurnMetadata(identity)), 'stable metadata');
+  assertEqual(metadata, stableSerializeCodexMetadata(createCodexTurnMetadata(identity, 'turn', turnStartedAtUnixMs)), 'stable metadata');
+  const safeSnapshot = buildCodexProtocolSnapshot({
+    identity,
+    turnStartedAtUnixMs,
+    settings: {
+      headerOverrides: { originator: 'custom-client', Authorization: 'must-not-win', 'x-extra': 'yes', 'x-codex-routing-hint': 'route-a' },
+      clientMetadataOverrides: { custom_surface: 'vscode', thread_id: 'must-not-win' },
+      turnMetadataOverrides: { custom_surface: 'vscode', thread_id: 'must-not-win' }
+    }
+  });
+  const safeHeaders = buildCodexRequestHeaders({
+    credentialsHeaders: { Authorization: 'Bearer real', 'ChatGPT-Account-ID': 'acct-test' },
+    identity,
+    turnMetadata: safeSnapshot.compatibilityTurnMetadata,
+    snapshot: safeSnapshot,
+    turnState: 'sticky-secret',
+    extensionVersion: '1.2.3',
+    userAgent: 'codex-for-copilot/1.2.3 (test)'
+  }, 'http');
+  assertEqual(safeHeaders.originator, 'custom-client', 'safe header override');
+  assertEqual(safeHeaders['x-extra'], 'yes', 'extra header override');
+  assertEqual(safeHeaders['x-codex-routing-hint'], 'route-a', 'routing hint override');
+  assertEqual(safeHeaders.Authorization, 'Bearer real', 'credential override is protected');
+  assertEqual(safeHeaders['x-codex-turn-state'], 'sticky-secret', 'Turn State override is protected');
+  assertEqual(safeSnapshot.turnMetadata.thread_id, identity.threadId, 'reserved turn metadata is protected');
+  assertEqual(safeSnapshot.clientMetadata.thread_id, identity.threadId, 'reserved client metadata is protected');
+  assertEqual(safeSnapshot.turnMetadata.custom_surface, 'vscode', 'extra turn metadata is accepted');
+  assertEqual(safeSnapshot.clientMetadata.custom_surface, 'vscode', 'extra client metadata is accepted');
+  const toolSnapshot = buildCodexProtocolSnapshot({
+    identity,
+    turnStartedAtUnixMs,
+    toolPlan: {
+      mode: 'native-hosted',
+      responseTools: [{
+        type: 'function',
+        name: 'open_file',
+        description: 'Open',
+        parameters: {}
+      }, {
+        type: 'namespace',
+        name: 'workspace_tools',
+        description: 'Workspace tools',
+        tools: [{ type: 'function', name: 'read_file', description: 'Read', parameters: {}, defer_loading: true }]
+      }, { type: 'tool_search' }]
+    }
+  });
+  const fullToolMetadata = JSON.parse(toolSnapshot.clientMetadata['x-codex-turn-metadata']);
+  const boundedToolMetadata = JSON.parse(toolSnapshot.compatibilityTurnMetadata);
+  assertEqual(fullToolMetadata.tool_namespaces_info.workspace_tools.functions.read_file.deferred, true, 'tool namespace metadata');
+  assertEqual(fullToolMetadata.tool_namespaces_info.functions.functions.open_file.direct, true, 'direct function metadata');
+  assertEqual(fullToolMetadata.tool_namespaces_info.tool_search.functions.tool_search_tool.direct, true, 'Tool Search metadata');
+  assertEqual('tool_namespaces_info' in boundedToolMetadata, false, 'compatibility header omits unbounded tool inventory');
   assertEqual(getCodexCompatibilityProfile('https://chatgpt.com/backend-api/codex/responses', { kind: 'codexAccessToken' }).enabled, true, 'Codex profile enabled');
   assertEqual(getCodexCompatibilityProfile('https://api.openai.com/v1', { kind: 'openaiApiKey' }).enabled, false, 'BYOK profile disabled');
+  assertEqual(getCodexCompatibilityProfile('https://gateway.example/v1', { kind: 'openaiApiKey' }, 'custom').enabled, true, 'custom HTTPS profile enabled');
+  assertEqual(getCodexCompatibilityProfile('https://chatgpt.com/backend-api/codex/responses', { kind: 'codexAccessToken' }, 'minimal').enabled, false, 'minimal profile disabled');
   console.log('Smoke test passed: Codex protocol constants, headers, gating, and metadata are stable.');
 } finally {
   await loaded.dispose();

--- a/test/smokeCodexRequestBuilder.mjs
+++ b/test/smokeCodexRequestBuilder.mjs
@@ -28,7 +28,8 @@ try {
     reasoning: { effort: 'high', summary: 'auto' },
     maxOutputTokens: 100,
     omitMaxOutputTokens: true,
-    textVerbosity: 'medium'
+    textVerbosity: 'medium',
+    turnStartedAtUnixMs: 1_787_000_000_000
   };
   const request = buildCodexResponsesRequest(base);
   const compatibilityDefaultReasoningRequest = buildCodexResponsesRequest({
@@ -71,6 +72,7 @@ try {
   const secondBuild = buildCodexResponsesRequestWithMetrics(base);
   assertEqual(request.prompt_cache_key, identity.threadId, 'stable prompt cache key');
   assertEqual(request.client_metadata.turn_id, identity.turnId, 'turn metadata');
+  assertEqual(JSON.parse(request.client_metadata['x-codex-turn-metadata']).turn_started_at_unix_ms, base.turnStartedAtUnixMs, 'turn start metadata');
   assertEqual(request.parallel_tool_calls, true, 'parallel tools');
   assertEqual(request.instructions, base.instructions, 'configured instructions preserved with tools');
   assertEqual(request.include[0], 'reasoning.encrypted_content', 'encrypted reasoning include');


### PR DESCRIPTION
## Summary

- introduce a canonical Codex protocol snapshot that projects one source of truth into `client_metadata` and bounded HTTP/WebSocket compatibility headers
- add current Codex turn metadata, including agent name, turn start time, parent/root turn hierarchy, and Native Tool Search namespace/function inventory
- add configurable protocol profiles plus protected header/client-metadata/turn-metadata overrides
- add the redacted `Codex: Show Effective Protocol` diagnostic command
- update the upstream parity baseline and protocol architecture documentation

## Safety and compatibility

- authentication, account identity, Turn State, transport invariants, and `Sec-WebSocket-*` fields cannot be overridden
- the direct `x-codex-turn-metadata` header excludes the unbounded tool inventory, matching upstream behavior
- protocol settings participate in continuation-envelope fingerprints and connection invalidation
- the default `auto` profile preserves the existing official ChatGPT Codex endpoint gate
- attestation, Agent Identity, subagent, memory, Responses Lite, and FedRAMP-only behavior remain deliberately unsupported

## Validation

- `npm run check`
- `npm run test:codex-parity`
- full `test:smoke` file set under Node.js 22 with environment proxy variables removed, matching CI's direct local-mock assumptions
- `npm run compile`
- `git diff --check`

The workspace injects proxy environment variables and runs Node.js 24 by default; the two proxy-sensitive mock tests were therefore also rerun under the repository CI's Node.js 22 environment without those variables, where the complete smoke set passed.