### PR TITLE
feat: add multi-account support for Codex accounts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,8 @@
       "type": "extensionHost",
       "request": "launch",
       "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--disable-extension=gaussian.gaussian-codex-for-copilot"
       ],
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"

--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ Use **`Codex: Enable Native Tool Search`** to opt in. The extension saves the pr
 - `Codex: Use VS Code Virtual Tool Groups`
 - `Codex: Show Native Tool Search Status`
 - `Codex for Copilot: Sign in with ChatGPT`
+- `Codex for Copilot: Add Codex Account`
+- `Codex for Copilot: Switch Codex Account`
+- `Codex for Copilot: Remove Codex Account`
 - `Codex for Copilot: Sign in with Device Code`
 - `Codex for Copilot: Import Codex auth.json`
 - `Codex for Copilot: Show Auth Status`
-- `Codex for Copilot: Sign Out`
+- `Codex for Copilot: Sign Out (All Accounts)`
 
 ## Diagnostics and privacy
 

--- a/package.json
+++ b/package.json
@@ -95,6 +95,10 @@
         "title": "Codex: Refresh Account Limits"
       },
       {
+        "command": "codexModelProvider.showAccountLimits",
+        "title": "Codex: Show Account Limits"
+      },
+      {
         "command": "codexForCopilot.auth.signInWithChatGPT",
         "title": "Codex for Copilot: Sign in with ChatGPT"
       },
@@ -116,7 +120,19 @@
       },
       {
         "command": "codexForCopilot.auth.signOut",
-        "title": "Codex for Copilot: Sign Out"
+        "title": "Codex for Copilot: Sign Out (All Accounts)"
+      },
+      {
+        "command": "codexForCopilot.auth.addAccount",
+        "title": "Codex for Copilot: Add Codex Account"
+      },
+      {
+        "command": "codexForCopilot.auth.switchAccount",
+        "title": "Codex for Copilot: Switch Codex Account"
+      },
+      {
+        "command": "codexForCopilot.auth.removeAccount",
+        "title": "Codex for Copilot: Remove Codex Account"
       },
       {
         "command": "codexForCopilot.auth.showStatus",

--- a/src/accountUsage.ts
+++ b/src/accountUsage.ts
@@ -70,7 +70,7 @@ export async function fetchCodexAccountUsage(options: {
       signal: options.signal
     };
     const response = options.credentials.authManager
-      ? await codexFetch(options.credentials.authManager, usageURL, requestInit, proxyAwareFetch)
+      ? await codexFetch(options.credentials.authManager, usageURL, requestInit, proxyAwareFetch, options.credentials.accountKey)
       : await proxyAwareFetch(usageURL, {
           ...requestInit,
           headers: {

--- a/src/accountUsageStatusBar.ts
+++ b/src/accountUsageStatusBar.ts
@@ -2,29 +2,36 @@ import * as vscode from 'vscode';
 import { buildCodexAccountUsageDisplay, fetchCodexAccountUsage, type CodexAccountUsageSnapshot } from './accountUsage';
 import type { CodexAuthManager } from './auth/codexAuthManager';
 import { getProviderConfig } from './config';
-import { getApiCredentials } from './secrets';
+import { getCodexCredentialsForAccount } from './secrets';
 import { type CodexLogSink, CodexLogger, createCodexLogger } from './codexLogger';
 
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
+interface AccountUsageEntry {
+  accountKey: string;
+  label: string;
+  isActive: boolean;
+  snapshot?: CodexAccountUsageSnapshot;
+  error?: boolean;
+}
 
 export class CodexAccountUsageStatusBar implements vscode.Disposable {
   private readonly statusBarItem: vscode.StatusBarItem;
   private readonly disposables: vscode.Disposable[];
   private readonly refreshTimer: ReturnType<typeof setInterval>;
-  private lastSnapshot?: CodexAccountUsageSnapshot;
+  private readonly usageByAccount = new Map<string, AccountUsageEntry>();
   private refreshInFlight?: Promise<void>;
   private selectedModel = getProviderConfig().model;
   private readonly logger: CodexLogger;
 
   constructor(
-    private readonly context: vscode.ExtensionContext,
     logger: CodexLogger | CodexLogSink,
     private readonly authManager?: CodexAuthManager
   ) {
     this.logger = logger instanceof CodexLogger ? logger : createCodexLogger(logger, 'account-usage');
     this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 101);
     this.statusBarItem.name = 'Codex Account Limits';
-    this.statusBarItem.command = 'codexModelProvider.refreshAccountLimits';
+    this.statusBarItem.command = 'codexModelProvider.showAccountLimits';
     this.statusBarItem.hide();
 
     this.refreshTimer = setInterval(() => {
@@ -52,9 +59,7 @@ export class CodexAccountUsageStatusBar implements vscode.Disposable {
     }
 
     this.selectedModel = model;
-    if (this.lastSnapshot) {
-      this.render(this.lastSnapshot);
-    }
+    this.renderActive();
   }
 
   async refresh(): Promise<void> {
@@ -70,17 +75,65 @@ export class CodexAccountUsageStatusBar implements vscode.Disposable {
   }
 
   async showDetails(): Promise<void> {
-    if (!this.lastSnapshot) {
+    if (this.usageByAccount.size === 0) {
       await this.refresh();
     }
 
-    if (!this.lastSnapshot) {
-      vscode.window.showInformationMessage('No Codex account limits are available for the active credentials.');
+    if (this.usageByAccount.size === 0) {
+      vscode.window.showInformationMessage('No Codex account limits are available.');
       return;
     }
 
-    const display = buildCodexAccountUsageDisplay(this.lastSnapshot, this.selectedModel);
-    await vscode.window.showInformationMessage(display.tooltip.replace(/\n/g, ' | '));
+    interface UsagePick extends vscode.QuickPickItem {
+      accountKey?: string;
+    }
+
+    const items: UsagePick[] = [...this.usageByAccount.values()].map((entry) => {
+      if (entry.error || !entry.snapshot) {
+        return {
+          label: `${entry.isActive ? '$(check) ' : ''}${entry.label}`,
+          description: entry.isActive ? 'active' : '',
+          detail: 'Usage unavailable (failed to load)',
+          accountKey: entry.accountKey
+        };
+      }
+      const display = buildCodexAccountUsageDisplay(entry.snapshot, this.selectedModel);
+      return {
+        label: `${entry.isActive ? '$(check) ' : ''}${entry.label}`,
+        description: [entry.isActive ? 'active' : '', display.compactText ?? ''].filter(Boolean).join('  '),
+        detail: display.tooltip.replace(/\n/g, '  •  '),
+        accountKey: entry.accountKey
+      };
+    });
+
+    const actions: vscode.QuickPickItem = { label: '$(sync) Refresh all', };
+    const picked = await vscode.window.showQuickPick(
+      [...items, { label: '', kind: vscode.QuickPickItemKind.Separator }, actions],
+      {
+        title: 'Codex Account Limits',
+        placeHolder: 'Select an account to set it active, or refresh all.'
+      }
+    );
+
+    if (!picked) {
+      return;
+    }
+
+    if (picked === actions) {
+      await this.refresh();
+      return;
+    }
+
+    const selected = (picked as UsagePick).accountKey;
+    if (selected && this.authManager) {
+      const entry = this.usageByAccount.get(selected);
+      if (entry && !entry.isActive) {
+        await this.authManager.switchAccount(selected);
+        vscode.window.showInformationMessage(`Active Codex account switched to ${entry.label}.`);
+        // Switching fires onDidChangeAuth which triggers a refresh; render immediately too.
+        this.renderActive();
+      }
+    }
   }
 
   dispose(): void {
@@ -91,48 +144,73 @@ export class CodexAccountUsageStatusBar implements vscode.Disposable {
   private async refreshNow(): Promise<void> {
     const logger = this.logger.operation('account-usage.refresh');
     const config = getProviderConfig();
-    const credentials = await getApiCredentials(this.context, this.authManager);
 
-    if (!credentials || credentials.kind !== 'codexAccessToken') {
-      this.lastSnapshot = undefined;
+    if (!this.authManager) {
+      this.usageByAccount.clear();
       this.statusBarItem.hide();
-      logger.debug('refresh.skipped', { reason: 'credentials-unavailable' });
+      logger.debug('refresh.skipped', { reason: 'no-auth-manager' });
       return;
     }
 
-    try {
-      const snapshot = await fetchCodexAccountUsage({
-        baseURL: config.baseURL,
-        credentials,
-        selectedModel: this.selectedModel
-      });
-      this.lastSnapshot = snapshot;
-      this.render(snapshot);
-      logger.debug('refresh.completed', {
-        selectedModel: this.selectedModel,
-        rateLimitCount: snapshot.limits.length,
-        creditBudgetCount: snapshot.creditBudgets.length
-      });
-    } catch (error) {
-      logger.warn('refresh.failed', { error });
-
-      if (this.lastSnapshot) {
-        this.render(this.lastSnapshot);
-      } else {
-        this.statusBarItem.hide();
-      }
+    const accounts = await this.authManager.listAccounts();
+    if (accounts.length === 0) {
+      this.usageByAccount.clear();
+      this.statusBarItem.hide();
+      logger.debug('refresh.skipped', { reason: 'no-accounts' });
+      return;
     }
+
+    // Fetch each account's usage in parallel; keep prior snapshots for accounts that fail.
+    const results = await Promise.all(accounts.map(async (account) => {
+      const label = account.email ?? account.accountId ?? account.accountKey;
+      const credentials = await getCodexCredentialsForAccount(this.authManager!, account.accountKey);
+      if (!credentials) {
+        return { accountKey: account.accountKey, label, isActive: account.isActive, error: true } as AccountUsageEntry;
+      }
+      try {
+        const snapshot = await fetchCodexAccountUsage({
+          baseURL: config.baseURL,
+          credentials,
+          selectedModel: this.selectedModel
+        });
+        return { accountKey: account.accountKey, label, isActive: account.isActive, snapshot } as AccountUsageEntry;
+      } catch (error) {
+        logger.warn('refresh.account-failed', { accountKey: account.accountKey, error });
+        const prior = this.usageByAccount.get(account.accountKey);
+        return { accountKey: account.accountKey, label, isActive: account.isActive, snapshot: prior?.snapshot, error: !prior?.snapshot } as AccountUsageEntry;
+      }
+    }));
+
+    this.usageByAccount.clear();
+    for (const entry of results) {
+      this.usageByAccount.set(entry.accountKey, entry);
+    }
+
+    this.renderActive();
+    logger.debug('refresh.completed', { accountCount: results.length, selectedModel: this.selectedModel });
   }
 
-  private render(snapshot: CodexAccountUsageSnapshot): void {
-    const display = buildCodexAccountUsageDisplay(snapshot, this.selectedModel);
+  private renderActive(): void {
+    const active = [...this.usageByAccount.values()].find((entry) => entry.isActive)
+      ?? this.usageByAccount.values().next().value;
+
+    if (!active || !active.snapshot) {
+      this.statusBarItem.hide();
+      return;
+    }
+
+    const display = buildCodexAccountUsageDisplay(active.snapshot, this.selectedModel);
     if (!display.compactText) {
       this.statusBarItem.hide();
       return;
     }
 
-    this.statusBarItem.text = display.compactText;
-    this.statusBarItem.tooltip = display.tooltip;
+    const accountCount = this.usageByAccount.size;
+    const prefix = accountCount > 1 ? `$(organization) ${active.label} ` : '';
+    this.statusBarItem.text = `${prefix}${display.compactText}`;
+    this.statusBarItem.tooltip = accountCount > 1
+      ? `${display.tooltip}\n\n${accountCount} accounts — click to view all.`
+      : display.tooltip;
     this.statusBarItem.show();
   }
 }

--- a/src/accountUsageStatusBar.ts
+++ b/src/accountUsageStatusBar.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { buildCodexAccountUsageDisplay, fetchCodexAccountUsage, type CodexAccountUsageSnapshot } from './accountUsage';
 import type { CodexAuthManager } from './auth/codexAuthManager';
 import { getProviderConfig } from './config';
-import { getCodexCredentialsForAccount } from './secrets';
+import { getApiCredentials, getCodexCredentialsForAccount, type ApiCredentials } from './secrets';
 import { type CodexLogSink, CodexLogger, createCodexLogger } from './codexLogger';
 
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
@@ -25,6 +25,7 @@ export class CodexAccountUsageStatusBar implements vscode.Disposable {
   private readonly logger: CodexLogger;
 
   constructor(
+    private readonly context: vscode.ExtensionContext,
     logger: CodexLogger | CodexLogSink,
     private readonly authManager?: CodexAuthManager
   ) {
@@ -144,26 +145,36 @@ export class CodexAccountUsageStatusBar implements vscode.Disposable {
   private async refreshNow(): Promise<void> {
     const logger = this.logger.operation('account-usage.refresh');
     const config = getProviderConfig();
+    const activeCredentials = await getApiCredentials(this.context, this.authManager);
 
-    if (!this.authManager) {
+    if (!activeCredentials || activeCredentials.kind !== 'codexAccessToken') {
       this.usageByAccount.clear();
       this.statusBarItem.hide();
-      logger.debug('refresh.skipped', { reason: 'no-auth-manager' });
+      logger.debug('refresh.skipped', { reason: 'credentials-unavailable' });
       return;
     }
 
-    const accounts = await this.authManager.listAccounts();
-    if (accounts.length === 0) {
-      this.usageByAccount.clear();
-      this.statusBarItem.hide();
-      logger.debug('refresh.skipped', { reason: 'no-accounts' });
-      return;
-    }
+    const storedAccounts = this.authManager && activeCredentials.accountKey
+      ? await this.authManager.listAccounts()
+      : [];
+    const accounts: Array<{ accountKey: string; label: string; isActive: boolean; credentials?: ApiCredentials }> = storedAccounts.length > 0
+      ? storedAccounts.map((account) => ({
+          accountKey: account.accountKey,
+          label: account.email ?? account.accountId ?? account.accountKey,
+          isActive: account.accountKey === activeCredentials.accountKey
+        }))
+      : [{
+          accountKey: activeCredentials.accountKey ?? 'configured-codex-credentials',
+          label: activeCredentials.headers['ChatGPT-Account-ID'] ?? 'Active Codex account',
+          isActive: true,
+          credentials: activeCredentials
+        }];
 
     // Fetch each account's usage in parallel; keep prior snapshots for accounts that fail.
     const results = await Promise.all(accounts.map(async (account) => {
-      const label = account.email ?? account.accountId ?? account.accountKey;
-      const credentials = await getCodexCredentialsForAccount(this.authManager!, account.accountKey);
+      const label = account.label;
+      const credentials = account.credentials
+        ?? (this.authManager ? await getCodexCredentialsForAccount(this.authManager, account.accountKey) : undefined);
       if (!credentials) {
         return { accountKey: account.accountKey, label, isActive: account.isActive, error: true } as AccountUsageEntry;
       }

--- a/src/auth/codexAuthManager.ts
+++ b/src/auth/codexAuthManager.ts
@@ -7,62 +7,161 @@ import { ACCESS_TOKEN_REFRESH_WINDOW_MS, PERIODIC_REFRESH_INTERVAL_MS } from './
 import { CodexOAuthClient, type OAuthTokens } from './codexOAuthClient';
 import { signInWithLoopback } from './codexLoopbackLogin';
 import { signInWithDeviceCode } from './codexDeviceCodeLogin';
-import { AuthRequiredError, type CodexAuthChangeEvent, type CodexAuthStatus, type CodexCredentialRecord, type CodexCredentialSnapshot, type ExtensionOAuthCredentialRecord, type RefreshableCodexCredentialRecord, ReauthRequiredError, TokenRefreshError } from './codexAuthTypes';
+import { AuthRequiredError, type CodexAuthChangeEvent, type CodexAuthStatus, type CodexCredentialRecord, type CodexCredentialSnapshot, type CodexCredentialSource, type ExtensionOAuthCredentialRecord, type RefreshableCodexCredentialRecord, ReauthRequiredError, TokenRefreshError } from './codexAuthTypes';
 import type { CodexLogger } from '../codexLogger';
 
+export interface CodexAccountSummary {
+  accountKey: string;
+  source: CodexCredentialSource;
+  email?: string;
+  accountId?: string;
+  isActive: boolean;
+  accessTokenExpiresAt?: number;
+  reauthRequired: boolean;
+}
+
 export class CodexAuthManager implements vscode.Disposable {
-  private refreshPromise: Promise<CodexCredentialSnapshot> | undefined;
-  private permanentFailureRevision: string | undefined;
+  private readonly refreshPromises = new Map<string, Promise<CodexCredentialSnapshot>>();
+  private readonly permanentFailureRevisions = new Map<string, string>();
   private readonly changes = new vscode.EventEmitter<CodexAuthChangeEvent>();
   readonly onDidChangeAuth = this.changes.event;
   constructor(
     private readonly store: CodexSecretStore,
-    private readonly lock: CodexAuthLock,
+    private readonly lockFor: (accountKey: string) => CodexAuthLock,
     private readonly oauth = new CodexOAuthClient(),
     private readonly logger?: CodexLogger
   ) {}
   dispose(): void { this.changes.dispose(); }
-  async getStatus(): Promise<CodexAuthStatus> { const record = await this.store.getCredential(); if (!record) return { authenticated: false }; const snapshot = snapshotFor(record); return { authenticated: true, source: record.source, email: record.email, accountId: snapshot.accountId, accessTokenExpiresAt: snapshot.expiresAt, lastRefresh: isRefreshableCredential(record) ? record.lastRefreshAt : record.loadedAt, reauthRequired: this.permanentFailureRevision === snapshot.revision }; }
-  async getCredentialSnapshot(): Promise<CodexCredentialSnapshot> { const record = await this.store.getCredential(); if (!record) throw new AuthRequiredError(); if (isRefreshableCredential(record)) await this.refreshIfNeeded(); const latest = await this.store.getCredential(); if (!latest) throw new AuthRequiredError(); return snapshotFor(latest); }
-  async getAccessToken(): Promise<string> { return (await this.getCredentialSnapshot()).accessToken; }
-  async importAuthJson(rawJson: string): Promise<void> { const bundle = parseCodexAuthJson(rawJson); const payload = safeDecode(bundle.tokens.id_token); const previous = await this.store.getCredential(); const record: RefreshableCodexCredentialRecord = { schemaVersion: 2, source: 'importedAuthJson', revision: randomRevision(), tokens: bundle.tokens, email: stringValue(payload.email), accessTokenExpiresAt: getJwtExpiration(bundle.tokens.access_token), lastRefreshAt: bundle.last_refresh ?? new Date().toISOString() }; await this.store.setCredential(record); this.permanentFailureRevision = undefined; this.fire(previous ? 'accountChanged' : 'signedIn', record.revision); }
-  async signInWithBrowser(): Promise<void> {
+
+  async getActiveAccountKey(): Promise<string | undefined> { return this.store.getActiveAccountKey(); }
+
+  async listAccounts(): Promise<CodexAccountSummary[]> {
+    const keys = await this.store.listAccountKeys();
+    const active = await this.store.getActiveAccountKey();
+    const accounts: CodexAccountSummary[] = [];
+    for (const accountKey of keys) {
+      const record = await this.store.getCredential(accountKey);
+      if (!record) continue;
+      const snapshot = snapshotFor(record);
+      accounts.push({
+        accountKey,
+        source: record.source,
+        email: record.email,
+        accountId: snapshot.accountId,
+        isActive: accountKey === active,
+        accessTokenExpiresAt: snapshot.expiresAt,
+        reauthRequired: this.permanentFailureRevisions.get(accountKey) === snapshot.revision
+      });
+    }
+    return accounts;
+  }
+
+  async getStatus(accountKey?: string): Promise<CodexAuthStatus> {
+    const key = accountKey ?? await this.store.getActiveAccountKey();
+    if (!key) return { authenticated: false };
+    const record = await this.store.getCredential(key);
+    if (!record) return { authenticated: false };
+    const snapshot = snapshotFor(record);
+    return { authenticated: true, accountKey: key, source: record.source, email: record.email, accountId: snapshot.accountId, accessTokenExpiresAt: snapshot.expiresAt, lastRefresh: isRefreshableCredential(record) ? record.lastRefreshAt : record.loadedAt, reauthRequired: this.permanentFailureRevisions.get(key) === snapshot.revision };
+  }
+
+  async getCredentialSnapshot(accountKey?: string): Promise<CodexCredentialSnapshot> {
+    const key = accountKey ?? await this.store.getActiveAccountKey();
+    if (!key) throw new AuthRequiredError();
+    const record = await this.store.getCredential(key);
+    if (!record) throw new AuthRequiredError();
+    if (isRefreshableCredential(record)) await this.refreshIfNeeded('proactive', key);
+    const latest = await this.store.getCredential(key);
+    if (!latest) throw new AuthRequiredError();
+    return snapshotFor(latest, key);
+  }
+
+  async getAccessToken(accountKey?: string): Promise<string> { return (await this.getCredentialSnapshot(accountKey)).accessToken; }
+
+  async switchAccount(accountKey: string): Promise<void> {
+    const previous = await this.store.getActiveAccountKey();
+    await this.store.setActiveAccountKey(accountKey);
+    if (previous !== accountKey) this.changes.fire({ reason: 'activeAccountChanged', accountKey });
+  }
+
+  async importAuthJson(rawJson: string): Promise<string> {
+    const bundle = parseCodexAuthJson(rawJson);
+    const payload = safeDecode(bundle.tokens.id_token);
+    const record: RefreshableCodexCredentialRecord = { schemaVersion: 2, source: 'importedAuthJson', revision: randomRevision(), tokens: bundle.tokens, email: stringValue(payload.email), accessTokenExpiresAt: getJwtExpiration(bundle.tokens.access_token), lastRefreshAt: bundle.last_refresh ?? new Date().toISOString() };
+    const accountKey = await this.store.setCredential(record);
+    this.permanentFailureRevisions.delete(accountKey);
+    this.fire('signedIn', accountKey, record.revision);
+    return accountKey;
+  }
+
+  async signInWithBrowser(): Promise<string> {
     const logger = this.logger?.operation('auth.browser-sign-in');
     logger?.info('sign-in.started');
+    let accountKey: string | undefined;
     await signInWithLoopback(
       this.oauth,
       (uri) => vscode.env.openExternal(vscode.Uri.parse(uri)),
       undefined,
       (stage, port) => logger?.debug('sign-in.stage', { stage, port }),
       async (tokens) => {
-        await this.completeSignIn(tokens);
+        accountKey = await this.completeSignIn(tokens);
         logger?.info('sign-in.completed');
       }
     );
+    return accountKey!;
   }
-  async signInWithDeviceCode(): Promise<void> { const logger = this.logger?.operation('auth.device-code-sign-in'); try { await this.completeSignIn(await signInWithDeviceCode(this.oauth)); logger?.info('sign-in.completed'); } catch (error) { logger?.error('sign-in.failed', error); throw error; } }
-  async refreshIfNeeded(reason: 'proactive' | 'unauthorized' = 'proactive'): Promise<CodexCredentialSnapshot> {
-    if (!this.refreshPromise) this.refreshPromise = this.doRefresh(reason).finally(() => { this.refreshPromise = undefined; });
-    return this.refreshPromise;
+  async signInWithDeviceCode(): Promise<string> { const logger = this.logger?.operation('auth.device-code-sign-in'); try { const accountKey = await this.completeSignIn(await signInWithDeviceCode(this.oauth)); logger?.info('sign-in.completed'); return accountKey; } catch (error) { logger?.error('sign-in.failed', error); throw error; } }
+
+  async refreshIfNeeded(reason: 'proactive' | 'unauthorized' = 'proactive', accountKey?: string): Promise<CodexCredentialSnapshot> {
+    const key = accountKey ?? await this.store.getActiveAccountKey();
+    if (!key) throw new AuthRequiredError();
+    const existing = this.refreshPromises.get(key);
+    if (existing) return existing;
+    const promise = this.doRefresh(reason, key).finally(() => { if (this.refreshPromises.get(key) === promise) this.refreshPromises.delete(key); });
+    this.refreshPromises.set(key, promise);
+    return promise;
   }
-  async refreshAfter401(): Promise<void> { await this.recoverFromUnauthorized({ snapshotRevision: (await this.getCredentialSnapshot()).revision, visibleActivity: false, reason: 'http401' }); }
-  async recoverFromUnauthorized(context: { snapshotRevision: string; visibleActivity: boolean; reason: 'http401' | 'websocketUnauthorized' }): Promise<CodexCredentialSnapshot> {
+
+  async refreshAfter401(accountKey?: string): Promise<void> { const key = accountKey ?? await this.store.getActiveAccountKey(); await this.recoverFromUnauthorized({ accountKey: key!, snapshotRevision: (await this.getCredentialSnapshot(key)).revision, visibleActivity: false, reason: 'http401' }); }
+
+  async recoverFromUnauthorized(context: { accountKey: string; snapshotRevision: string; visibleActivity: boolean; reason: 'http401' | 'websocketUnauthorized' }): Promise<CodexCredentialSnapshot> {
     if (context.visibleActivity) throw new ReauthRequiredError('Authentication failed after response activity started.');
-    try { return await this.refreshIfNeeded('unauthorized'); } catch (error) { if (error instanceof TokenRefreshError && error.permanent) { this.permanentFailureRevision = context.snapshotRevision; this.fire('reauthRequired'); throw new ReauthRequiredError(); } throw error; }
+    try { return await this.refreshIfNeeded('unauthorized', context.accountKey); } catch (error) { if (error instanceof TokenRefreshError && error.permanent) { this.permanentFailureRevisions.set(context.accountKey, context.snapshotRevision); this.fire('reauthRequired', context.accountKey); throw new ReauthRequiredError(); } throw error; }
   }
-  async signOut(): Promise<void> { const record = await this.store.getCredential(); if (record?.source === 'extensionOAuth') await this.oauth.revoke(record.tokens.refresh_token).catch(() => undefined); await this.store.deleteCredential(); this.permanentFailureRevision = undefined; this.fire('signedOut'); }
-  private async doRefresh(reason: 'proactive' | 'unauthorized'): Promise<CodexCredentialSnapshot> {
-    const existing = await this.store.getCredential(); if (!existing) throw new AuthRequiredError(); if (!isRefreshableCredential(existing)) return snapshotFor(existing); if (reason === 'proactive' && !needsRefresh(existing)) return snapshotFor(existing); if (this.permanentFailureRevision === existing.revision) throw new ReauthRequiredError();
+
+  /** Sign out / remove an account. Defaults to the active account. */
+  async signOut(accountKey?: string): Promise<void> {
+    const key = accountKey ?? await this.store.getActiveAccountKey();
+    if (!key) return;
+    const record = await this.store.getCredential(key);
+    if (record?.source === 'extensionOAuth') await this.oauth.revoke(record.tokens.refresh_token).catch(() => undefined);
+    await this.store.deleteCredential(key);
+    this.permanentFailureRevisions.delete(key);
+    this.refreshPromises.delete(key);
+    this.fire('signedOut', key);
+  }
+
+  /** Sign out of every stored account. */
+  async signOutAll(): Promise<void> {
+    for (const account of await this.listAccounts()) {
+      await this.signOut(account.accountKey);
+    }
+  }
+
+  private async doRefresh(reason: 'proactive' | 'unauthorized', accountKey: string): Promise<CodexCredentialSnapshot> {
+    const existing = await this.store.getCredential(accountKey); if (!existing) throw new AuthRequiredError(); if (!isRefreshableCredential(existing)) return snapshotFor(existing, accountKey); if (reason === 'proactive' && !needsRefresh(existing)) return snapshotFor(existing, accountKey); if (this.permanentFailureRevisions.get(accountKey) === existing.revision) throw new ReauthRequiredError();
     const logger = this.logger?.operation('auth.refresh', { reason });
     try {
-      return await this.lock.withLock(async () => { const latest = await this.store.getCredential(); if (!latest) throw new AuthRequiredError(); if (!isRefreshableCredential(latest)) return snapshotFor(latest); if (reason === 'proactive' && !needsRefresh(latest)) return snapshotFor(latest); const tokens = await this.oauth.refresh(latest.tokens.refresh_token); const replacement: RefreshableCodexCredentialRecord = { ...latest, revision: randomRevision(), tokens: { ...latest.tokens, ...tokens }, accessTokenExpiresAt: getJwtExpiration(tokens.access_token ?? latest.tokens.access_token), lastRefreshAt: new Date().toISOString() }; await this.store.setCredential(replacement); this.permanentFailureRevision = undefined; this.fire('tokensRefreshed', replacement.revision); logger?.info('refresh.completed'); return snapshotFor(replacement); });
+      return await this.lockFor(accountKey).withLock(async () => { const latest = await this.store.getCredential(accountKey); if (!latest) throw new AuthRequiredError(); if (!isRefreshableCredential(latest)) return snapshotFor(latest, accountKey); if (reason === 'proactive' && !needsRefresh(latest)) return snapshotFor(latest, accountKey); const tokens = await this.oauth.refresh(latest.tokens.refresh_token); const replacement: RefreshableCodexCredentialRecord = { ...latest, revision: randomRevision(), tokens: { ...latest.tokens, ...tokens }, accessTokenExpiresAt: getJwtExpiration(tokens.access_token ?? latest.tokens.access_token), lastRefreshAt: new Date().toISOString() }; await this.store.setCredential(replacement, accountKey); this.permanentFailureRevisions.delete(accountKey); this.fire('tokensRefreshed', accountKey, replacement.revision); logger?.info('refresh.completed'); return snapshotFor(replacement, accountKey); });
     } catch (error) { logger?.warn('refresh.failed', { error }); throw error; }
   }
-  private async completeSignIn(tokens: OAuthTokens): Promise<void> { const payload = safeDecode(tokens.id_token); const previous = await this.store.getCredential(); const record: ExtensionOAuthCredentialRecord = { schemaVersion: 2, source: 'extensionOAuth', revision: randomRevision(), tokens, email: stringValue(payload.email), accessTokenExpiresAt: getJwtExpiration(tokens.access_token), lastRefreshAt: new Date().toISOString() }; await this.store.setCredential(record); this.permanentFailureRevision = undefined; this.fire(previous ? 'accountChanged' : 'signedIn', record.revision); }
-  private fire(reason: CodexAuthChangeEvent['reason'], revision?: string): void { this.changes.fire({ reason, revision }); }
+
+  private async completeSignIn(tokens: OAuthTokens): Promise<string> { const payload = safeDecode(tokens.id_token); const record: ExtensionOAuthCredentialRecord = { schemaVersion: 2, source: 'extensionOAuth', revision: randomRevision(), tokens, email: stringValue(payload.email), accessTokenExpiresAt: getJwtExpiration(tokens.access_token), lastRefreshAt: new Date().toISOString() }; const accountKey = await this.store.setCredential(record); this.permanentFailureRevisions.delete(accountKey); this.fire('signedIn', accountKey, record.revision); return accountKey; }
+
+  private fire(reason: CodexAuthChangeEvent['reason'], accountKey: string, revision?: string): void { this.changes.fire({ reason, accountKey, revision }); }
 }
 export function needsRefresh(record: CodexCredentialRecord | { tokens: { access_token: string }; last_refresh?: string; lastRefreshAt?: string }): boolean { const access = 'tokens' in record ? record.tokens.access_token : record.accessToken; const last = 'lastRefreshAt' in record ? record.lastRefreshAt : ('last_refresh' in record ? record.last_refresh : undefined); return isJwtExpiringSoon(access, ACCESS_TOKEN_REFRESH_WINDOW_MS) || !last || !Number.isFinite(Date.parse(last)) || Date.now() - Date.parse(last) >= PERIODIC_REFRESH_INTERVAL_MS; }
-function snapshotFor(record: CodexCredentialRecord): CodexCredentialSnapshot { return isRefreshableCredential(record) ? { source: record.source, accessToken: record.tokens.access_token, accountId: record.tokens.account_id, expiresAt: record.accessTokenExpiresAt ?? getJwtExpiration(record.tokens.access_token), revision: record.revision, refreshable: true } : { source: record.source, accessToken: record.accessToken, accountId: record.accountId, expiresAt: record.accessTokenExpiresAt, revision: record.revision, refreshable: false }; }
+function snapshotFor(record: CodexCredentialRecord, accountKey?: string): CodexCredentialSnapshot { return isRefreshableCredential(record) ? { source: record.source, accessToken: record.tokens.access_token, accountId: record.tokens.account_id, accountKey, expiresAt: record.accessTokenExpiresAt ?? getJwtExpiration(record.tokens.access_token), revision: record.revision, refreshable: true } : { source: record.source, accessToken: record.accessToken, accountId: record.accountId, accountKey, expiresAt: record.accessTokenExpiresAt, revision: record.revision, refreshable: false }; }
 function isRefreshableCredential(record: CodexCredentialRecord | undefined): record is RefreshableCodexCredentialRecord { return record?.source === 'extensionOAuth' || record?.source === 'importedAuthJson'; }
 function safeDecode(token: string): Record<string, unknown> { try { const value = decodeJwtPayload(token); return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}; } catch { return {}; } }
 function stringValue(value: unknown): string | undefined { return typeof value === 'string' && value.trim() ? value.trim() : undefined; }

--- a/src/auth/codexAuthRequest.ts
+++ b/src/auth/codexAuthRequest.ts
@@ -5,12 +5,13 @@ export async function codexFetch(
   authManager: CodexAuthManager,
   input: Parameters<typeof fetch>[0],
   init: RequestInit = {},
-  performFetch: typeof fetch = fetch
+  performFetch: typeof fetch = fetch,
+  accountKey?: string
 ): Promise<Response> {
   const compatibleManager = authManager as CodexAuthManager & { getAccessToken?: () => Promise<string>; refreshAfter401?: () => Promise<void> };
   const snapshot = typeof compatibleManager.getCredentialSnapshot === 'function'
-    ? await compatibleManager.getCredentialSnapshot()
-    : { accessToken: await compatibleManager.getAccessToken!(), revision: 'legacy' };
+    ? await compatibleManager.getCredentialSnapshot(accountKey)
+    : { accessToken: await compatibleManager.getAccessToken!(), revision: 'legacy', accountKey };
   const first = await performFetch(input, withAuthorization(init, snapshot));
   if (first.status !== 401) {
     return first;
@@ -18,7 +19,7 @@ export async function codexFetch(
 
   await first.body?.cancel().catch(() => undefined);
   const retrySnapshot = typeof compatibleManager.recoverFromUnauthorized === 'function'
-    ? await compatibleManager.recoverFromUnauthorized({ snapshotRevision: snapshot.revision, visibleActivity: false, reason: 'http401' })
+    ? await compatibleManager.recoverFromUnauthorized({ accountKey: accountKey ?? snapshot.accountKey ?? '', snapshotRevision: snapshot.revision, visibleActivity: false, reason: 'http401' })
     : (await compatibleManager.refreshAfter401!(), { accessToken: await compatibleManager.getAccessToken!() });
   const retry = await performFetch(input, withAuthorization(init, retrySnapshot));
   if (retry.status === 401) {

--- a/src/auth/codexAuthTypes.ts
+++ b/src/auth/codexAuthTypes.ts
@@ -53,6 +53,7 @@ export interface CodexCredentialSnapshot {
   source: CodexCredentialSource | 'openaiApiKey';
   accessToken: string;
   accountId?: string;
+  accountKey?: string;
   expiresAt?: number;
   revision: string;
   refreshable: boolean;
@@ -60,6 +61,7 @@ export interface CodexCredentialSnapshot {
 
 export interface CodexAuthStatus {
   authenticated: boolean;
+  accountKey?: string;
   source?: CodexCredentialSource;
   email?: string;
   accountId?: string;
@@ -68,8 +70,9 @@ export interface CodexAuthStatus {
   reauthRequired?: boolean;
 }
 
-export type CodexAuthChangeReason = 'signedIn' | 'tokensRefreshed' | 'reauthRequired' | 'signedOut' | 'accountChanged';
-export interface CodexAuthChangeEvent { reason: CodexAuthChangeReason; revision?: string; }
+/** Fine-grained auth change reasons, carrying the account and credential revision affected. */
+export type CodexAuthChangeReason = 'signedIn' | 'tokensRefreshed' | 'reauthRequired' | 'signedOut' | 'activeAccountChanged';
+export interface CodexAuthChangeEvent { reason: CodexAuthChangeReason; accountKey?: string; revision?: string; }
 
 export class AuthRequiredError extends Error {
   constructor(message = 'Sign in with ChatGPT or configure an API key.') { super(message); this.name = 'AuthRequiredError'; }

--- a/src/auth/codexAuthenticationProvider.ts
+++ b/src/auth/codexAuthenticationProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { CODEX_OAUTH } from './codexOAuthCompatibility';
 import { CodexAuthManager } from './codexAuthManager';
-import type { CodexAuthChangeEvent, CodexAuthStatus, CodexCredentialSnapshot } from './codexAuthTypes';
+import type { CodexAuthChangeEvent, CodexCredentialSnapshot } from './codexAuthTypes';
 
 export const CODEX_AUTHENTICATION_PROVIDER_ID = 'codex-for-copilot';
 
@@ -10,7 +10,8 @@ const supportedScopes = CODEX_OAUTH.scopes.split(' ');
 export class CodexAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
   private readonly sessionChanges = new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
   private readonly authChangeSubscription: vscode.Disposable;
-  private currentSession: vscode.AuthenticationSession | undefined;
+  /** Sessions as last reported to VS Code, keyed by session id. */
+  private knownSessions = new Map<string, vscode.AuthenticationSession>();
 
   readonly onDidChangeSessions = this.sessionChanges.event;
 
@@ -24,9 +25,9 @@ export class CodexAuthenticationProvider implements vscode.AuthenticationProvide
     if (scopes && !supportsRequestedScopes(scopes)) {
       return [];
     }
-    const session = await this.getCurrentSession();
-    this.currentSession = session;
-    return session ? [session] : [];
+    const sessions = await this.getAllSessions();
+    this.knownSessions = new Map(sessions.map((session) => [session.id, session]));
+    return sessions;
   }
 
   async createSession(scopes: readonly string[], _options: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession> {
@@ -34,20 +35,20 @@ export class CodexAuthenticationProvider implements vscode.AuthenticationProvide
       throw new Error('Codex for Copilot does not support the requested authentication scopes.');
     }
     await this.authManager.signInWithBrowser();
-    const session = await this.getCurrentSession();
+    const sessions = await this.getAllSessions();
+    const session = sessions.find((candidate) => !this.knownSessions.has(candidate.id)) ?? sessions.at(-1);
     if (!session) {
       throw new Error('ChatGPT sign-in completed without creating a credential session.');
     }
-    this.currentSession = session;
     return session;
   }
 
   async removeSession(sessionId: string): Promise<void> {
-    const session = await this.getCurrentSession();
-    if (!session || session.id !== sessionId) {
+    const session = this.knownSessions.get(sessionId) ?? await this.findSessionById(sessionId);
+    if (!session) {
       throw new Error('The requested Codex for Copilot authentication session does not exist.');
     }
-    await this.authManager.signOut();
+    await this.authManager.signOut(session.account.id);
   }
 
   dispose(): void {
@@ -55,37 +56,42 @@ export class CodexAuthenticationProvider implements vscode.AuthenticationProvide
     this.sessionChanges.dispose();
   }
 
-  private async handleAuthenticationChange(event: CodexAuthChangeEvent): Promise<void> {
-    const previousSession = this.currentSession;
-    const nextSession = event.reason === 'signedOut' || event.reason === 'reauthRequired'
-      ? undefined
-      : await this.getCurrentSession();
-    this.currentSession = nextSession;
+  private async handleAuthenticationChange(_event: CodexAuthChangeEvent): Promise<void> {
+    // Recompute the full session set and diff against what VS Code last saw.
+    const previous = this.knownSessions;
+    const nextSessions = await this.getAllSessions();
+    const next = new Map(nextSessions.map((session) => [session.id, session]));
+    this.knownSessions = next;
 
-    if (!previousSession && nextSession) {
-      this.sessionChanges.fire({ added: [nextSession], removed: [], changed: [] });
-    } else if (previousSession && !nextSession) {
-      this.sessionChanges.fire({ added: [], removed: [previousSession], changed: [] });
-    } else if (previousSession && nextSession) {
-      if (previousSession.id === nextSession.id) {
-        this.sessionChanges.fire({ added: [], removed: [], changed: [nextSession] });
-      } else {
-        this.sessionChanges.fire({ added: [nextSession], removed: [previousSession], changed: [] });
-      }
+    const added = nextSessions.filter((session) => !previous.has(session.id));
+    const removed = [...previous.values()].filter((session) => !next.has(session.id));
+    const changed = nextSessions.filter((session) => {
+      const prior = previous.get(session.id);
+      return prior !== undefined && prior.accessToken !== session.accessToken;
+    });
+
+    if (added.length || removed.length || changed.length) {
+      this.sessionChanges.fire({ added, removed, changed });
     }
   }
 
-  private async getCurrentSession(): Promise<vscode.AuthenticationSession | undefined> {
-    const status = await this.authManager.getStatus();
-    if (!status.authenticated) {
-      return undefined;
+  private async findSessionById(sessionId: string): Promise<vscode.AuthenticationSession | undefined> {
+    const sessions = await this.getAllSessions();
+    return sessions.find((session) => session.id === sessionId);
+  }
+
+  private async getAllSessions(): Promise<vscode.AuthenticationSession[]> {
+    const accounts = await this.authManager.listAccounts();
+    const sessions: vscode.AuthenticationSession[] = [];
+    for (const account of accounts) {
+      try {
+        const snapshot = await this.authManager.getCredentialSnapshot(account.accountKey);
+        sessions.push(toAuthenticationSession(account, snapshot));
+      } catch {
+        // Skip accounts whose credentials can no longer be read.
+      }
     }
-    try {
-      const snapshot = await this.authManager.getCredentialSnapshot();
-      return toAuthenticationSession(status, snapshot);
-    } catch {
-      return undefined;
-    }
+    return sessions;
   }
 }
 
@@ -93,14 +99,14 @@ function supportsRequestedScopes(scopes: readonly string[]): boolean {
   return scopes.every((scope) => supportedScopes.includes(scope));
 }
 
-function toAuthenticationSession(status: CodexAuthStatus, snapshot: CodexCredentialSnapshot): vscode.AuthenticationSession {
-  const accountId = snapshot.accountId ?? status.email ?? snapshot.source;
+function toAuthenticationSession(account: { accountKey: string; source: string; email?: string; accountId?: string }, snapshot: CodexCredentialSnapshot): vscode.AuthenticationSession {
+  const label = account.email ?? account.accountId ?? 'ChatGPT';
   return {
-    id: `${snapshot.source}:${accountId}`,
+    id: `${account.source}:${account.accountKey}`,
     accessToken: snapshot.accessToken,
     account: {
-      id: accountId,
-      label: status.email ?? 'ChatGPT'
+      id: account.accountKey,
+      label
     },
     scopes: supportedScopes
   };

--- a/src/auth/codexSecretStore.ts
+++ b/src/auth/codexSecretStore.ts
@@ -134,15 +134,15 @@ export class CodexSecretStore {
   private async migrateLegacyIfNeeded(): Promise<void> {
     const legacyRaw = await this.secrets.get(CODEX_AUTH_SECRET_KEY);
     if (!legacyRaw) return;
+    const record = parseCredential(legacyRaw);
+    if (!record) return;
+
+    const key = deriveAccountKey(record);
     try {
-      const record = parseCredential(legacyRaw);
-      if (record) {
-        const key = deriveAccountKey(record);
-        await this.secrets.store(this.accountKeyFor(key), JSON.stringify(record));
-        await this.addToIndex(key);
-      }
-    } catch { /* ignore unparsable legacy secret */ }
-    await this.secrets.delete(CODEX_AUTH_SECRET_KEY);
+      await this.secrets.store(this.accountKeyFor(key), JSON.stringify(record));
+      await this.addToIndex(key);
+      await this.secrets.delete(CODEX_AUTH_SECRET_KEY);
+    } catch { /* retain the legacy secret so a later access can retry migration */ }
   }
 }
 

--- a/src/auth/codexSecretStore.ts
+++ b/src/auth/codexSecretStore.ts
@@ -1,36 +1,186 @@
 import * as vscode from 'vscode';
+import { decodeJwtPayload } from './codexJwt';
 import type { CodexAuthBundle, CodexCredentialRecord, LegacyCodexCredentialRecord, RefreshableCodexCredentialRecord } from './codexAuthTypes';
 
+/** Legacy single-account secret key retained purely for first-run migration. */
 export const CODEX_AUTH_SECRET_KEY = 'codexForCopilot.codexAuthBundle';
+const ACCOUNTS_INDEX_SECRET_KEY = 'codexForCopilot.codexAuthAccounts';
+const ACTIVE_ACCOUNT_SECRET_KEY = 'codexForCopilot.codexActiveAccount';
+const ACCOUNT_SECRET_PREFIX = 'codexForCopilot.codexAuthAccount.';
 
+/** Value persisted in the accounts index secret. */
+interface AccountsIndex {
+  accountKeys: string[];
+  activeAccountKey?: string;
+}
+
+/** Stores Codex credentials across multiple accounts plus a pointer to the active one. */
 export class CodexSecretStore {
   constructor(private readonly secrets: vscode.SecretStorage) {}
-  async getCredential(): Promise<CodexCredentialRecord | undefined> {
-    const raw = await this.secrets.get(CODEX_AUTH_SECRET_KEY);
-    if (!raw) return undefined;
-    try {
-      const value = JSON.parse(raw) as unknown;
-      if (isCredential(value)) return value;
-      const legacy = value as CodexAuthBundle;
-      if (legacy?.auth_mode === 'chatgpt' && legacy.tokens?.access_token && legacy.tokens?.id_token && legacy.tokens?.refresh_token) {
-        // Migrate pre-schema imports into the same refreshable record used by new
-        // auth.json imports, preserving a stable record identity for VS Code sessions.
-        const migrated: RefreshableCodexCredentialRecord = { schemaVersion: 2, source: 'importedAuthJson', revision: randomRevision(), tokens: legacy.tokens, lastRefreshAt: legacy.last_refresh ?? new Date().toISOString() };
-        try { await this.setCredential(migrated); } catch { /* preserve usable credentials if migration persistence fails */ }
-        return migrated;
-      }
-    } catch { /* invalid stored secret is treated as absent */ }
-    return undefined;
+
+  /** List every stored account key. Migration from the legacy single record is performed on first access. */
+  async listAccountKeys(): Promise<string[]> {
+    await this.migrateLegacyIfNeeded();
+    return (await this.readIndex()).accountKeys;
   }
-  async setCredential(record: RefreshableCodexCredentialRecord): Promise<void> { await this.secrets.store(CODEX_AUTH_SECRET_KEY, JSON.stringify(record)); }
-  async setLegacyCredential(record: LegacyCodexCredentialRecord): Promise<void> { await this.secrets.store(CODEX_AUTH_SECRET_KEY, JSON.stringify(record)); }
-  async deleteCredential(): Promise<void> { await this.secrets.delete(CODEX_AUTH_SECRET_KEY); }
-  // Compatibility helpers retained for existing consumers during migration.
-  async getAuthBundle(): Promise<CodexAuthBundle | undefined> { const record = await this.getCredential(); return isRefreshableCredential(record) ? { auth_mode: 'chatgpt', tokens: record.tokens, last_refresh: record.lastRefreshAt } : undefined; }
-  async setAuthBundle(bundle: CodexAuthBundle): Promise<void> { await this.setCredential({ schemaVersion: 2, source: 'importedAuthJson', revision: randomRevision(), tokens: bundle.tokens, lastRefreshAt: bundle.last_refresh ?? new Date().toISOString() }); }
-  async deleteAuthBundle(): Promise<void> { await this.deleteCredential(); }
+
+  /** The active account key, defaulting to the first stored account when unset. */
+  async getActiveAccountKey(): Promise<string | undefined> {
+    await this.migrateLegacyIfNeeded();
+    const index = await this.readIndex();
+    const requested = index.activeAccountKey;
+    if (requested && await this.hasCredential(requested)) {
+      return requested;
+    }
+    const first = index.accountKeys[0];
+    if (first && first !== requested) {
+      await this.writeIndex({ accountKeys: index.accountKeys, activeAccountKey: first });
+    }
+    return first;
+  }
+
+  async setActiveAccountKey(accountKey: string): Promise<void> {
+    await this.migrateLegacyIfNeeded();
+    if (!await this.hasCredential(accountKey)) throw new Error(`Unknown Codex account: ${accountKey}`);
+    const index = await this.readIndex();
+    await this.writeIndex({ accountKeys: index.accountKeys, activeAccountKey: accountKey });
+  }
+
+  // ------------------------------------------------------------------
+  // Per-account credential access
+  // ------------------------------------------------------------------
+
+  async getCredential(accountKey?: string): Promise<CodexCredentialRecord | undefined> {
+    const key = accountKey ?? await this.getActiveAccountKey();
+    if (!key) return undefined;
+    const raw = await this.secrets.get(this.accountKeyFor(key));
+    return raw ? parseCredential(raw) : undefined;
+  }
+
+  /** Persist a record under a derived account key; returns the key used. */
+  async setCredential(record: RefreshableCodexCredentialRecord, accountKey?: string): Promise<string> {
+    await this.migrateLegacyIfNeeded();
+    const key = accountKey ?? deriveAccountKey(record);
+    await this.secrets.store(this.accountKeyFor(key), JSON.stringify(record));
+    await this.addToIndex(key);
+    return key;
+  }
+
+  async setLegacyCredential(record: LegacyCodexCredentialRecord, accountKey?: string): Promise<string> {
+    await this.migrateLegacyIfNeeded();
+    const key = accountKey ?? deriveAccountKey(record);
+    await this.secrets.store(this.accountKeyFor(key), JSON.stringify(record));
+    await this.addToIndex(key);
+    return key;
+  }
+
+  async deleteCredential(accountKey?: string): Promise<void> {
+    const key = accountKey ?? await this.getActiveAccountKey();
+    if (!key) return;
+    await this.secrets.delete(this.accountKeyFor(key));
+    const index = await this.readIndex();
+    const accountKeys = index.accountKeys.filter((k) => k !== key);
+    const activeAccountKey = index.activeAccountKey === key ? accountKeys[0] : index.activeAccountKey;
+    await this.writeIndex({ accountKeys, activeAccountKey });
+  }
+
+  async hasCredential(accountKey: string): Promise<boolean> {
+    return (await this.secrets.get(this.accountKeyFor(accountKey))) !== undefined;
+  }
+
+  // ------------------------------------------------------------------
+  // Internals
+  // ------------------------------------------------------------------
+
+  private accountKeyFor(accountKey: string): string {
+    return `${ACCOUNT_SECRET_PREFIX}${accountKey}`;
+  }
+
+  private async readIndex(): Promise<AccountsIndex> {
+    const raw = await this.secrets.get(ACCOUNTS_INDEX_SECRET_KEY);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as AccountsIndex;
+        if (Array.isArray(parsed?.accountKeys)) {
+          return { accountKeys: parsed.accountKeys.filter((k): k is string => typeof k === 'string'), activeAccountKey: typeof parsed.activeAccountKey === 'string' ? parsed.activeAccountKey : undefined };
+        }
+      } catch { /* fall through to reconstruct from active key */ }
+    }
+    const active = await this.secrets.get(ACTIVE_ACCOUNT_SECRET_KEY);
+    return { accountKeys: [], activeAccountKey: active ?? undefined };
+  }
+
+  private async writeIndex(index: AccountsIndex): Promise<void> {
+    await this.secrets.store(ACCOUNTS_INDEX_SECRET_KEY, JSON.stringify(index));
+    if (index.activeAccountKey) {
+      await this.secrets.store(ACTIVE_ACCOUNT_SECRET_KEY, index.activeAccountKey);
+    } else {
+      await this.secrets.delete(ACTIVE_ACCOUNT_SECRET_KEY);
+    }
+  }
+
+  private async addToIndex(accountKey: string): Promise<void> {
+    const index = await this.readIndex();
+    if (!index.accountKeys.includes(accountKey)) {
+      index.accountKeys.push(accountKey);
+    }
+    if (!index.activeAccountKey) {
+      index.activeAccountKey = accountKey;
+    }
+    await this.writeIndex(index);
+  }
+
+  /** Move the legacy single-key record into a derived account key. Runs once. */
+  private async migrateLegacyIfNeeded(): Promise<void> {
+    const legacyRaw = await this.secrets.get(CODEX_AUTH_SECRET_KEY);
+    if (!legacyRaw) return;
+    try {
+      const record = parseCredential(legacyRaw);
+      if (record) {
+        const key = deriveAccountKey(record);
+        await this.secrets.store(this.accountKeyFor(key), JSON.stringify(record));
+        await this.addToIndex(key);
+      }
+    } catch { /* ignore unparsable legacy secret */ }
+    await this.secrets.delete(CODEX_AUTH_SECRET_KEY);
+  }
 }
+
 export function randomRevision(): string { return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`; }
+
+function parseCredential(raw: string): CodexCredentialRecord | undefined {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (isCredential(value)) return value;
+    const legacy = value as CodexAuthBundle;
+    if (legacy?.auth_mode === 'chatgpt' && legacy.tokens?.access_token && legacy.tokens?.id_token && legacy.tokens?.refresh_token) {
+      return { schemaVersion: 2, source: 'importedAuthJson', revision: randomRevision(), tokens: legacy.tokens, lastRefreshAt: legacy.last_refresh ?? new Date().toISOString() };
+    }
+  } catch { /* invalid stored secret is treated as absent */ }
+  return undefined;
+}
+
+/** Stable per-account secret suffix derived from the credential's identity. */
+function deriveAccountKey(record: CodexCredentialRecord): string {
+  const accountId = isRefreshableCredential(record) ? record.tokens.account_id : record.accountId;
+  if (accountId?.trim()) return sanitize(accountId.trim());
+  if (record.email?.trim()) return sanitize(record.email.trim());
+  if (isRefreshableCredential(record)) {
+    try {
+      const payload = decodeJwtPayload(record.tokens.id_token);
+      if (payload && typeof payload === 'object') {
+        const email = (payload as Record<string, unknown>).email;
+        if (typeof email === 'string' && email.trim()) return sanitize(email.trim());
+      }
+    } catch { /* fall through */ }
+  }
+  return sanitize(`account-${record.revision}`);
+}
+
+function sanitize(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
 function isCredential(value: unknown): value is CodexCredentialRecord {
   if (!value || typeof value !== 'object') return false;
   const candidate = value as Partial<CodexCredentialRecord>;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     logger.child('auth')
   );
   const authenticationProvider = new CodexAuthenticationProvider(authManager);
-  const accountUsageStatusBar = new CodexAccountUsageStatusBar(logger.child('account-usage'), authManager);
+  const accountUsageStatusBar = new CodexAccountUsageStatusBar(context, logger.child('account-usage'), authManager);
   const provider = new CodexModelProvider(context, logger.child('provider'), undefined, accountUsageStatusBar, accountUsageStatusBar, authManager);
 
   context.subscriptions.push(authManager, authManager.onDidChangeAuth((event) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,12 +52,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   void vscode.workspace.fs.createDirectory(context.globalStorageUri);
   const authManager = new CodexAuthManager(
     new CodexSecretStore(context.secrets),
-    new CodexAuthLock(vscode.Uri.joinPath(context.globalStorageUri, 'codex-auth-refresh.lock')),
+    (accountKey) => new CodexAuthLock(vscode.Uri.joinPath(context.globalStorageUri, `codex-auth-refresh.${sanitizeLockKey(accountKey)}.lock`)),
     undefined,
     logger.child('auth')
   );
   const authenticationProvider = new CodexAuthenticationProvider(authManager);
-  const accountUsageStatusBar = new CodexAccountUsageStatusBar(context, logger.child('account-usage'), authManager);
+  const accountUsageStatusBar = new CodexAccountUsageStatusBar(logger.child('account-usage'), authManager);
   const provider = new CodexModelProvider(context, logger.child('provider'), undefined, accountUsageStatusBar, accountUsageStatusBar, authManager);
 
   context.subscriptions.push(authManager, authManager.onDidChangeAuth((event) => {
@@ -74,7 +74,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       CODEX_AUTHENTICATION_PROVIDER_ID,
       'Codex for Copilot',
       authenticationProvider,
-      { supportsMultipleAccounts: false }
+      { supportsMultipleAccounts: true }
     ),
     vscode.lm.registerLanguageModelChatProvider('codex-for-copilot', provider),
     vscode.commands.registerCommand('codexModelProvider.openDebugLogs', () => {
@@ -104,21 +104,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       vscode.window.showInformationMessage('Responses API key cleared.');
     }),
     vscode.commands.registerCommand('codexForCopilot.auth.importAuthJson', async () => {
-      const selected = await vscode.window.showOpenDialog({
-        title: 'Import Codex auth.json',
-        canSelectFiles: true,
-        canSelectFolders: false,
-        canSelectMany: false,
-        filters: { JSON: ['json'] }
-      });
-      const uri = selected?.[0];
-      if (!uri) {
-        return;
-      }
       try {
-        const raw = Buffer.from(await vscode.workspace.fs.readFile(uri)).toString('utf8');
-        await authManager.importAuthJson(raw);
-        const status = await authManager.getStatus();
+        const accountKey = await importCodexAuthJsonInteractive(authManager);
+        if (!accountKey) {
+          return;
+        }
+        const status = await authManager.getStatus(accountKey);
         const suffix = status.email ? ` for ${status.email}` : '';
         vscode.window.showInformationMessage(`Codex credentials imported${suffix}.`);
       } catch (error) {
@@ -128,9 +119,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
     }),
     vscode.commands.registerCommand('codexForCopilot.auth.signOut', async () => {
-      await authManager.signOut();
-      logger.child('command').info('auth.sign-out.completed');
-      vscode.window.showInformationMessage('Codex credentials removed.');
+      const accounts = await authManager.listAccounts();
+      if (accounts.length === 0) {
+        vscode.window.showInformationMessage('No Codex accounts are signed in.');
+        return;
+      }
+      await authManager.signOutAll();
+      logger.child('command').info('auth.sign-out.completed', { count: accounts.length });
+      vscode.window.showInformationMessage(accounts.length > 1 ? `Signed out of all ${accounts.length} Codex accounts.` : 'Codex credentials removed.');
     }),
     vscode.commands.registerCommand('codexForCopilot.auth.signInWithChatGPT', async () => {
       try {
@@ -160,6 +156,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand('codexModelProvider.refreshAccountLimits', async () => {
       await accountUsageStatusBar.refresh();
+      await accountUsageStatusBar.showDetails();
+    }),
+    vscode.commands.registerCommand('codexModelProvider.showAccountLimits', async () => {
       await accountUsageStatusBar.showDetails();
     }),
     vscode.commands.registerCommand('codexModelProvider.enableNativeToolSearch', () => enableNativeToolSearchGroupingBridge(context)),
@@ -194,19 +193,75 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         await vscode.commands.executeCommand('workbench.action.openSettings', 'codexModelProvider.nativeToolSearch');
       }
     }),
+    vscode.commands.registerCommand('codexForCopilot.auth.switchAccount', async () => {
+      const picked = await pickAccount(authManager, 'Switch Codex Account', 'Choose which account new chat requests use.');
+      if (!picked) return;
+      await authManager.switchAccount(picked.accountKey);
+      logger.child('command').info('auth.switched', { accountKey: picked.accountKey });
+      vscode.window.showInformationMessage(`Active Codex account switched to ${picked.email ?? picked.accountId ?? picked.accountKey}.`);
+    }),
+    vscode.commands.registerCommand('codexForCopilot.auth.removeAccount', async () => {
+      const picked = await pickAccount(authManager, 'Remove Codex Account', 'Choose an account to remove (its credentials will be deleted).');
+      if (!picked) return;
+      const label = picked.email ?? picked.accountId ?? picked.accountKey;
+      const confirm = await vscode.window.showWarningMessage(`Remove Codex account ${label}?`, { modal: true }, 'Remove');
+      if (confirm !== 'Remove') return;
+      await authManager.signOut(picked.accountKey);
+      logger.child('command').info('auth.removed', { accountKey: picked.accountKey });
+      vscode.window.showInformationMessage(`Codex account ${label} removed.`);
+    }),
+    vscode.commands.registerCommand('codexForCopilot.auth.addAccount', async () => {
+      const method = await vscode.window.showQuickPick(
+        [
+          { label: 'Sign in with ChatGPT', description: 'Open the ChatGPT website in your browser', id: 'browser' as const },
+          { label: 'Sign in with Device Code', description: 'Authorize with a one-time device code', id: 'device' as const },
+          { label: 'Import Codex auth.json', description: 'Load credentials from an exported auth.json file', id: 'import' as const }
+        ],
+        { title: 'Add Codex Account', placeHolder: 'Choose how to sign in to the new account' }
+      );
+      if (!method) {
+        return;
+      }
+      try {
+        let accountKey: string | undefined;
+        if (method.id === 'browser') {
+          accountKey = await authManager.signInWithBrowser();
+        } else if (method.id === 'device') {
+          accountKey = await authManager.signInWithDeviceCode();
+        } else {
+          accountKey = await importCodexAuthJsonInteractive(authManager);
+          if (!accountKey) {
+            return;
+          }
+        }
+        await authManager.switchAccount(accountKey);
+        const status = await authManager.getStatus(accountKey);
+        vscode.window.showInformationMessage(`Added Codex account${status.email ? ` ${status.email}` : ''} and set it active.`);
+      } catch (error) {
+        logger.child('command').error('auth.add-account.failed', error);
+        const message = error instanceof InvalidAuthJsonError ? error.message : (error instanceof Error ? error.message : 'Adding a Codex account failed.');
+        vscode.window.showErrorMessage(message);
+      }
+    }),
     vscode.commands.registerCommand('codexModelProvider.manage', async () => {
       const action = await vscode.window.showQuickPick(
-        ['Sign in with ChatGPT', 'Sign in with Device Code', 'Show Auth Status', 'Sign Out', 'Import Codex auth.json', 'Refresh Account Limits', 'Enable Native Tool Search', 'Use VS Code Virtual Tool Groups', 'Show Native Tool Search Status', 'Open Debug Logs', 'Set API Key', 'Clear API Key', 'Open Settings'],
+        ['Sign in with ChatGPT', 'Add Codex Account', 'Switch Codex Account', 'Remove Codex Account', 'Sign in with Device Code', 'Show Auth Status', 'Sign Out (All Accounts)', 'Import Codex auth.json', 'Refresh Account Limits', 'Enable Native Tool Search', 'Use VS Code Virtual Tool Groups', 'Show Native Tool Search Status', 'Open Debug Logs', 'Set API Key', 'Clear API Key', 'Open Settings'],
         { title: 'Codex' }
       );
 
       if (action === 'Sign in with ChatGPT') {
         await vscode.commands.executeCommand('codexForCopilot.auth.signInWithChatGPT');
+      } else if (action === 'Add Codex Account') {
+        await vscode.commands.executeCommand('codexForCopilot.auth.addAccount');
+      } else if (action === 'Switch Codex Account') {
+        await vscode.commands.executeCommand('codexForCopilot.auth.switchAccount');
+      } else if (action === 'Remove Codex Account') {
+        await vscode.commands.executeCommand('codexForCopilot.auth.removeAccount');
       } else if (action === 'Import Codex auth.json') {
         await vscode.commands.executeCommand('codexForCopilot.auth.importAuthJson');
       } else if (action === 'Show Auth Status') {
         await vscode.commands.executeCommand('codexForCopilot.auth.showStatus');
-      } else if (action === 'Sign Out') {
+      } else if (action === 'Sign Out (All Accounts)') {
         await vscode.commands.executeCommand('codexForCopilot.auth.signOut');
       } else if (action === 'Sign in with Device Code') {
         await vscode.commands.executeCommand('codexForCopilot.auth.signInWithDeviceCode');
@@ -249,4 +304,45 @@ function formatNativeToolSearchReason(reason: string): string {
 
 function formatSettingValue(value: unknown): string {
   return value === undefined ? 'default' : String(value);
+}
+
+function sanitizeLockKey(accountKey: string): string {
+  return accountKey.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+/** Prompt for an auth.json file and import it, returning the new account key (or undefined if cancelled). */
+async function importCodexAuthJsonInteractive(authManager: CodexAuthManager): Promise<string | undefined> {
+  const selected = await vscode.window.showOpenDialog({
+    title: 'Import Codex auth.json',
+    canSelectFiles: true,
+    canSelectFolders: false,
+    canSelectMany: false,
+    filters: { JSON: ['json'] }
+  });
+  const uri = selected?.[0];
+  if (!uri) {
+    return undefined;
+  }
+  const raw = Buffer.from(await vscode.workspace.fs.readFile(uri)).toString('utf8');
+  return authManager.importAuthJson(raw);
+}
+
+async function pickAccount(
+  authManager: CodexAuthManager,
+  title: string,
+  placeHolder: string
+): Promise<{ accountKey: string; email?: string; accountId?: string; isActive: boolean } | undefined> {
+  const accounts = await authManager.listAccounts();
+  if (accounts.length === 0) {
+    vscode.window.showInformationMessage('No Codex accounts are configured. Use "Add Codex Account" to sign in.');
+    return undefined;
+  }
+  const items = accounts.map((account) => ({
+    label: `${account.isActive ? '$(check) ' : ''}${account.email ?? account.accountId ?? account.accountKey}`,
+    description: account.isActive ? 'active' : (account.accountId ?? ''),
+    detail: account.reauthRequired ? 'Re-authentication required' : undefined,
+    account
+  }));
+  const picked = await vscode.window.showQuickPick(items, { title, placeHolder, matchOnDescription: true });
+  return picked?.account;
 }

--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -603,6 +603,7 @@ async function streamCodexResponseTextOverManagedWebSocket(
       if (attempt === 0 && !visibleActivity && options.authManager && isUnauthorizedError(error)) {
         const currentSnapshot = await options.authManager.getCredentialSnapshot();
         const snapshot = await options.authManager.recoverFromUnauthorized({
+          accountKey: currentSnapshot.accountKey ?? '',
           snapshotRevision: currentSnapshot.revision,
           visibleActivity: false,
           reason: 'websocketUnauthorized'

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -12,6 +12,8 @@ export interface ApiCredentials {
   headers: Record<string, string>;
   source: 'secretStorage' | 'codexAuth';
   authManager?: CodexAuthManager;
+  /** Codex account the credentials belong to (SecretStore account key). */
+  accountKey?: string;
   kind: 'codexAccessToken' | 'openaiApiKey';
   omitMaxOutputTokens: boolean;
 }
@@ -60,6 +62,7 @@ async function readCodexAuthCredentials(authManager?: CodexAuthManager): Promise
         headers,
         source: 'codexAuth',
         authManager,
+        accountKey: snapshot.accountKey,
         kind: 'codexAccessToken',
         omitMaxOutputTokens: true
       };
@@ -123,4 +126,26 @@ async function readSecretStorageCredentials(context: vscode.ExtensionContext): P
   }
 
   return undefined;
+}
+
+/** Build Codex access-token credentials for one account, refreshing that account's token if needed. */
+export async function getCodexCredentialsForAccount(authManager: CodexAuthManager, accountKey: string): Promise<ApiCredentials | undefined> {
+  try {
+    const snapshot = await authManager.getCredentialSnapshot(accountKey);
+    const headers: Record<string, string> = { 'User-Agent': DEFAULT_USER_AGENT };
+    if (snapshot.accountId?.trim()) {
+      headers['ChatGPT-Account-ID'] = snapshot.accountId.trim();
+    }
+    return {
+      apiKey: snapshot.accessToken,
+      headers,
+      source: 'codexAuth',
+      authManager,
+      accountKey,
+      kind: 'codexAccessToken',
+      omitMaxOutputTokens: true
+    };
+  } catch {
+    return undefined;
+  }
 }

--- a/test/smokeAuth.mjs
+++ b/test/smokeAuth.mjs
@@ -165,6 +165,22 @@ try {
   assertEqual(rawImportedSecrets.has('codexForCopilot.codexAuthBundle'), false, 'legacy single-key record is removed after migration');
   assertEqual(JSON.parse(rawImportedSecrets.get(`codexForCopilot.codexAuthAccount.${migratedKey}`)).source, 'importedAuthJson', 'pre-schema auth.json migration persists a stable schema-v2 record');
 
+  for (const failingKey of ['codexForCopilot.codexAuthAccount.acct_1', 'codexForCopilot.codexAuthAccounts']) {
+    const migrationSecrets = new Map([
+      ['codexForCopilot.codexAuthBundle', JSON.stringify({ auth_mode: 'chatgpt', tokens: valid.tokens })]
+    ]);
+    const migrationStore = new auth.CodexSecretStore({
+      async get(key) { return migrationSecrets.get(key); },
+      async store(key, value) {
+        if (key === failingKey) throw new Error('temporary SecretStorage failure');
+        migrationSecrets.set(key, value);
+      },
+      async delete(key) { migrationSecrets.delete(key); }
+    });
+    await migrationStore.listAccountKeys();
+    assertEqual(migrationSecrets.has('codexForCopilot.codexAuthBundle'), true, `legacy secret survives failed migration write for ${failingKey}`);
+  }
+
   const legacySecrets = new Map();
   const legacySecretStorage = {
     async get(key) { return legacySecrets.get(key); },

--- a/test/smokeAuth.mjs
+++ b/test/smokeAuth.mjs
@@ -112,7 +112,7 @@ try {
   let importedRevokeCalls = 0;
   const importedManager = new auth.CodexAuthManager(
     new auth.CodexSecretStore(importedSecretStorage),
-    { async withLock(callback) { return callback(); } },
+    () => ({ async withLock(callback) { return callback(); } }),
     {
       async refresh(refreshToken) {
         importedRefreshCalls.push(refreshToken);
@@ -123,7 +123,7 @@ try {
   );
   const importedEvents = [];
   const importedSubscription = importedManager.onDidChangeAuth((event) => importedEvents.push(event));
-  await importedManager.importAuthJson(JSON.stringify({
+  const importedAccountKey = await importedManager.importAuthJson(JSON.stringify({
     auth_mode: 'chatgpt',
     tokens: {
       id_token: futureToken,
@@ -132,11 +132,12 @@ try {
       account_id: 'acct_1'
     }
   }));
-  const importedBeforeRefresh = JSON.parse(importedSecrets.get('codexForCopilot.codexAuthBundle'));
+  const accountSecretKey = `codexForCopilot.codexAuthAccount.${importedAccountKey}`;
+  const importedBeforeRefresh = JSON.parse(importedSecrets.get(accountSecretKey));
   assertEqual(importedBeforeRefresh.source, 'importedAuthJson', 'auth.json import retains its credential source');
   assertEqual(importedBeforeRefresh.tokens.refresh_token, 'imported-refresh-token', 'auth.json import stores its refresh token');
   const importedSnapshot = await importedManager.getCredentialSnapshot();
-  const importedAfterRefresh = JSON.parse(importedSecrets.get('codexForCopilot.codexAuthBundle'));
+  const importedAfterRefresh = JSON.parse(importedSecrets.get(accountSecretKey));
   assertEqual(importedSnapshot.source, 'importedAuthJson', 'auth.json import remains identifiable after refresh');
   assertEqual(importedSnapshot.refreshable, true, 'auth.json import is refreshable');
   assertEqual(JSON.stringify(importedRefreshCalls), JSON.stringify(['imported-refresh-token']), 'auth.json import enters the automatic refresh path');
@@ -144,7 +145,7 @@ try {
   assertEqual(importedAfterRefresh.tokens.account_id, 'acct_2', 'auth.json refresh persists refreshed account metadata');
   assertEqual(JSON.stringify(importedEvents.map((event) => event.reason)), JSON.stringify(['signedIn', 'tokensRefreshed']), 'auth.json import emits sign-in and refresh events');
   await importedManager.signOut();
-  assertEqual(importedSecrets.has('codexForCopilot.codexAuthBundle'), false, 'sign-out removes the imported credential copy');
+  assertEqual(importedSecrets.has(accountSecretKey), false, 'sign-out removes the imported credential copy');
   assertEqual(importedRevokeCalls, 0, 'sign-out does not revoke an imported auth.json credential');
   importedSubscription.dispose();
   importedManager.dispose();
@@ -160,7 +161,9 @@ try {
   const migratedRawImport = await rawImportedStore.getCredential();
   assertEqual(migratedRawImport.source, 'importedAuthJson', 'pre-schema auth.json import migrates into the refreshable path');
   assertEqual(migratedRawImport.tokens.refresh_token, 'refresh-token', 'pre-schema auth.json migration preserves the refresh token');
-  assertEqual(JSON.parse(rawImportedSecrets.get('codexForCopilot.codexAuthBundle')).source, 'importedAuthJson', 'pre-schema auth.json migration persists a stable schema-v2 record');
+  const migratedKey = (await rawImportedStore.listAccountKeys())[0];
+  assertEqual(rawImportedSecrets.has('codexForCopilot.codexAuthBundle'), false, 'legacy single-key record is removed after migration');
+  assertEqual(JSON.parse(rawImportedSecrets.get(`codexForCopilot.codexAuthAccount.${migratedKey}`)).source, 'importedAuthJson', 'pre-schema auth.json migration persists a stable schema-v2 record');
 
   const legacySecrets = new Map();
   const legacySecretStorage = {
@@ -168,22 +171,25 @@ try {
     async store(key, value) { legacySecrets.set(key, value); },
     async delete(key) { legacySecrets.delete(key); }
   };
+  const legacyStore = new auth.CodexSecretStore(legacySecretStorage);
   const legacyManager = new auth.CodexAuthManager(
-    new auth.CodexSecretStore(legacySecretStorage),
-    { async withLock(callback) { return callback(); } },
+    legacyStore,
+    () => ({ async withLock(callback) { return callback(); } }),
     { async refresh() { throw new Error('legacy snapshots must not refresh'); }, async revoke() {} }
   );
   await legacyManager.importAuthJson(JSON.stringify({
     auth_mode: 'chatgpt',
     tokens: { id_token: futureToken, access_token: futureToken, refresh_token: 'fresh-import-token' }
   }));
-  await legacySecretStorage.store('codexForCopilot.codexAuthBundle', JSON.stringify({
+  await legacyStore.setLegacyCredential({
     schemaVersion: 2,
     source: 'legacyCodexFile',
     revision: 'legacy',
     accessToken: futureToken,
+    accountId: 'legacy-acct',
     loadedAt: new Date().toISOString()
-  }));
+  });
+  await legacyManager.switchAccount('legacy-acct');
   const legacySnapshot = await legacyManager.getCredentialSnapshot();
   assertEqual(legacySnapshot.source, 'legacyCodexFile', 'stored legacy access-token snapshots remain identifiable');
   assertEqual(legacySnapshot.refreshable, false, 'stored legacy access-token snapshots stay non-refreshable');
@@ -206,11 +212,12 @@ try {
   const manager = {
     async getCredentialSnapshot() {
       calls += 1;
-      return { accessToken: calls === 1 ? 'old-token' : 'new-token', accountId: 'acct_1', revision: calls === 1 ? 'old' : 'new' };
+      return { accessToken: calls === 1 ? 'old-token' : 'new-token', accountId: 'acct_1', accountKey: 'acct_1', revision: calls === 1 ? 'old' : 'new' };
     },
+    async getActiveAccountKey() { return 'acct_1'; },
     async recoverFromUnauthorized() {
       calls += 10;
-      return { accessToken: 'new-token', accountId: 'acct_1', revision: 'new' };
+      return { accessToken: 'new-token', accountId: 'acct_1', accountKey: 'acct_1', revision: 'new' };
     }
   };
   const seenAuth = [];
@@ -293,6 +300,12 @@ try {
         ? { authenticated: true, email: 'user@example.com' }
         : { authenticated: false };
     },
+    async listAccounts() {
+      return signedInSnapshot
+        ? [{ accountKey: 'acct_1', source: 'extensionOAuth', email: 'user@example.com', accountId: signedInSnapshot.accountId, isActive: true, reauthRequired: false }]
+        : [];
+    },
+    async getActiveAccountKey() { return signedInSnapshot ? 'acct_1' : undefined; },
     async getCredentialSnapshot() {
       if (!signedInSnapshot) {
         throw new Error('not signed in');


### PR DESCRIPTION
Manage multiple ChatGPT/Codex accounts and view per-account usage.

<img width="602" height="86" alt="image" src="https://github.com/user-attachments/assets/982a0840-a884-486b-b683-84b398e062ac" />
<img width="604" height="140" alt="image" src="https://github.com/user-attachments/assets/01fc21bd-7b44-4306-a8e7-402fda81b4db" />
<img width="606" height="181" alt="image" src="https://github.com/user-attachments/assets/e3acd89b-a0a5-44c7-83bf-b1f1c8076551" />


- Store credentials per account with an active-account pointer; migrate the legacy single-account secret on first run
- Add per-account refresh locks and isolate token refresh per account
- Add Add/Switch/Remove account commands; "Sign Out (All Accounts)" clears every account while "Remove Codex Account" removes one
- Enable VS Code multi-account authentication (supportsMultipleAccounts) with full session diffing
- Show the active account's usage in the status bar with a click-through quick-pick listing every account's limits and a set-active action
- Fix per-account usage isolation by threading the account key through codexFetch so each request uses its own token and ChatGPT-Account-ID

