### PR TITLE
fix: honor context size model options

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1881,7 +1881,11 @@ function resolveConfiguredContextSize(
     return fallbackBudget;
   }
 
-  for (const candidate of [options.modelConfiguration?.contextSize, options.configuration?.contextSize]) {
+  for (const candidate of [
+    options.modelOptions?.contextSize,
+    options.modelConfiguration?.contextSize,
+    options.configuration?.contextSize
+  ]) {
     if (typeof candidate === 'number' && Number.isSafeInteger(candidate) && contextSizeSchema.options.includes(candidate)) {
       return candidate;
     }

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -737,7 +737,7 @@ async function runProviderLongContextSelectionSmokeTest() {
         { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('first reply')] },
         { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Follow up')] }
       ],
-      { modelConfiguration: { contextSize: 950000 } },
+      { modelOptions: { contextSize: 950000 } },
       { report() {} },
       token
     );

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -674,7 +674,11 @@ async function runProviderLongContextSelectionSmokeTest() {
       ['first reply', 'resp_standard'],
       ['long reply', 'resp_long'],
       ['long follow-up reply', 'resp_long_follow_up'],
-      ['downgrade reply', 'resp_downgrade']
+      ['downgrade reply', 'resp_downgrade'],
+      ['model options seed reply', 'resp_model_options_seed'],
+      ['model options follow-up reply', 'resp_model_options_follow_up'],
+      ['precedence seed reply', 'resp_precedence_seed'],
+      ['precedence follow-up reply', 'resp_precedence_follow_up']
     ];
     const reply = replies[responseRequests.length - 1];
     if (!reply) {
@@ -737,7 +741,7 @@ async function runProviderLongContextSelectionSmokeTest() {
         { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('first reply')] },
         { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Follow up')] }
       ],
-      { modelOptions: { contextSize: 950000 } },
+      { modelConfiguration: { contextSize: 950000 } },
       { report() {} },
       token
     );
@@ -772,8 +776,51 @@ async function runProviderLongContextSelectionSmokeTest() {
       token
     );
 
-    assertEqual(responseRequests.length, 4, 'context-size transition request count');
-    assertEqual(selectedModels.join(','), 'gpt-5.4,gpt-5.4,gpt-5.4,gpt-5.4', 'context sizes resolve to the real backend model');
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Model options seed')] }],
+      { modelConfiguration: { contextSize: 950000 } },
+      { report() {} },
+      token
+    );
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Model options seed')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('model options seed reply')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Model options follow up')] }
+      ],
+      { modelOptions: { contextSize: 950000 } },
+      { report() {} },
+      token
+    );
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Precedence seed')] }],
+      { modelConfiguration: { contextSize: 950000 } },
+      { report() {} },
+      token
+    );
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Precedence seed')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('precedence seed reply')] },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Precedence follow up')] }
+      ],
+      {
+        modelOptions: { contextSize: 258400 },
+        modelConfiguration: { contextSize: 950000 }
+      },
+      { report() {} },
+      token
+    );
+
+    assertEqual(responseRequests.length, 8, 'context-size transition request count');
+    assertEqual(selectedModels.join(','), Array(8).fill('gpt-5.4').join(','), 'context sizes resolve to the real backend model');
     for (const body of responseRequests) {
       assertEqual(body.model, 'gpt-5.4', 'context-size request sends the real backend model');
       assertEqual(
@@ -790,6 +837,17 @@ async function runProviderLongContextSelectionSmokeTest() {
       'same context size sends only appended input'
     );
     assertEqual(responseRequests[3].previous_response_id, undefined, 'switching back to the default size starts an isolated chain');
+    assertEqual(responseRequests[5].previous_response_id, 'resp_model_options_seed', 'request-time model options select the matching long-context branch');
+    assertEqual(
+      JSON.stringify(responseRequests[5].input),
+      JSON.stringify([{ role: 'user', content: 'Model options follow up', type: 'message' }]),
+      'request-time model options preserve incremental continuation input'
+    );
+    assertEqual(
+      responseRequests[7].previous_response_id,
+      undefined,
+      'request-time model options override conflicting persisted model configuration'
+    );
   } finally {
     server.close();
   }


### PR DESCRIPTION
## Summary

- retain canonical VS Code picker/configuration support through `modelConfiguration.contextSize`
- add `modelOptions.contextSize` as an additional request-time provider-specific override
- retain the legacy `configuration.contextSize` compatibility alias
- explicitly test that request-time `modelOptions` takes precedence when it conflicts with persisted/model-picker configuration

## Why

Context Size selections can arrive through the model configuration generated from `configurationSchema`. Some callers can also provide request-specific model options. Supporting both preserves the canonical picker path while allowing an explicit per-request override.

## Verification

- canonical `modelConfiguration` continuation coverage
- separate `modelOptions` continuation coverage
- conflicting-option precedence coverage
- `npm run check`
- `npm run compile`
- `npm run test:smoke`
- `npm run test:extension-host`
- LSP diagnostics
- `git diff --check`

All passed.