### PR TITLE
feat: support Agent Host continuation markers

### DIFF
--- a/src/convertMessages.ts
+++ b/src/convertMessages.ts
@@ -12,6 +12,29 @@ import * as vscode from 'vscode';
 
 export type ResponsesInputMessage = ResponseInputItem;
 
+export const STATEFUL_MARKER_DATA_PART_MIME = 'stateful_marker';
+
+export type StatefulMarkerResult =
+  | { kind: 'none' }
+  | {
+      kind: 'invalid';
+      reason: 'metadata' | 'multiple';
+      isLeadingStandalone: boolean;
+    }
+  | {
+      kind: 'valid';
+      modelId: string;
+      previousResponseId: string;
+      incrementalInput: ResponsesInputMessage[];
+      isLeadingStandalone: boolean;
+    };
+
+export interface ResponsesInputConversionResult {
+  input: ResponsesInputMessage[];
+  systemInstructions?: string;
+  statefulMarker: StatefulMarkerResult;
+}
+
 export interface ResponsesInputHistoryComparison {
   kind: 'initial' | 'append' | 'fork';
   matchedPrefixCount: number;
@@ -26,6 +49,11 @@ export interface ResponsesInputHistoryComparison {
 const textDecoder = new TextDecoder();
 const USAGE_DATA_PART_MIME = 'usage';
 const CACHE_CONTROL_DATA_PART_MIME = 'cache_control';
+const MAX_STATEFUL_MARKER_BYTES = 4096;
+const MAX_STATEFUL_MARKER_MODEL_ID_BYTES = 512;
+const MAX_STATEFUL_MARKER_RESPONSE_ID_BYTES = 512;
+const RUNTIME_SYSTEM_MESSAGE_ROLE = 3;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/;
 const IMAGE_DATA_URL_PATTERN = /^data:image\/[a-z0-9.+-]+;base64,[a-z0-9+/=\s]+$/i;
 const HISTORY_IMAGE_URI_PLACEHOLDER_PATTERN = /^\[Image was previously shown to you\. Image URI: ([^\]]+)\]$/;
 const HISTORY_IMAGE_URI_ANNOTATION_PATTERN = /^\s*\[Image URI: ([^\]]+)\]\s*$/;
@@ -33,6 +61,76 @@ const IGNORED_HISTORY_CONTENT = Symbol('ignored-history-content');
 
 export function convertMessagesToResponsesInput(messages: readonly vscode.LanguageModelChatRequestMessage[]): ResponsesInputMessage[] {
   return normalizeDanglingFunctionCallsForReplay(messages.flatMap((message) => convertMessageToResponsesInput(message)));
+}
+
+export function convertMessagesToResponsesInputWithStatefulMarker(
+  messages: readonly vscode.LanguageModelChatRequestMessage[]
+): ResponsesInputConversionResult {
+  const markerLocations: Array<{
+    messageIndex: number;
+    partIndex: number;
+    part: vscode.LanguageModelDataPart;
+  }> = [];
+
+  for (let messageIndex = 0; messageIndex < messages.length; messageIndex += 1) {
+    const message = messages[messageIndex];
+    for (let partIndex = 0; partIndex < message.content.length; partIndex += 1) {
+      const part = message.content[partIndex];
+      if (part instanceof vscode.LanguageModelDataPart && isStatefulMarkerDataPart(part)) {
+        markerLocations.push({ messageIndex, partIndex, part });
+      }
+    }
+  }
+
+  const input = normalizeDanglingFunctionCallsForReplay(messages.flatMap((message) =>
+    isRuntimeSystemMessage(message) ? [] : convertMessageToResponsesInput(message)
+  ));
+  const systemInstructions = normalizeSystemInstructions(messages);
+  if (markerLocations.length === 0) {
+    return { input, systemInstructions, statefulMarker: { kind: 'none' } };
+  }
+  const firstMarkerLocation = markerLocations[0];
+  const isLeadingStandalone = isLeadingStandaloneMarker(messages, firstMarkerLocation);
+  if (markerLocations.length > 1) {
+    return {
+      input,
+      systemInstructions,
+      statefulMarker: { kind: 'invalid', reason: 'multiple', isLeadingStandalone }
+    };
+  }
+
+  const markerLocation = firstMarkerLocation;
+  const marker = parseStatefulMarker(markerLocation.part);
+  if (!marker) {
+    return {
+      input,
+      systemInstructions,
+      statefulMarker: { kind: 'invalid', reason: 'metadata', isLeadingStandalone }
+    };
+  }
+
+  const markerMessage = messages[markerLocation.messageIndex];
+  const incrementalInput = normalizeDanglingFunctionCallsForReplay([
+    ...convertMessageContentToResponsesInput(
+      markerMessage.role,
+      markerMessage.content.slice(markerLocation.partIndex + 1)
+    ),
+    ...messages
+      .slice(markerLocation.messageIndex + 1)
+      .flatMap((message) => isRuntimeSystemMessage(message) ? [] : convertMessageToResponsesInput(message))
+  ]);
+
+  return {
+    input,
+    systemInstructions,
+    statefulMarker: {
+      kind: 'valid',
+      modelId: marker.modelId,
+      previousResponseId: marker.previousResponseId,
+      incrementalInput,
+      isLeadingStandalone
+    }
+  };
 }
 
 export function estimateTokenCount(value: string | vscode.LanguageModelChatRequestMessage): number {
@@ -133,8 +231,15 @@ export function getTextFromMessage(message: vscode.LanguageModelChatRequestMessa
 }
 
 function convertMessageToResponsesInput(message: vscode.LanguageModelChatRequestMessage): ResponsesInputMessage[] {
+  return convertMessageContentToResponsesInput(message.role, message.content);
+}
+
+function convertMessageContentToResponsesInput(
+  messageRole: vscode.LanguageModelChatMessageRole,
+  content: vscode.LanguageModelChatRequestMessage['content']
+): ResponsesInputMessage[] {
   const items: ResponsesInputMessage[] = [];
-  const role = message.role === vscode.LanguageModelChatMessageRole.User ? 'user' : 'assistant';
+  const role = messageRole === vscode.LanguageModelChatMessageRole.User ? 'user' : 'assistant';
   let bufferedText = '';
   let bufferedContent: ResponseInputMessageContentList = [];
 
@@ -170,7 +275,7 @@ function convertMessageToResponsesInput(message: vscode.LanguageModelChatRequest
     bufferedContent = [];
   };
 
-  for (const part of message.content) {
+  for (const part of content) {
     if (part instanceof vscode.LanguageModelTextPart) {
       const image = tryParseMessageImageDataUrl(part.value);
       if (image) {
@@ -365,7 +470,9 @@ function serializeToolResultContent(content: readonly unknown[]): string | Respo
 function serializeDataPart(part: vscode.LanguageModelDataPart): string {
   const mimeType = part.mimeType.toLowerCase();
 
-  if (mimeType === USAGE_DATA_PART_MIME || mimeType === CACHE_CONTROL_DATA_PART_MIME) {
+  if (mimeType === USAGE_DATA_PART_MIME
+    || mimeType === CACHE_CONTROL_DATA_PART_MIME
+    || mimeType === STATEFUL_MARKER_DATA_PART_MIME) {
     return '';
   }
 
@@ -374,6 +481,72 @@ function serializeDataPart(part: vscode.LanguageModelDataPart): string {
   }
 
   return `[binary data: ${part.mimeType}, ${part.data.byteLength} bytes]`;
+}
+
+function isStatefulMarkerDataPart(part: vscode.LanguageModelDataPart): boolean {
+  return part.mimeType.toLowerCase() === STATEFUL_MARKER_DATA_PART_MIME;
+}
+
+function parseStatefulMarker(part: vscode.LanguageModelDataPart): {
+  modelId: string;
+  previousResponseId: string;
+} | undefined {
+  if (part.data.byteLength > MAX_STATEFUL_MARKER_BYTES) {
+    return undefined;
+  }
+
+  let value: string;
+  try {
+    value = new TextDecoder('utf-8', { fatal: true }).decode(part.data);
+  } catch {
+    return undefined;
+  }
+
+  const delimiterIndex = value.indexOf('\\');
+  if (delimiterIndex < 0) {
+    return undefined;
+  }
+
+  const modelId = value.slice(0, delimiterIndex);
+  const previousResponseId = value.slice(delimiterIndex + 1);
+  if (!isValidStatefulMarkerComponent(modelId, MAX_STATEFUL_MARKER_MODEL_ID_BYTES)
+    || !isValidStatefulMarkerComponent(previousResponseId, MAX_STATEFUL_MARKER_RESPONSE_ID_BYTES)) {
+    return undefined;
+  }
+
+  return { modelId, previousResponseId };
+}
+
+function isValidStatefulMarkerComponent(value: string, maxBytes: number): boolean {
+  return value.length > 0
+    && value.trim() === value
+    && !CONTROL_CHARACTER_PATTERN.test(value)
+    && Buffer.byteLength(value, 'utf8') <= maxBytes;
+}
+
+function isRuntimeSystemMessage(message: vscode.LanguageModelChatRequestMessage): boolean {
+  return Number(message.role) === RUNTIME_SYSTEM_MESSAGE_ROLE;
+}
+
+function normalizeSystemInstructions(
+  messages: readonly vscode.LanguageModelChatRequestMessage[]
+): string | undefined {
+  const instructions = messages
+    .filter((message) => isRuntimeSystemMessage(message))
+    .map((message) => getTextFromMessage(message).trim())
+    .filter((value) => value.length > 0);
+  return instructions.length > 0 ? instructions.join('\n\n') : undefined;
+}
+
+function isLeadingStandaloneMarker(
+  messages: readonly vscode.LanguageModelChatRequestMessage[],
+  markerLocation: { messageIndex: number; partIndex: number }
+): boolean {
+  if (markerLocation.messageIndex !== 0 || markerLocation.partIndex !== 0) {
+    return false;
+  }
+
+  return messages[0].role === vscode.LanguageModelChatMessageRole.Assistant;
 }
 
 function dataPartToMessageImage(part: vscode.LanguageModelDataPart): ResponseInputImage | undefined {

--- a/src/convertMessages.ts
+++ b/src/convertMessages.ts
@@ -517,6 +517,17 @@ function parseStatefulMarker(part: vscode.LanguageModelDataPart): {
   return { modelId, previousResponseId };
 }
 
+export function createStatefulMarkerPayload(modelId: string, previousResponseId: string): string | undefined {
+  if (modelId.includes('\\')
+    || !isValidStatefulMarkerComponent(modelId, MAX_STATEFUL_MARKER_MODEL_ID_BYTES)
+    || !isValidStatefulMarkerComponent(previousResponseId, MAX_STATEFUL_MARKER_RESPONSE_ID_BYTES)) {
+    return undefined;
+  }
+
+  const payload = `${modelId}\\${previousResponseId}`;
+  return Buffer.byteLength(payload, 'utf8') <= MAX_STATEFUL_MARKER_BYTES ? payload : undefined;
+}
+
 function isValidStatefulMarkerComponent(value: string, maxBytes: number): boolean {
   return value.length > 0
     && value.trim() === value

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -2,7 +2,15 @@ import * as vscode from 'vscode';
 import { createHash } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 import type { ResponseUsage } from 'openai/resources/responses/responses';
-import { compareResponsesInputHistory, convertMessagesToResponsesInput, estimateTokenCount, stableSerialize, type ResponsesInputMessage } from './convertMessages';
+import {
+  compareResponsesInputHistory,
+  convertMessagesToResponsesInput,
+  convertMessagesToResponsesInputWithStatefulMarker,
+  estimateTokenCount,
+  STATEFUL_MARKER_DATA_PART_MIME,
+  stableSerialize,
+  type ResponsesInputMessage
+} from './convertMessages';
 import { getProviderConfig, type ProviderConfig } from './config';
 import { buildFallbackModel, buildProviderModels, fetchAvailableModels, isProviderModelIdentifier, parseModelIdentifier, type ParsedModelIdentifier, type ResolvedProviderModel } from './models';
 import {
@@ -90,6 +98,7 @@ const MAX_PENDING_REPORTED_TOOL_CALLS = 200;
 const TOOL_OUTPUT_CONTINUATION_CAPABILITY_TTL_MS = 30 * 60_000;
 const MAX_TOOL_OUTPUT_CONTINUATION_CAPABILITIES = 64;
 const MAX_LOCAL_TOKEN_ESTIMATE_DIAGNOSTICS = 64;
+const STATEFUL_MARKER_LOCAL_ERROR = 'Stateful continuation marker could not be resolved locally.';
 // The WebSocket tool-output continuation path passed the real-backend release
 // gate: five consecutive store:false tool loops completed with a matching
 // previous_response_id and a single incremental function_call_output.
@@ -283,6 +292,17 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       throw new Error('Codex credentials are missing. Run "Codex for Copilot: Import Codex auth.json".');
     }
 
+    const convertedMessages = convertMessagesToResponsesInputWithStatefulMarker(messages);
+    if (convertedMessages.statefulMarker.kind === 'invalid'
+      && convertedMessages.statefulMarker.isLeadingStandalone) {
+      throw new Error(STATEFUL_MARKER_LOCAL_ERROR);
+    }
+    if (convertedMessages.statefulMarker.kind === 'valid'
+      && convertedMessages.statefulMarker.isLeadingStandalone
+      && convertedMessages.statefulMarker.modelId !== model.id) {
+      throw new Error(STATEFUL_MARKER_LOCAL_ERROR);
+    }
+
     const authIdentity = getCredentialIdentity(credentials);
     this.handleConnectionConfiguration(config, authIdentity);
     const compatibilityProfile = getCodexCompatibilityProfile(config.baseURL, credentials, config.protocol.profile);
@@ -323,7 +343,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     );
     const reasoningEffort = reasoning.effort;
     const requestStartedAt = latency.entryAt;
-    const input = convertMessagesToResponsesInput(messages);
+    const input = convertedMessages.input;
     const observedToolResults = this.consumeReportedToolResults(input);
     latency.mark('messagesConverted');
     const requestBuildStartedAt = performance.now();
@@ -385,7 +405,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     let requestOptions: CodexRequestEnvelopeOptions = {
       compatibilityEnabled: compatibilityProfile.enabled,
       model: selectedModel.requestModel,
-      instructions: config.instructions,
+      instructions: combineRequestInstructions(config.instructions, convertedMessages.systemInstructions),
       tools: options.tools,
       toolPlan,
       toolMode: options.toolMode,
@@ -422,8 +442,22 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       ...requestOptions
     });
     latency.recordContext({ requestBuildMs: Math.max(0, performance.now() - requestBuildStartedAt) });
-    const reusableBranch = this.responseBranchStore.findReusableBranch(reuseEnvelope, input);
-    const reuseMissDiagnostic = reusableBranch
+    const markerHint = convertedMessages.statefulMarker.kind === 'valid'
+      && convertedMessages.statefulMarker.isLeadingStandalone
+      ? {
+          responseId: convertedMessages.statefulMarker.previousResponseId,
+          incrementalInput: convertedMessages.statefulMarker.incrementalInput
+        }
+      : undefined;
+    const reusableBranch = convertedMessages.statefulMarker.kind === 'none'
+      ? this.responseBranchStore.findReusableBranch(reuseEnvelope, input)
+      : markerHint
+        ? this.responseBranchStore.findReusableBranch(reuseEnvelope, input, markerHint)
+        : undefined;
+    if (markerHint && !reusableBranch) {
+      throw new Error(STATEFUL_MARKER_LOCAL_ERROR);
+    }
+    const reuseMissDiagnostic = reusableBranch || convertedMessages.statefulMarker.kind !== 'none'
       ? undefined
       : this.responseBranchStore.explainReuseMiss(reuseEnvelope, input);
     latency.mark('branchResolved');
@@ -431,6 +465,20 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       reusableBranch?.comparison.appendedInput.some((item) => item.type === 'function_call_output')
     );
     const appendedInput = reusableBranch?.comparison.appendedInput ?? [];
+    const isMarkerContinuation = Boolean(markerHint && reusableBranch);
+    const markerContinuationSnapshot = isMarkerContinuation
+      ? reusableBranch?.state?.continuation
+      : undefined;
+    if (isMarkerContinuation && !markerContinuationSnapshot) {
+      throw new Error(STATEFUL_MARKER_LOCAL_ERROR);
+    }
+    const markerCanonicalReplayInput = isMarkerContinuation
+      ? buildCanonicalReplayInput({
+          previousSnapshot: markerContinuationSnapshot,
+          convertedInput: input,
+          appendedInput
+        })
+      : undefined;
     const hasOnlyToolOutputAppend = requiresFullInputForToolOutput
       && appendedInput.length > 0
       && appendedInput.every((item) => item.type === 'function_call_output');
@@ -458,7 +506,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       && (!requiresFullInputForToolOutput || shouldAttemptToolOutputContinuation);
     const initialRequestInput = usePreviousResponseId
       ? appendedInput
-      : input;
+      : markerCanonicalReplayInput ?? input;
     const initialPreviousResponseId = usePreviousResponseId
       ? reusableBranch?.responseId
       : undefined;
@@ -1010,7 +1058,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           requestModel: selectedModel.requestModel,
           nativeToolSearchFallback: true
         });
-        await streamRequest(input);
+        await streamRequest(markerCanonicalReplayInput ?? input);
       } else if (shouldAttemptToolOutputContinuation && isResponsesContinuationMissError(error)) {
         if (reportedVisibleOutput) {
           this.responseBranchStore.invalidateResponseId(error.previousResponseId);
@@ -1035,12 +1083,19 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           requestModel: selectedModel.requestModel,
           branchId: reusableBranch?.branchId ?? null,
           previousResponseId: initialPreviousResponseId,
-          reason: error.message
+          reason: error.message,
+          reuseDisabledUntilExpiry: error.disableReuseUntilExpiry
         });
 
         completedResponseId = undefined;
         rawResponseItems.length = 0;
-        await streamRequest(input);
+        this.responseBranchStore.disableReuse(reuseEnvelope, !error.disableReuseUntilExpiry);
+        this.responseBranchStore.invalidateResponseId(error.previousResponseId);
+        if (reusableBranch) {
+          this.responseBranchStore.invalidate(reusableBranch.branchId);
+        }
+        activeBranchId = undefined;
+        await streamRequest(markerCanonicalReplayInput ?? input);
       } else {
         if (!initialPreviousResponseId || !isResponsesContinuationMissError(error)) {
           const unavailableModel = getExactModelNotFoundName(error, selectedModel.requestModel);
@@ -1092,18 +1147,21 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         completedResponseId = undefined;
         rawResponseItems.length = 0;
         activeBranchId = undefined;
-        await streamRequest(input);
+        await streamRequest(markerCanonicalReplayInput ?? input);
       }
     }
 
     const finalResponseId = completedResponseId;
     if (finalResponseId) {
+      const recordedInput = markerCanonicalReplayInput ?? input;
       const builtFullRequest = buildCodexResponsesRequest({
         ...requestOptions,
         identity: requestIdentity,
-        input,
+        input: recordedInput,
       });
-      const fullRequest = toolPlan.mode === 'native-hosted'
+      const fullRequest = isMarkerContinuation
+        ? builtFullRequest
+        : toolPlan.mode === 'native-hosted'
         ? createCanonicalReplayRequest(builtFullRequest, buildCanonicalReplayInput({
             previousSnapshot: reusableBranch?.state?.continuation,
             convertedInput: input,
@@ -1127,7 +1185,16 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         ),
         updatedAt: Date.now()
       };
-      activeBranchId = this.responseBranchStore.recordSuccess(reuseEnvelope, input, finalResponseId, activeBranchId, branchState);
+      activeBranchId = this.responseBranchStore.recordSuccess(
+        reuseEnvelope,
+        recordedInput,
+        finalResponseId,
+        activeBranchId,
+        branchState
+      );
+      if (!token.isCancellationRequested && !this.responseBranchStore.isReuseDisabled(reuseEnvelope)) {
+        progress.report(createStatefulMarkerDataPart(model.id, finalResponseId));
+      }
     }
   }
 
@@ -1989,6 +2056,19 @@ function createUsageDataPart(usage: ResponseUsage | null | undefined): vscode.La
     },
     USAGE_DATA_PART_MIME
   ) as vscode.LanguageModelResponsePart;
+}
+
+function createStatefulMarkerDataPart(modelId: string, previousResponseId: string): vscode.LanguageModelResponsePart {
+  return vscode.LanguageModelDataPart.text(
+    `${modelId}\\${previousResponseId}`,
+    STATEFUL_MARKER_DATA_PART_MIME
+  ) as vscode.LanguageModelResponsePart;
+}
+
+function combineRequestInstructions(configuredInstructions: string, systemInstructions: string | undefined): string {
+  return systemInstructions
+    ? `${configuredInstructions}\n\n${systemInstructions}`
+    : configuredInstructions;
 }
 
 function createTemporarilyUnavailableModelError(model: string, cause: unknown): Error {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -4,6 +4,7 @@ import { performance } from 'node:perf_hooks';
 import type { ResponseUsage } from 'openai/resources/responses/responses';
 import {
   compareResponsesInputHistory,
+  createStatefulMarkerPayload,
   convertMessagesToResponsesInput,
   convertMessagesToResponsesInputWithStatefulMarker,
   estimateTokenCount,
@@ -1152,7 +1153,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     }
 
     const finalResponseId = completedResponseId;
-    if (finalResponseId) {
+    const statefulMarkerPayload = finalResponseId
+      ? createStatefulMarkerPayload(model.id, finalResponseId)
+      : undefined;
+    if (finalResponseId && statefulMarkerPayload) {
       const recordedInput = markerCanonicalReplayInput ?? input;
       const builtFullRequest = buildCodexResponsesRequest({
         ...requestOptions,
@@ -1193,8 +1197,12 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         branchState
       );
       if (!token.isCancellationRequested && !this.responseBranchStore.isReuseDisabled(reuseEnvelope)) {
-        progress.report(createStatefulMarkerDataPart(model.id, finalResponseId));
+        progress.report(createStatefulMarkerDataPart(statefulMarkerPayload));
       }
+    } else if (finalResponseId) {
+      requestLogger.warn('response continuation metadata rejected', {
+        requestModel: selectedModel.requestModel
+      });
     }
   }
 
@@ -2058,9 +2066,9 @@ function createUsageDataPart(usage: ResponseUsage | null | undefined): vscode.La
   ) as vscode.LanguageModelResponsePart;
 }
 
-function createStatefulMarkerDataPart(modelId: string, previousResponseId: string): vscode.LanguageModelResponsePart {
+function createStatefulMarkerDataPart(payload: string): vscode.LanguageModelResponsePart {
   return vscode.LanguageModelDataPart.text(
-    `${modelId}\\${previousResponseId}`,
+    payload,
     STATEFUL_MARKER_DATA_PART_MIME
   ) as vscode.LanguageModelResponsePart;
 }

--- a/src/responseBranchStore.ts
+++ b/src/responseBranchStore.ts
@@ -85,6 +85,7 @@ interface ResponseBranchEntry {
   responseId: string;
   state?: CodexBranchState;
   updatedAt: number;
+  supersededForHistoryReuse?: boolean;
 }
 
 export class ResponseBranchStore {
@@ -120,7 +121,8 @@ export class ResponseBranchStore {
     } | undefined;
 
     for (const branch of this.branches.values()) {
-      if (branch.envelope.identityKey !== envelope.identityKey
+      if (branch.supersededForHistoryReuse
+        || branch.envelope.identityKey !== envelope.identityKey
         || !hasMatchingRequestFingerprint(branch, envelope)
         || !hasCompatibleInputBudget(branch.envelope.effectiveInputBudget, envelope.effectiveInputBudget)) {
         continue;
@@ -207,7 +209,7 @@ export class ResponseBranchStore {
     let bestDiagnostic: ResponseBranchReuseMissDiagnostic | undefined;
 
     for (const branch of this.branches.values()) {
-      if (branch.envelope.scopeKey !== envelope.scopeKey) {
+      if (branch.supersededForHistoryReuse || branch.envelope.scopeKey !== envelope.scopeKey) {
         continue;
       }
 
@@ -253,7 +255,7 @@ export class ResponseBranchStore {
 
     if (branchId) {
       const existing = this.branches.get(branchId);
-      if (existing) {
+      if (existing?.responseId === responseId) {
         existing.envelope = envelope;
         existing.input = [...currentInput];
         existing.continuationInput = continuationInput;
@@ -261,6 +263,9 @@ export class ResponseBranchStore {
         existing.state = state ? cloneBranchState(state) : existing.state;
         existing.updatedAt = Date.now();
         return existing.id;
+      }
+      if (existing) {
+        existing.supersededForHistoryReuse = true;
       }
     }
 
@@ -270,7 +275,9 @@ export class ResponseBranchStore {
       }
 
       const comparison = compareResponsesInputHistory(branch.continuationInput, continuationInput);
-      if (comparison.kind === 'append' && comparison.appendedInput.length === 0) {
+      if (branch.responseId === responseId
+        && comparison.kind === 'append'
+        && comparison.appendedInput.length === 0) {
         branch.input = [...currentInput];
         branch.continuationInput = continuationInput;
         branch.responseId = responseId;
@@ -278,6 +285,9 @@ export class ResponseBranchStore {
         branch.state = state ? cloneBranchState(state) : branch.state;
         branch.updatedAt = Date.now();
         return branch.id;
+      }
+      if (comparison.kind === 'append' && comparison.appendedInput.length === 0) {
+        branch.supersededForHistoryReuse = true;
       }
     }
 

--- a/src/responseBranchStore.ts
+++ b/src/responseBranchStore.ts
@@ -7,6 +7,7 @@ import {
 } from './convertMessages';
 import type { CodexRequestIdentity } from './codexProtocol';
 import { cloneCodexContinuationSnapshot, type CodexContinuationSnapshot } from './codexContinuation';
+import { fingerprintCodexRequest } from './codexRequestBuilder';
 
 export interface CodexTurnState {
   id: string;
@@ -29,6 +30,11 @@ export interface ReusableResponseBranchMatch {
   responseId: string;
   comparison: ResponsesInputHistoryComparison;
   state?: CodexBranchState;
+}
+
+export interface ResponseBranchMarkerHint {
+  responseId: string;
+  incrementalInput: readonly ResponsesInputMessage[];
 }
 
 export interface ResponseBranchReuseEnvelope {
@@ -93,12 +99,17 @@ export class ResponseBranchStore {
 
   findReusableBranch(
     envelope: ResponseBranchReuseEnvelope,
-    currentInput: readonly ResponsesInputMessage[]
+    currentInput: readonly ResponsesInputMessage[],
+    markerHint?: ResponseBranchMarkerHint
   ): ReusableResponseBranchMatch | undefined {
     this.evictExpiredEntries();
 
     if (this.disabledReuseKeys.has(envelope.identityKey)) {
       return undefined;
+    }
+
+    if (markerHint) {
+      return this.findMarkerBranch(envelope, currentInput, markerHint);
     }
 
     const currentContinuationInput = projectResponsesInputForContinuation(currentInput);
@@ -142,6 +153,43 @@ export class ResponseBranchStore {
       comparison: bestCandidate.comparison,
       state: bestCandidate.branch.state ? cloneBranchState(bestCandidate.branch.state) : undefined
     };
+  }
+
+  private findMarkerBranch(
+    envelope: ResponseBranchReuseEnvelope,
+    currentInput: readonly ResponsesInputMessage[],
+    markerHint: ResponseBranchMarkerHint
+  ): ReusableResponseBranchMatch | undefined {
+    if (markerHint.incrementalInput.length === 0
+      || !haveEquivalentResponsesInput(markerHint.incrementalInput, currentInput)) {
+      return undefined;
+    }
+
+    for (const branch of this.branches.values()) {
+      if (branch.responseId !== markerHint.responseId) {
+        continue;
+      }
+      if (branch.envelope.identityKey !== envelope.identityKey
+        || !hasMatchingRequestFingerprint(branch, envelope)
+        || !hasCompatibleInputBudget(branch.envelope.effectiveInputBudget, envelope.effectiveInputBudget)
+        || !compareToolSignatures(branch.envelope.toolSignatures, envelope.toolSignatures).compatible
+        || !hasMarkerContinuationIntegrity(branch, markerHint.incrementalInput)) {
+        return undefined;
+      }
+
+      return {
+        branchId: branch.id,
+        responseId: branch.responseId,
+        comparison: {
+          kind: 'append',
+          matchedPrefixCount: 0,
+          appendedInput: [...markerHint.incrementalInput]
+        },
+        state: branch.state ? cloneBranchState(branch.state) : undefined
+      };
+    }
+
+    return undefined;
   }
 
   explainReuseMiss(
@@ -276,6 +324,11 @@ export class ResponseBranchStore {
     });
   }
 
+  isReuseDisabled(envelope: ResponseBranchReuseEnvelope): boolean {
+    this.evictExpiredEntries();
+    return this.disabledReuseKeys.has(envelope.identityKey);
+  }
+
   private evictExpiredEntries(): void {
     const now = Date.now();
 
@@ -373,6 +426,57 @@ function hasContinuationIntegrity(
       .filter(Boolean)
   );
   return [...functionCallIds].every((callId) => outputCallIds.has(callId));
+}
+
+function hasMarkerContinuationIntegrity(
+  branch: ResponseBranchEntry,
+  appendedInput: readonly ResponsesInputMessage[]
+): boolean {
+  const state = branch.state;
+  return Boolean(
+    state?.continuation
+    && state.continuation.responseId === branch.responseId
+    && state.continuation.turnId === state.turn.id
+    && state.continuation.toolPlanMode === branch.envelope.toolPlanMode
+    && Array.isArray(state.continuation.fullRequest.input)
+    && hasMatchingStoredRequestFingerprint(branch, state.continuation.fullRequest)
+    && hasContinuationIntegrity(branch, appendedInput)
+  );
+}
+
+function hasMatchingStoredRequestFingerprint(
+  branch: ResponseBranchEntry,
+  fullRequest: CodexContinuationSnapshot['fullRequest']
+): boolean {
+  let envelopeFingerprint: unknown;
+  try {
+    envelopeFingerprint = JSON.parse(branch.envelope.requestFingerprint);
+  } catch {
+    return false;
+  }
+
+  if (typeof envelopeFingerprint !== 'object' || envelopeFingerprint === null) {
+    return false;
+  }
+
+  const record = envelopeFingerprint as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  return keys.length === 2
+    && keys[0] === 'protocolSettings'
+    && keys[1] === 'requestFingerprint'
+    && typeof record.requestFingerprint === 'string'
+    && fingerprintCodexRequest(fullRequest) === record.requestFingerprint;
+}
+
+function haveEquivalentResponsesInput(
+  left: readonly ResponsesInputMessage[],
+  right: readonly ResponsesInputMessage[]
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return compareResponsesInputHistory(left, right).matchedPrefixCount === left.length;
 }
 
 function compareToolSignatures(

--- a/test/smokeConversationReuse.mjs
+++ b/test/smokeConversationReuse.mjs
@@ -378,6 +378,37 @@ function runStatefulMarkerBranchStoreSmokeTest(ResponseBranchStore) {
   assertEqual(exactMatch?.comparison.matchedPrefixCount, 0, 'marker lookup does not require historical prefix');
   assertEqual(JSON.stringify(exactMatch?.comparison.appendedInput), JSON.stringify(currentInput), 'exact marker returns complete delta');
 
+  const continuedBranchId = store.recordSuccess(
+    envelope,
+    currentInput,
+    'resp_marker_continued',
+    branchId,
+    createCompletedBranchState(envelope, currentInput, 'resp_marker_continued')
+  );
+  assertEqual(continuedBranchId === branchId, false, 'continuation creates a new immutable marker anchor');
+  assertEqual(store.findReusableBranch(envelope, currentInput, {
+    responseId: 'resp_marker_exact',
+    incrementalInput: currentInput
+  })?.branchId, branchId, 'older emitted marker remains reusable after continuation');
+  const siblingInput = [{ type: 'message', role: 'user', content: 'sibling follow up' }];
+  const siblingBranchId = store.recordSuccess(
+    envelope,
+    siblingInput,
+    'resp_marker_sibling',
+    branchId,
+    createCompletedBranchState(envelope, siblingInput, 'resp_marker_sibling')
+  );
+  assertEqual(siblingBranchId === branchId || siblingBranchId === continuedBranchId, false, 'same-anchor sibling continuation gets an independent branch');
+  assertEqual(store.findReusableBranch(envelope, siblingInput, {
+    responseId: 'resp_marker_exact',
+    incrementalInput: siblingInput
+  })?.branchId, branchId, 'source marker survives sibling continuation recording');
+  const nextInput = [{ type: 'message', role: 'user', content: 'continue from child' }];
+  assertEqual(store.findReusableBranch(envelope, nextInput, {
+    responseId: 'resp_marker_continued',
+    incrementalInput: nextInput
+  })?.branchId, continuedBranchId, 'new continuation marker resolves independently');
+
   const alternateInput = [{ type: 'message', role: 'user', content: 'alternate seed' }];
   store.recordSuccess(envelope, alternateInput, 'resp_marker_alternate');
   assertEqual(store.findReusableBranch(envelope, currentInput, {

--- a/test/smokeConversationReuse.mjs
+++ b/test/smokeConversationReuse.mjs
@@ -32,6 +32,7 @@ class MockLanguageModelDataPart {
   static text(value, mimeType = 'text/plain') {
     return new MockLanguageModelDataPart(textEncoder.encode(value), mimeType);
   }
+
 }
 
 class MockLanguageModelToolResultPart {
@@ -56,7 +57,8 @@ const vscodeStub = {
   LanguageModelToolCallPart: MockLanguageModelToolCallPart,
   LanguageModelChatMessageRole: {
     User: 1,
-    Assistant: 2
+    Assistant: 2,
+    System: 3
   },
   LanguageModelChatToolMode: {
     Required: 2
@@ -101,7 +103,12 @@ Module._load = function patchedLoad(request, parent, isMain) {
   return moduleLoad.call(this, request, parent, isMain);
 };
 
-const { compareResponsesInputHistory, convertMessagesToResponsesInput, stableSerialize } = require(compareBundlePath);
+const {
+  compareResponsesInputHistory,
+  convertMessagesToResponsesInput,
+  convertMessagesToResponsesInputWithStatefulMarker,
+  stableSerialize
+} = require(compareBundlePath);
 const { ResponseBranchStore } = require(branchStoreBundlePath);
 const { buildResponseBranchReuseEnvelope, buildResponseBranchToolSignatures, getReasoningEffort } = require(providerBundlePath);
 
@@ -110,6 +117,9 @@ try {
   runReasoningEffortOptionSmokeTest(getReasoningEffort);
   runCompareHistorySmokeTest(compareResponsesInputHistory);
   runToolCallIdCanonicalizationSmokeTest(compareResponsesInputHistory);
+  runLegacyRuntimeSystemConversionSmokeTest(convertMessagesToResponsesInput);
+  runStatefulMarkerConversionSmokeTest(convertMessagesToResponsesInputWithStatefulMarker);
+  runStatefulMarkerBranchStoreSmokeTest(ResponseBranchStore);
   runBranchStoreSmokeTest(ResponseBranchStore);
   runInputBudgetReuseSmokeTest(buildResponseBranchReuseEnvelope, ResponseBranchStore);
   runBranchStoreDisableReuseSmokeTest(ResponseBranchStore);
@@ -236,6 +246,259 @@ function runToolCallIdCanonicalizationSmokeTest(compareResponsesInputHistory) {
   assertEqual(comparison.kind, 'append', 'call id drift comparison kind');
   assertEqual(comparison.matchedPrefixCount, previousInput.length, 'call id drift matched prefix count');
   assertEqual(JSON.stringify(comparison.appendedInput), JSON.stringify([currentInput[4]]), 'call id drift delta');
+}
+
+function runLegacyRuntimeSystemConversionSmokeTest(convertMessagesToResponsesInput) {
+  const converted = convertMessagesToResponsesInput([{
+    role: vscodeStub.LanguageModelChatMessageRole.System,
+    content: [new vscodeStub.LanguageModelTextPart('Runtime instructions')]
+  }]);
+  assertEqual(JSON.stringify(converted), JSON.stringify([{
+    role: 'assistant',
+    content: 'Runtime instructions',
+    type: 'message'
+  }]), 'legacy conversion remains unchanged before provider marker integration');
+}
+
+function runStatefulMarkerConversionSmokeTest(convertMessagesToResponsesInputWithStatefulMarker) {
+  const official = convertMessagesToResponsesInputWithStatefulMarker([
+    {
+      role: vscodeStub.LanguageModelChatMessageRole.Assistant,
+      content: [vscodeStub.LanguageModelDataPart.text('codex::gpt-5.6-sol\\resp_official', 'Stateful_Marker')]
+    },
+    {
+      role: vscodeStub.LanguageModelChatMessageRole.System,
+      content: [new vscodeStub.LanguageModelTextPart(' Runtime Agent instructions. ')]
+    },
+    {
+      role: vscodeStub.LanguageModelChatMessageRole.User,
+      content: [new vscodeStub.LanguageModelTextPart('Only this delta')]
+    }
+  ]);
+  assertEqual(official.statefulMarker.kind, 'valid', 'official marker is valid');
+  assertEqual(official.statefulMarker.modelId, 'codex::gpt-5.6-sol', 'official marker model id');
+  assertEqual(official.statefulMarker.previousResponseId, 'resp_official', 'official marker response id');
+  assertEqual(official.statefulMarker.isLeadingStandalone, true, 'official marker is a leading standalone anchor');
+  assertEqual(official.systemInstructions, 'Runtime Agent instructions.', 'runtime System instructions are extracted');
+  assertEqual(JSON.stringify(official.input), JSON.stringify([
+    { role: 'user', content: 'Only this delta', type: 'message' }
+  ]), 'System and marker are excluded from current input');
+  assertEqual(JSON.stringify(official.statefulMarker.incrementalInput), JSON.stringify(official.input), 'official delta equals sanitized input');
+
+  const firstDelimiter = convertMessagesToResponsesInputWithStatefulMarker([{
+    role: vscodeStub.LanguageModelChatMessageRole.Assistant,
+    content: [vscodeStub.LanguageModelDataPart.text('model-a\\resp\\with-delimiter', 'stateful_marker')]
+  }]);
+  assertEqual(firstDelimiter.statefulMarker.modelId, 'model-a', 'marker model ends at first delimiter');
+  assertEqual(firstDelimiter.statefulMarker.previousResponseId, 'resp\\with-delimiter', 'marker response id retains later delimiters');
+
+  const sameMessageRemainder = convertMessagesToResponsesInputWithStatefulMarker([
+    {
+      role: vscodeStub.LanguageModelChatMessageRole.Assistant,
+      content: [
+        vscodeStub.LanguageModelDataPart.text('model-a\\resp_same_message', 'stateful_marker'),
+        new vscodeStub.LanguageModelTextPart('assistant delta')
+      ]
+    },
+    {
+      role: vscodeStub.LanguageModelChatMessageRole.User,
+      content: [new vscodeStub.LanguageModelTextPart('later delta')]
+    }
+  ]);
+  assertEqual(JSON.stringify(sameMessageRemainder.statefulMarker.incrementalInput), JSON.stringify([
+    { role: 'assistant', content: 'assistant delta', type: 'message' },
+    { role: 'user', content: 'later delta', type: 'message' }
+  ]), 'structural delta includes the marker message remainder and later messages');
+
+  const invalidMarkers = [
+    vscodeStub.LanguageModelDataPart.text('missing-delimiter', 'stateful_marker'),
+    vscodeStub.LanguageModelDataPart.text('\\resp_empty_model', 'stateful_marker'),
+    vscodeStub.LanguageModelDataPart.text('model-empty-response\\', 'stateful_marker'),
+    new vscodeStub.LanguageModelDataPart(new Uint8Array([0xc3, 0x28]), 'stateful_marker'),
+    new vscodeStub.LanguageModelDataPart(new Uint8Array(4097), 'stateful_marker'),
+    vscodeStub.LanguageModelDataPart.text(`${'m'.repeat(513)}\\resp_large_model`, 'stateful_marker'),
+    vscodeStub.LanguageModelDataPart.text(`model-large-response\\${'r'.repeat(513)}`, 'stateful_marker'),
+    vscodeStub.LanguageModelDataPart.text('model-control\u0001\\resp_control', 'stateful_marker'),
+    vscodeStub.LanguageModelDataPart.text('model-whitespace\\ resp_whitespace', 'stateful_marker')
+  ];
+  for (const [index, marker] of invalidMarkers.entries()) {
+    const converted = convertMessagesToResponsesInputWithStatefulMarker([{
+      role: vscodeStub.LanguageModelChatMessageRole.User,
+      content: [
+        new vscodeStub.LanguageModelTextPart('safe'),
+        marker,
+        new vscodeStub.LanguageModelTextPart(' input')
+      ]
+    }]);
+    assertEqual(converted.statefulMarker.kind, 'invalid', `invalid marker ${index} fails closed`);
+    assertEqual(converted.statefulMarker.reason, 'metadata', `invalid marker ${index} metadata reason`);
+    assertEqual(converted.statefulMarker.isLeadingStandalone, false, `invalid marker ${index} is embedded`);
+    assertEqual(JSON.stringify(converted.input), JSON.stringify([
+      { role: 'user', content: 'safe input', type: 'message' }
+    ]), `invalid marker ${index} is stripped`);
+  }
+
+  const duplicate = convertMessagesToResponsesInputWithStatefulMarker([{
+    role: vscodeStub.LanguageModelChatMessageRole.Assistant,
+    content: [
+      vscodeStub.LanguageModelDataPart.text('model-one\\resp_one', 'stateful_marker'),
+      vscodeStub.LanguageModelDataPart.text('model-two\\resp_two', 'STATEFUL_MARKER')
+    ]
+  }]);
+  assertEqual(duplicate.statefulMarker.kind, 'invalid', 'duplicate markers fail closed');
+  assertEqual(duplicate.statefulMarker.reason, 'multiple', 'duplicate markers report multiple');
+  assertEqual(duplicate.statefulMarker.isLeadingStandalone, true, 'duplicate leading anchor is classified for local failure');
+  assertEqual(JSON.stringify(duplicate.input), '[]', 'duplicate markers are stripped');
+
+  const nested = convertMessagesToResponsesInputWithStatefulMarker([{
+    role: vscodeStub.LanguageModelChatMessageRole.User,
+    content: [new vscodeStub.LanguageModelToolResultPart('call_nested_marker', [
+      vscodeStub.LanguageModelDataPart.text('model-nested\\resp_nested', 'stateful_marker'),
+      new vscodeStub.LanguageModelTextPart('safe tool output')
+    ])]
+  }]);
+  assertEqual(nested.statefulMarker.kind, 'none', 'nested marker never anchors');
+  assertEqual(JSON.stringify(nested.input), JSON.stringify([
+    { type: 'function_call_output', call_id: 'call_nested_marker', output: 'safe tool output' }
+  ]), 'nested marker is suppressed from tool output');
+}
+
+function runStatefulMarkerBranchStoreSmokeTest(ResponseBranchStore) {
+  const envelope = reuseEnvelope('reuse-key-marker');
+  const previousInput = [{ type: 'message', role: 'user', content: 'seed' }];
+  const currentInput = [{ type: 'message', role: 'user', content: 'follow up' }];
+  const store = createTestResponseBranchStore(ResponseBranchStore);
+  const branchId = store.recordSuccess(envelope, previousInput, 'resp_marker_exact');
+  const exactMatch = store.findReusableBranch(envelope, currentInput, {
+    responseId: 'resp_marker_exact',
+    incrementalInput: currentInput
+  });
+  assertEqual(exactMatch?.branchId, branchId, 'exact marker branch id');
+  assertEqual(exactMatch?.responseId, 'resp_marker_exact', 'exact marker response id');
+  assertEqual(exactMatch?.comparison.matchedPrefixCount, 0, 'marker lookup does not require historical prefix');
+  assertEqual(JSON.stringify(exactMatch?.comparison.appendedInput), JSON.stringify(currentInput), 'exact marker returns complete delta');
+
+  const alternateInput = [{ type: 'message', role: 'user', content: 'alternate seed' }];
+  store.recordSuccess(envelope, alternateInput, 'resp_marker_alternate');
+  assertEqual(store.findReusableBranch(envelope, currentInput, {
+    responseId: 'resp_unknown',
+    incrementalInput: currentInput
+  }), undefined, 'unknown marker id never falls through');
+  assertEqual(store.findReusableBranch(envelope, currentInput, {
+    responseId: 'resp_marker_exact',
+    incrementalInput: [{ type: 'message', role: 'user', content: 'different delta' }]
+  }), undefined, 'marker suffix mismatch never falls through');
+
+  const compatibilityCases = [
+    { label: 'request envelope mismatch', envelope: { ...envelope, identityKey: 'changed-identity', requestFingerprint: 'changed-fingerprint' } },
+    { label: 'instruction mismatch', envelope: { ...envelope, identityKey: 'changed-instructions', requestFingerprint: 'changed-instructions' } },
+    { label: 'catalog mismatch', envelope: { ...envelope, catalogHash: 'changed-catalog' } },
+    { label: 'tool plan mismatch', envelope: { ...envelope, toolPlanMode: 'native-hosted' } },
+    { label: 'tool mismatch', envelope: { ...envelope, toolSignatures: { read_file: 'changed-tool' } } },
+    { label: 'budget downgrade', envelope: { ...envelope, effectiveInputBudget: 128000 } }
+  ];
+  for (const compatibilityCase of compatibilityCases) {
+    assertEqual(store.findReusableBranch(compatibilityCase.envelope, currentInput, {
+      responseId: 'resp_marker_exact',
+      incrementalInput: currentInput
+    }), undefined, `${compatibilityCase.label} rejects an exact marker`);
+  }
+
+  store.disableReuse(envelope, false);
+  assertEqual(store.findReusableBranch(envelope, currentInput, {
+    responseId: 'resp_marker_exact',
+    incrementalInput: currentInput
+  }), undefined, 'disabled reuse rejects an exact marker');
+
+  const expiredStore = new ResponseBranchStore(0);
+  expiredStore.recordSuccess(
+    envelope,
+    previousInput,
+    'resp_marker_expired',
+    undefined,
+    createCompletedBranchState(envelope, previousInput, 'resp_marker_expired')
+  );
+  const originalNow = Date.now;
+  Date.now = () => originalNow() + 1;
+  try {
+    assertEqual(expiredStore.findReusableBranch(envelope, currentInput, {
+      responseId: 'resp_marker_expired',
+      incrementalInput: currentInput
+    }), undefined, 'expired exact marker fails closed');
+  } finally {
+    Date.now = originalNow;
+  }
+
+  const incompleteStore = new ResponseBranchStore();
+  const incompleteState = createCompletedBranchState(envelope, previousInput, 'resp_marker_incomplete');
+  incompleteState.turn.completed = false;
+  incompleteStore.recordSuccess(envelope, previousInput, 'resp_marker_incomplete', undefined, incompleteState);
+  assertEqual(incompleteStore.findReusableBranch(envelope, currentInput, {
+    responseId: 'resp_marker_incomplete',
+    incrementalInput: currentInput
+  }), undefined, 'incomplete turn rejects an exact marker');
+
+  const missingSnapshotStore = new ResponseBranchStore();
+  const missingSnapshotState = createCompletedBranchState(envelope, previousInput, 'resp_marker_missing_snapshot');
+  delete missingSnapshotState.continuation;
+  missingSnapshotStore.recordSuccess(envelope, previousInput, 'resp_marker_missing_snapshot', undefined, missingSnapshotState);
+  assertEqual(missingSnapshotStore.findReusableBranch(envelope, currentInput, {
+    responseId: 'resp_marker_missing_snapshot',
+    incrementalInput: currentInput
+  }), undefined, 'missing continuation snapshot rejects an exact marker');
+
+  const malformedFingerprintEnvelope = {
+    ...envelope,
+    identityKey: 'reuse-key-marker-malformed-fingerprint',
+    requestFingerprint: JSON.stringify({ requestFingerprint: fingerprintFullRequest() })
+  };
+  const malformedFingerprintStore = new ResponseBranchStore();
+  malformedFingerprintStore.recordSuccess(
+    malformedFingerprintEnvelope,
+    previousInput,
+    'resp_marker_malformed_fingerprint',
+    undefined,
+    createCompletedBranchState(
+      malformedFingerprintEnvelope,
+      previousInput,
+      'resp_marker_malformed_fingerprint'
+    )
+  );
+  assertEqual(malformedFingerprintStore.findReusableBranch(malformedFingerprintEnvelope, currentInput, {
+    responseId: 'resp_marker_malformed_fingerprint',
+    incrementalInput: currentInput
+  }), undefined, 'malformed protocol fingerprint wrapper rejects an exact marker');
+
+  const pendingStore = createTestResponseBranchStore(ResponseBranchStore);
+  const pendingEnvelope = reuseEnvelope('reuse-key-marker-pending');
+  const pendingItems = [
+    { type: 'function_call', call_id: 'call_pending_one', name: 'read_file', arguments: '{}' },
+    { type: 'function_call', call_id: 'call_pending_two', name: 'list_dir', arguments: '{}' }
+  ];
+  pendingStore.recordSuccess(
+    pendingEnvelope,
+    previousInput,
+    'resp_marker_pending',
+    undefined,
+    createCompletedBranchState(pendingEnvelope, previousInput, 'resp_marker_pending', pendingItems)
+  );
+  const completeOutputs = [
+    { type: 'function_call_output', call_id: 'call_pending_one', output: 'one' },
+    { type: 'function_call_output', call_id: 'call_pending_two', output: 'two' }
+  ];
+  assertEqual(pendingStore.findReusableBranch(pendingEnvelope, completeOutputs, {
+    responseId: 'resp_marker_pending',
+    incrementalInput: completeOutputs
+  })?.responseId, 'resp_marker_pending', 'exact marker accepts complete pending-call outputs');
+  const noOutputs = [{ type: 'message', role: 'user', content: 'skip the calls' }];
+  assertEqual(pendingStore.findReusableBranch(pendingEnvelope, noOutputs, {
+    responseId: 'resp_marker_pending',
+    incrementalInput: noOutputs
+  }), undefined, 'exact marker rejects unanswered pending calls');
+  assertEqual(pendingStore.findReusableBranch(pendingEnvelope, [completeOutputs[0]], {
+    responseId: 'resp_marker_pending',
+    incrementalInput: [completeOutputs[0]]
+  }), undefined, 'exact marker rejects partial pending-call outputs');
 }
 
 function runBranchStoreSmokeTest(ResponseBranchStore) {
@@ -677,35 +940,40 @@ function createTestResponseBranchStore(ResponseBranchStore) {
     input,
     responseId,
     branchId,
-    state ?? {
-      identity: {
-        installationId: 'test-installation',
-        sessionId: 'test-session',
-        threadId: 'test-thread',
-        windowId: 'test-window'
-      },
-      turn: {
-        id: `turn-${responseId}`,
-        startedAt: Date.now(),
-        completed: true
-      },
-      continuation: {
-        fullRequest: {
-          model: 'test-model',
-          instructions: 'Smoke test instructions',
-          input,
-          store: false,
-          stream: true
-        },
-        responseId,
-        responseItems: [],
-        requestFingerprint: envelope.requestFingerprint,
-        turnId: `turn-${responseId}`
-      },
-      updatedAt: Date.now()
-    }
+    state ?? createCompletedBranchState(envelope, input, responseId)
   );
   return store;
+}
+
+function createCompletedBranchState(envelope, input, responseId, responseItems = []) {
+  return {
+    identity: {
+      installationId: 'test-installation',
+      sessionId: 'test-session',
+      threadId: 'test-thread',
+      windowId: 'test-window'
+    },
+    turn: {
+      id: `turn-${responseId}`,
+      startedAt: Date.now(),
+      completed: true
+    },
+    continuation: {
+      fullRequest: {
+        model: 'test-model',
+        instructions: 'Smoke test instructions',
+        input,
+        store: false,
+        stream: true
+      },
+      responseId,
+      responseItems,
+      requestFingerprint: envelope.requestFingerprint,
+      catalogHash: envelope.catalogHash,
+      turnId: `turn-${responseId}`
+    },
+    updatedAt: Date.now()
+  };
 }
 
 function assertEqual(actual, expected, label) {
@@ -715,5 +983,18 @@ function assertEqual(actual, expected, label) {
 }
 
 function reuseEnvelope(identityKey, toolSignatures) {
-  return { identityKey, effectiveInputBudget: 258400, toolSignatures };
+  return {
+    identityKey,
+    scopeKey: identityKey,
+    requestFingerprint: JSON.stringify({
+      protocolSettings: null,
+      requestFingerprint: fingerprintFullRequest()
+    }),
+    effectiveInputBudget: 258400,
+    toolSignatures
+  };
+}
+
+function fingerprintFullRequest() {
+  return '{"instructions":"Smoke test instructions","model":"test-model","store":false,"stream":true}';
 }

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -72,6 +72,14 @@ class LanguageModelDataPart {
     this.data = data;
     this.mimeType = mimeType;
   }
+
+  static json(value, mimeType = 'application/json') {
+    return new LanguageModelDataPart(new TextEncoder().encode(JSON.stringify(value)), mimeType);
+  }
+
+  static text(value, mimeType = 'text/plain') {
+    return new LanguageModelDataPart(new TextEncoder().encode(value), mimeType);
+  }
 }
 
 class LanguageModelThinkingPart {
@@ -106,8 +114,9 @@ const vscodeMock = {
   LanguageModelToolCallPart,
   LanguageModelToolResultPart,
   LanguageModelChatMessageRole: {
-    User: 'user',
-    Assistant: 'assistant'
+    User: 1,
+    Assistant: 2,
+    System: 3
   },
   LanguageModelChatToolMode: {
     Required: 2
@@ -178,6 +187,12 @@ try {
   await runProviderLongContextSelectionSmokeTest();
   await runProviderFallbackSmokeTest();
   await runInterleavedResponsePresentationSmokeTest();
+  await runStatefulMarkerRoundTripSmokeTest();
+  await runStatefulMarkerContinuationRecoverySmokeTest();
+  await runStatefulMarkerOpaqueRecoverySmokeTest();
+  await runStatefulMarkerToolOutputReplaySmokeTest();
+  await runStatefulMarkerAutoFallbackOpaqueToolOutputRecoverySmokeTest();
+  await runStatefulMarkerRecordFailureSmokeTest();
   await runHttpContinuationRecoverySmokeTest();
   await runStructuredHttpContinuationRecoverySmokeTest();
   await runContinuationMissAfterVisibleOutputSmokeTest();
@@ -1067,6 +1082,765 @@ async function runInterleavedResponsePresentationSmokeTest() {
       { type: 'text', value: '我先看一下仓库的' },
       { type: 'text', value: '结构。' }
     ]), 'raw reasoning falls back as one bounded Thinking part before visible text');
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function runStatefulMarkerRoundTripSmokeTest() {
+  const responseRequests = [];
+  const replies = [
+    ['seed reply', 'resp_marker_seed', 'msg_marker_seed'],
+    ['second reply', 'resp_marker_second', 'msg_marker_second'],
+    ['third reply', 'resp_marker_third', 'msg_marker_third']
+  ];
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    responseRequests.push(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+    const reply = replies[responseRequests.length - 1];
+    if (!reply) {
+      response.writeHead(500, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: { message: 'Unexpected extra marker request.' } }));
+      return;
+    }
+    writeSseResponseWithOutputItem(response, reply[0], reply[1], reply[2]);
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+  const provider = new CodexModelProvider(
+    {
+      secrets: { async get() { return 'test-api-key'; } },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected model for official stateful marker coverage.');
+    }
+    const systemMessage = createSystemMessage('Agent Host instructions');
+
+    const seedParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        systemMessage,
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Initial input')] }
+      ],
+      {},
+      { report(part) { seedParts.push(part); } },
+      token
+    );
+    assertEqual(responseRequests[0].instructions, 'Smoke test instructions\n\nAgent Host instructions', 'configured and Agent Host instructions are preserved');
+    assertEqual(JSON.stringify(responseRequests[0].input), JSON.stringify([
+      { role: 'user', content: 'Initial input', type: 'message' }
+    ]), 'first Agent Host call sends only Responses input');
+    const seedMarkerPart = getSingleStatefulMarkerPart(seedParts, 'seed completion');
+    assertEqual(decodeStatefulMarker(seedMarkerPart), `${model.id}\\resp_marker_seed`, 'seed marker uses official text encoding');
+
+    const invalidCases = [
+      {
+        label: 'changed System instructions',
+        messages: createAgentHostContinuationMessages(seedMarkerPart, 'Changed Agent Host instructions', 'Changed instruction delta')
+      },
+      {
+        label: 'forged unknown response id',
+        messages: createAgentHostContinuationMessages(createStatefulMarkerPart(`${model.id}\\resp_forged`), 'Agent Host instructions', 'Forged delta')
+      },
+      {
+        label: 'model-mismatched marker',
+        messages: createAgentHostContinuationMessages(createStatefulMarkerPart('codex::gpt-5.6-luna\\resp_marker_seed'), 'Agent Host instructions', 'Wrong model delta')
+      },
+      {
+        label: 'malformed marker',
+        messages: createAgentHostContinuationMessages(createStatefulMarkerPart('missing-delimiter'), 'Agent Host instructions', 'Malformed delta')
+      },
+      {
+        label: 'duplicate leading marker',
+        messages: [
+          {
+            role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+            content: [seedMarkerPart, createStatefulMarkerPart(`${model.id}\\resp_other`)]
+          },
+          systemMessage,
+          { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Duplicate delta')] }
+        ]
+      }
+    ];
+    for (const invalidCase of invalidCases) {
+      await assertLocalMarkerFailure(
+        () => provider.provideLanguageModelChatResponse(model, invalidCase.messages, {}, { report() {} }, token),
+        responseRequests,
+        1,
+        invalidCase.label
+      );
+    }
+
+    const secondParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      createAgentHostContinuationMessages(seedMarkerPart, 'Agent Host instructions', 'Second delta'),
+      {},
+      { report(part) { secondParts.push(part); } },
+      token
+    );
+    const secondMarkerPart = getSingleStatefulMarkerPart(secondParts, 'second completion');
+
+    const thirdParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      createAgentHostContinuationMessages(secondMarkerPart, 'Agent Host instructions', 'Third delta'),
+      {},
+      { report(part) { thirdParts.push(part); } },
+      token
+    );
+    const thirdMarkerPart = getSingleStatefulMarkerPart(thirdParts, 'third completion');
+
+    assertEqual(responseRequests.length, 3, 'only valid official marker calls reach Responses');
+    assertEqual(responseRequests[1].previous_response_id, 'resp_marker_seed', 'second call selects exact local seed response');
+    assertEqual(JSON.stringify(responseRequests[1].input), JSON.stringify([
+      { role: 'user', content: 'Second delta', type: 'message' }
+    ]), 'second call sends marker-free delta only');
+    assertEqual(responseRequests[2].previous_response_id, 'resp_marker_second', 'third call selects accumulated second response');
+    assertEqual(JSON.stringify(responseRequests[2].input), JSON.stringify([
+      { role: 'user', content: 'Third delta', type: 'message' }
+    ]), 'third call sends marker-free delta only');
+    assertEqual(decodeStatefulMarker(secondMarkerPart), `${model.id}\\resp_marker_second`, 'second marker uses official text encoding');
+    assertEqual(decodeStatefulMarker(thirdMarkerPart), `${model.id}\\resp_marker_third`, 'third marker proves repeated accumulated continuation');
+
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + 10 * 60 * 1000 + 1;
+    try {
+      await assertLocalMarkerFailure(
+        () => provider.provideLanguageModelChatResponse(
+          model,
+          createAgentHostContinuationMessages(thirdMarkerPart, 'Agent Host instructions', 'Expired delta'),
+          {},
+          { report() {} },
+          token
+        ),
+        responseRequests,
+        3,
+        'expired marker'
+      );
+    } finally {
+      Date.now = originalNow;
+    }
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function runStatefulMarkerContinuationRecoverySmokeTest() {
+  const responseRequests = [];
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    responseRequests.push(body);
+    if (responseRequests.length === 1) {
+      writeSseResponseWithOutputItem(response, 'recovery seed reply', 'resp_marker_recovery_seed', 'msg_marker_recovery_seed');
+      return;
+    }
+    if (responseRequests.length === 2 && body.previous_response_id) {
+      response.writeHead(400, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        error: {
+          type: 'invalid_request_error',
+          code: 'previous_response_not_found',
+          message: 'Untrusted remote detail.',
+          param: 'previous_response_id'
+        }
+      }));
+      return;
+    }
+    if (responseRequests.length === 3) {
+      writeSseResponseWithOutputItem(response, 'recovered reply', 'resp_marker_recovered', 'msg_marker_recovered');
+      return;
+    }
+    if (responseRequests.length === 4) {
+      writeSseResponseWithOutputItem(response, 'post-recovery reply', 'resp_marker_after_recovery', 'msg_marker_after_recovery');
+      return;
+    }
+    response.writeHead(500, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ error: { message: 'Unexpected marker recovery request.' } }));
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+  const provider = new CodexModelProvider(
+    {
+      secrets: { async get() { return 'test-api-key'; } },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected model for official stateful marker recovery coverage.');
+    }
+
+    const seedParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [createSystemMessage('Recovery instructions'), {
+        role: vscodeMock.LanguageModelChatMessageRole.User,
+        content: [new vscodeMock.LanguageModelTextPart('Recovery seed')]
+      }],
+      {},
+      { report(part) { seedParts.push(part); } },
+      token
+    );
+    const seedMarkerPart = getSingleStatefulMarkerPart(seedParts, 'recovery seed');
+
+    const recoveredParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      createAgentHostContinuationMessages(seedMarkerPart, 'Recovery instructions', 'Recovery delta'),
+      {},
+      { report(part) { recoveredParts.push(part); } },
+      token
+    );
+    const recoveredMarkerPart = getSingleStatefulMarkerPart(recoveredParts, 'recovered completion');
+
+    assertEqual(responseRequests.length, 3, 'marker continuation miss retries once');
+    assertEqual(responseRequests[1].previous_response_id, 'resp_marker_recovery_seed', 'marker continuation attempts exact stored response id');
+    assertEqual(JSON.stringify(responseRequests[1].input), JSON.stringify([
+      { role: 'user', content: 'Recovery delta', type: 'message' }
+    ]), 'marker continuation attempt is incremental');
+    assertEqual('previous_response_id' in responseRequests[2], false, 'marker recovery full replay omits previous response id');
+    assertEqual(JSON.stringify(responseRequests[2].input), JSON.stringify([
+      { role: 'user', content: 'Recovery seed', type: 'message' },
+      { id: 'msg_marker_recovery_seed', type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'recovery seed reply' }] },
+      { role: 'user', content: 'Recovery delta', type: 'message' }
+    ]), 'marker recovery uses canonical local snapshot input plus response item plus delta');
+    assertEqual(decodeStatefulMarker(recoveredMarkerPart), `${model.id}\\resp_marker_recovered`, 'only recovered completion emits a marker');
+
+    const finalParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      createAgentHostContinuationMessages(recoveredMarkerPart, 'Recovery instructions', 'After recovery delta'),
+      {},
+      { report(part) { finalParts.push(part); } },
+      token
+    );
+    assertEqual(responseRequests.length, 4, 'post-recovery marker reaches backend once');
+    assertEqual(responseRequests[3].previous_response_id, 'resp_marker_recovered', 'post-recovery marker selects the newly accumulated snapshot');
+    assertEqual(JSON.stringify(responseRequests[3].input), JSON.stringify([
+      { role: 'user', content: 'After recovery delta', type: 'message' }
+    ]), 'post-recovery continuation remains delta only');
+    assertEqual(decodeStatefulMarker(getSingleStatefulMarkerPart(finalParts, 'post-recovery completion')), `${model.id}\\resp_marker_after_recovery`, 'post-recovery marker is emitted');
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function runStatefulMarkerToolOutputReplaySmokeTest() {
+  const responseRequests = [];
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    responseRequests.push(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+    if (responseRequests.length === 1) {
+      response.writeHead(200, {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive'
+      });
+      const send = (event) => response.write(`data: ${JSON.stringify(event)}\n\n`);
+      send({
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'fc_marker_tool',
+          type: 'function_call',
+          call_id: 'call_marker_tool',
+          name: 'read_file',
+          arguments: '{"filePath":"src/provider.ts"}'
+        }
+      });
+      send({ type: 'response.completed', response: { id: 'resp_marker_tool_seed', status: 'completed' } });
+      response.write('data: [DONE]\n\n');
+      response.end();
+      return;
+    }
+    writeSseResponseWithOutputItem(response, 'tool result accepted', 'resp_marker_tool_done', 'msg_marker_tool_done');
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+  const provider = new CodexModelProvider(
+    {
+      secrets: { async get() { return 'test-api-key'; } },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected model for stateful marker tool-output replay coverage.');
+    }
+
+    const seedParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [createSystemMessage('Tool marker instructions'), {
+        role: vscodeMock.LanguageModelChatMessageRole.User,
+        content: [new vscodeMock.LanguageModelTextPart('Read the provider file')]
+      }],
+      { tools: [{ name: 'read_file', description: 'Reads a file.', inputSchema: { type: 'object' } }] },
+      { report(part) { seedParts.push(part); } },
+      token
+    );
+    const markerPart = getSingleStatefulMarkerPart(seedParts, 'tool marker seed');
+
+    const resultParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+          content: [markerPart]
+        },
+        createSystemMessage('Tool marker instructions'),
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.User,
+          content: [new vscodeMock.LanguageModelToolResultPart(
+            'call_marker_tool',
+            [new vscodeMock.LanguageModelTextPart('provider source')]
+          )]
+        }
+      ],
+      { tools: [{ name: 'read_file', description: 'Reads a file.', inputSchema: { type: 'object' } }] },
+      { report(part) { resultParts.push(part); } },
+      token
+    );
+
+    assertEqual(responseRequests.length, 2, 'HTTP marker tool-output request count');
+    assertEqual('previous_response_id' in responseRequests[1], false, 'HTTP marker tool output uses canonical full replay');
+    assertEqual(JSON.stringify(responseRequests[1].input), JSON.stringify([
+      { role: 'user', content: 'Read the provider file', type: 'message' },
+      {
+        id: 'fc_marker_tool',
+        type: 'function_call',
+        call_id: 'call_marker_tool',
+        name: 'read_file',
+        arguments: '{"filePath":"src/provider.ts"}'
+      },
+      { type: 'function_call_output', call_id: 'call_marker_tool', output: 'provider source' }
+    ]), 'HTTP marker tool output replays prior input, stored call, and current output');
+    assertEqual(
+      decodeStatefulMarker(getSingleStatefulMarkerPart(resultParts, 'tool marker completion')),
+      `${model.id}\\resp_marker_tool_done`,
+      'HTTP marker tool replay emits the completed marker'
+    );
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function runStatefulMarkerAutoFallbackOpaqueToolOutputRecoverySmokeTest() {
+  const responseRequests = [];
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+    if (request.method === 'GET') {
+      response.writeHead(426);
+      response.end();
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    responseRequests.push(body);
+    if (responseRequests.length === 1) {
+      response.writeHead(200, {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive'
+      });
+      const send = (event) => response.write(`data: ${JSON.stringify(event)}\n\n`);
+      const item = {
+        id: 'fc_marker_auto_opaque',
+        type: 'function_call',
+        call_id: 'call_marker_auto_opaque',
+        name: 'read_file',
+        arguments: '{"filePath":"src/provider.ts"}'
+      };
+      send({ type: 'response.output_item.added', output_index: 0, item });
+      send({
+        type: 'response.function_call_arguments.done',
+        item_id: item.id,
+        output_index: 0,
+        name: item.name,
+        arguments: item.arguments
+      });
+      send({ type: 'response.output_item.done', output_index: 0, item });
+      send({ type: 'response.completed', response: { id: 'resp_marker_auto_opaque_seed', status: 'completed' } });
+      response.write('data: [DONE]\n\n');
+      response.end();
+      return;
+    }
+    if (responseRequests.length === 2 && body.previous_response_id) {
+      response.writeHead(400);
+      response.end();
+      return;
+    }
+    const responseIndex = responseRequests.length;
+    writeSseResponseWithOutputItem(
+      response,
+      responseIndex === 3 ? 'opaque tool recovery accepted' : 'opaque disable follow-up accepted',
+      responseIndex === 3 ? 'resp_marker_auto_opaque_recovered' : 'resp_marker_auto_opaque_followup',
+      responseIndex === 3 ? 'msg_marker_auto_opaque_recovered' : 'msg_marker_auto_opaque_followup'
+    );
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'auto';
+  const provider = new CodexModelProvider(
+    {
+      secrets: { async get() { return 'test-api-key'; } },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+  const tools = [{ name: 'read_file', description: 'Reads a file.', inputSchema: { type: 'object' } }];
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected model for auto-fallback opaque tool-output recovery coverage.');
+    }
+
+    const seedParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [createSystemMessage('Auto opaque tool instructions'), {
+        role: vscodeMock.LanguageModelChatMessageRole.User,
+        content: [new vscodeMock.LanguageModelTextPart('Read through auto fallback')]
+      }],
+      { tools },
+      { report(part) { seedParts.push(part); } },
+      token
+    );
+    const markerPart = getSingleStatefulMarkerPart(seedParts, 'auto opaque tool seed');
+
+    const recoveredParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+          content: [markerPart]
+        },
+        createSystemMessage('Auto opaque tool instructions'),
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.User,
+          content: [new vscodeMock.LanguageModelToolResultPart(
+            'call_marker_auto_opaque',
+            [new vscodeMock.LanguageModelTextPart('provider source through auto fallback')]
+          )]
+        }
+      ],
+      { tools },
+      { report(part) { recoveredParts.push(part); } },
+      token
+    );
+
+    assertEqual(responseRequests.length, 3, 'auto opaque tool recovery sends seed, incremental, and canonical HTTP requests');
+    assertEqual(
+      responseRequests[1].previous_response_id,
+      'resp_marker_auto_opaque_seed',
+      'auto fallback first attempts incremental tool-output continuation'
+    );
+    assertEqual(JSON.stringify(responseRequests[1].input), JSON.stringify([
+      { type: 'function_call_output', call_id: 'call_marker_auto_opaque', output: 'provider source through auto fallback' }
+    ]), 'auto fallback sends only the incremental tool output before opaque rejection');
+    assertEqual('previous_response_id' in responseRequests[2], false, 'auto opaque tool recovery omits the rejected response id');
+    assertEqual(JSON.stringify(responseRequests[2].input), JSON.stringify([
+      { role: 'user', content: 'Read through auto fallback', type: 'message' },
+      {
+        id: 'fc_marker_auto_opaque',
+        type: 'function_call',
+        call_id: 'call_marker_auto_opaque',
+        name: 'read_file',
+        arguments: '{"filePath":"src/provider.ts"}'
+      },
+      { type: 'function_call_output', call_id: 'call_marker_auto_opaque', output: 'provider source through auto fallback' }
+    ]), 'auto opaque tool recovery replays the canonical call and output exactly once');
+    assertEqual(
+      getStatefulMarkers(recoveredParts).length,
+      0,
+      'auto opaque tool recovery emits no marker while reuse remains disabled until expiry'
+    );
+
+    const followUpParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        createSystemMessage('Auto opaque tool instructions'),
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.User,
+          content: [new vscodeMock.LanguageModelTextPart('Read through auto fallback')]
+        },
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+          content: [new vscodeMock.LanguageModelToolCallPart(
+            'call_marker_auto_opaque',
+            'read_file',
+            { filePath: 'src/provider.ts' }
+          )]
+        },
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.User,
+          content: [new vscodeMock.LanguageModelToolResultPart(
+            'call_marker_auto_opaque',
+            [new vscodeMock.LanguageModelTextPart('provider source through auto fallback')]
+          )]
+        },
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+          content: [new vscodeMock.LanguageModelTextPart('opaque tool recovery accepted')]
+        },
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.User,
+          content: [new vscodeMock.LanguageModelTextPart('Continue after opaque tool recovery')]
+        }
+      ],
+      { tools },
+      { report(part) { followUpParts.push(part); } },
+      token
+    );
+    assertEqual(responseRequests.length, 4, 'opaque disable follow-up reaches HTTP once');
+    assertEqual(
+      'previous_response_id' in responseRequests[3],
+      false,
+      'opaque disable follow-up does not reuse the recovered response before expiry'
+    );
+    assertEqual(
+      getStatefulMarkers(followUpParts).length,
+      0,
+      'opaque disable follow-up still emits no marker before expiry'
+    );
+  } finally {
+    configValues.transport = 'http';
+    await closeServer(server);
+  }
+}
+
+async function runStatefulMarkerOpaqueRecoverySmokeTest() {
+  const responseRequests = [];
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    responseRequests.push(body);
+    if (responseRequests.length === 1) {
+      writeSseResponseWithOutputItem(response, 'opaque seed reply', 'resp_marker_opaque_seed', 'msg_marker_opaque_seed');
+      return;
+    }
+    if (responseRequests.length === 2 && body.previous_response_id) {
+      response.writeHead(400);
+      response.end();
+      return;
+    }
+    writeSseResponseWithOutputItem(response, 'opaque recovery reply', 'resp_marker_opaque_recovered', 'msg_marker_opaque_recovered');
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+  const provider = new CodexModelProvider(
+    {
+      secrets: { async get() { return 'test-api-key'; } },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected model for opaque stateful marker recovery coverage.');
+    }
+
+    const seedParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [createSystemMessage('Opaque recovery instructions'), {
+        role: vscodeMock.LanguageModelChatMessageRole.User,
+        content: [new vscodeMock.LanguageModelTextPart('Opaque seed')]
+      }],
+      {},
+      { report(part) { seedParts.push(part); } },
+      token
+    );
+    const seedMarkerPart = getSingleStatefulMarkerPart(seedParts, 'opaque recovery seed');
+
+    const recoveredParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      createAgentHostContinuationMessages(seedMarkerPart, 'Opaque recovery instructions', 'Opaque delta'),
+      {},
+      { report(part) { recoveredParts.push(part); } },
+      token
+    );
+
+    assertEqual(responseRequests.length, 3, 'opaque marker continuation retries once');
+    assertEqual(responseRequests[1].previous_response_id, 'resp_marker_opaque_seed', 'opaque recovery first attempts the stored response');
+    assertEqual('previous_response_id' in responseRequests[2], false, 'opaque recovery replays without previous response id');
+    assertEqual(JSON.stringify(responseRequests[2].input), JSON.stringify([
+      { role: 'user', content: 'Opaque seed', type: 'message' },
+      { id: 'msg_marker_opaque_seed', type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'opaque seed reply' }] },
+      { role: 'user', content: 'Opaque delta', type: 'message' }
+    ]), 'opaque recovery uses the canonical local snapshot');
+    assertEqual(getStatefulMarkers(recoveredParts).length, 0, 'opaque HTTP rejection emits no marker while reuse remains disabled');
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function runStatefulMarkerRecordFailureSmokeTest() {
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+
+    for await (const _chunk of request) {
+      // Drain the request body before completing the response.
+    }
+    writeSseResponse(response, 'completed before local record failure', 'resp_marker_record_failure');
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+  const provider = new CodexModelProvider(
+    {
+      secrets: { async get() { return 'test-api-key'; } },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected model for stateful marker record-failure coverage.');
+    }
+
+    provider.responseBranchStore.recordSuccess = () => {
+      throw new Error('Synthetic branch record failure');
+    };
+    const parts = [];
+    let failureMessage = '';
+    try {
+      await provider.provideLanguageModelChatResponse(
+        model,
+        [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Do not emit an unrecorded marker.')] }],
+        {},
+        { report(part) { parts.push(part); } },
+        token
+      );
+    } catch (error) {
+      failureMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    assertEqual(failureMessage, 'Synthetic branch record failure', 'branch record failure is surfaced');
+    assertEqual(getStatefulMarkers(parts).length, 0, 'branch record failure emits no stateful marker');
   } finally {
     await closeServer(server);
   }
@@ -2089,14 +2863,16 @@ async function runCreatedResponseCancellationDoesNotRecordBranchSmokeTest() {
     }
 
     canceledToken = createMutableCancellationToken();
+    const createdOnlyParts = [];
     await provider.provideLanguageModelChatResponse(
       model,
       [{ role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Cancel this turn.')] }],
       {},
-      { report() {} },
+      { report(part) { createdOnlyParts.push(part); } },
       canceledToken
     );
     assertEqual(canceledToken.isCancellationRequested, true, 'response.created triggers deterministic cancellation');
+    assertEqual(getStatefulMarkers(createdOnlyParts).length, 0, 'created-only cancellation emits no marker');
 
     await provider.provideLanguageModelChatResponse(
       model,
@@ -2320,6 +3096,28 @@ function writeSseResponse(response, text, responseId) {
   response.end();
 }
 
+function writeSseResponseWithOutputItem(response, text, responseId, itemId) {
+  response.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive'
+  });
+  response.write(`data: ${JSON.stringify({ type: 'response.output_text.delta', delta: text })}\n\n`);
+  response.write(`data: ${JSON.stringify({
+    type: 'response.output_item.done',
+    output_index: 0,
+    item: {
+      id: itemId,
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text }]
+    }
+  })}\n\n`);
+  response.write(`data: ${JSON.stringify({ type: 'response.completed', response: { id: responseId, object: 'response', status: 'completed' } })}\n\n`);
+  response.write('data: [DONE]\n\n');
+  response.end();
+}
+
 async function closeServer(server) {
   await new Promise((resolve, reject) => {
     server.close((error) => error ? reject(error) : resolve());
@@ -2404,6 +3202,62 @@ function assertEqual(actual, expected, label) {
   if (actual !== expected) {
     throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
   }
+}
+
+function isStatefulMarkerPart(part) {
+  return part instanceof LanguageModelDataPart && part.mimeType.toLowerCase() === 'stateful_marker';
+}
+
+function getStatefulMarkers(parts) {
+  return parts
+    .filter(isStatefulMarkerPart)
+    .map((part) => decodeStatefulMarker(part));
+}
+
+function getSingleStatefulMarkerPart(parts, label) {
+  const markers = parts.filter(isStatefulMarkerPart);
+  assertEqual(markers.length, 1, `${label} emits exactly one marker`);
+  return markers[0];
+}
+
+function decodeStatefulMarker(part) {
+  return new TextDecoder('utf-8', { fatal: true }).decode(part.data);
+}
+
+function createStatefulMarkerPart(value) {
+  return vscodeMock.LanguageModelDataPart.text(value, 'stateful_marker');
+}
+
+function createSystemMessage(instructions) {
+  return {
+    role: vscodeMock.LanguageModelChatMessageRole.System,
+    content: [new vscodeMock.LanguageModelTextPart(instructions)]
+  };
+}
+
+function createAgentHostContinuationMessages(markerPart, instructions, delta) {
+  return [
+    {
+      role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+      content: [markerPart]
+    },
+    createSystemMessage(instructions),
+    {
+      role: vscodeMock.LanguageModelChatMessageRole.User,
+      content: [new vscodeMock.LanguageModelTextPart(delta)]
+    }
+  ];
+}
+
+async function assertLocalMarkerFailure(request, responseRequests, expectedRequestCount, label) {
+  let failureMessage = '';
+  try {
+    await request();
+  } catch (error) {
+    failureMessage = error instanceof Error ? error.message : String(error);
+  }
+  assertEqual(failureMessage, 'Stateful continuation marker could not be resolved locally.', `${label} uses the fixed local error`);
+  assertEqual(responseRequests.length, expectedRequestCount, `${label} sends zero backend requests`);
 }
 
 async function runProviderModelDiscoveryPolicySmokeTest() {

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -193,6 +193,7 @@ try {
   await runStatefulMarkerToolOutputReplaySmokeTest();
   await runStatefulMarkerAutoFallbackOpaqueToolOutputRecoverySmokeTest();
   await runStatefulMarkerRecordFailureSmokeTest();
+  await runStatefulMarkerInvalidCompletionIdSmokeTest();
   await runHttpContinuationRecoverySmokeTest();
   await runStructuredHttpContinuationRecoverySmokeTest();
   await runContinuationMissAfterVisibleOutputSmokeTest();
@@ -1841,6 +1842,94 @@ async function runStatefulMarkerRecordFailureSmokeTest() {
 
     assertEqual(failureMessage, 'Synthetic branch record failure', 'branch record failure is surfaced');
     assertEqual(getStatefulMarkers(parts).length, 0, 'branch record failure emits no stateful marker');
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function runStatefulMarkerInvalidCompletionIdSmokeTest() {
+  const responseRequests = [];
+  const responseIds = ['resp_invalid\u0001', 'r'.repeat(513), 'resp_valid_after_invalid'];
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    responseRequests.push(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+    const responseId = responseIds[responseRequests.length - 1];
+    if (!responseId) {
+      response.writeHead(500, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: { message: 'Unexpected invalid completion-id request.' } }));
+      return;
+    }
+    writeSseResponseWithOutputItem(
+      response,
+      `reply ${responseRequests.length}`,
+      responseId,
+      `msg_invalid_completion_${responseRequests.length}`
+    );
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+  const provider = new CodexModelProvider(
+    {
+      secrets: { async get() { return 'test-api-key'; } },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected model for invalid completion-id coverage.');
+    }
+
+    const messages = [];
+    for (let index = 0; index < responseIds.length; index += 1) {
+      messages.push({
+        role: vscodeMock.LanguageModelChatMessageRole.User,
+        content: [new vscodeMock.LanguageModelTextPart(`request ${index + 1}`)]
+      });
+      const parts = [];
+      await provider.provideLanguageModelChatResponse(
+        model,
+        messages,
+        {},
+        { report(part) { parts.push(part); } },
+        token
+      );
+      assertEqual(
+        getStatefulMarkers(parts).length,
+        index === responseIds.length - 1 ? 1 : 0,
+        `completion id ${index + 1} marker count`
+      );
+      if (index < responseIds.length - 1) {
+        messages.push({
+          role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+          content: [new vscodeMock.LanguageModelTextPart(`reply ${index + 1}`)]
+        });
+      }
+    }
+
+    assertEqual(responseRequests.length, 3, 'invalid completion IDs do not cause retries');
+    assertEqual('previous_response_id' in responseRequests[1], false, 'control-bearing response ID is not recorded');
+    assertEqual('previous_response_id' in responseRequests[2], false, 'oversized response ID is not recorded');
   } finally {
     await closeServer(server);
   }


### PR DESCRIPTION
## Summary

- parse and validate VS Code Agent Host `stateful_marker` data without forwarding marker metadata to the Responses API
- continue only exact model/history/request-envelope matches and fail closed for malformed, stale, conflicting, or unsafe markers
- preserve completed-only anchors, canonical full replay, HTTP/WebSocket parity, context budgets, and opaque `auto` fallback disable semantics

## Upstream limitation

VS Code issue microsoft/vscode#329283 still affects released 1.134. The provider-side marker support in this PR is necessary, but end-to-end Agent Host continuation is not claimed fixed until the open VS Code fix is released.

## Verification

- 50/50 focused QA scenarios
- `npm run check`
- `npm run compile`
- `npm run test:smoke`
- `npm run test:extension-host`
- LSP diagnostics
- `git diff --check`

All passed.