### PR TITLE
fix(streaming): smooth Chat playback and stabilize continuation reuse

### DIFF
--- a/src/codexLatency.ts
+++ b/src/codexLatency.ts
@@ -76,6 +76,12 @@ export interface CodexLatencyContext {
   coalescedDeltaCount?: number;
   coalescingDelayP95Ms?: number;
   coalescingDelayMaxMs?: number;
+  presentedCharacters?: number;
+  averageCharactersPerReport?: number;
+  reportsPerSecond?: number;
+  rawReasoningFallbackCharactersAtToolCall?: number;
+  rawReasoningFallbackDiscardedAtToolCall?: boolean;
+  pendingPresentationCharactersAtToolCall?: number;
   websocketSerializeMs?: number;
 }
 
@@ -188,6 +194,24 @@ export class CodexLatencyRecorder {
     }
     if (context.coalescingDelayMaxMs !== undefined) {
       this.context.coalescingDelayMaxMs = context.coalescingDelayMaxMs;
+    }
+    if (context.presentedCharacters !== undefined) {
+      this.context.presentedCharacters = context.presentedCharacters;
+    }
+    if (context.averageCharactersPerReport !== undefined) {
+      this.context.averageCharactersPerReport = context.averageCharactersPerReport;
+    }
+    if (context.reportsPerSecond !== undefined) {
+      this.context.reportsPerSecond = context.reportsPerSecond;
+    }
+    if (context.rawReasoningFallbackCharactersAtToolCall !== undefined) {
+      this.context.rawReasoningFallbackCharactersAtToolCall = context.rawReasoningFallbackCharactersAtToolCall;
+    }
+    if (context.rawReasoningFallbackDiscardedAtToolCall !== undefined) {
+      this.context.rawReasoningFallbackDiscardedAtToolCall = context.rawReasoningFallbackDiscardedAtToolCall;
+    }
+    if (context.pendingPresentationCharactersAtToolCall !== undefined) {
+      this.context.pendingPresentationCharactersAtToolCall = context.pendingPresentationCharactersAtToolCall;
     }
     if (context.websocketSerializeMs !== undefined) {
       this.context.websocketSerializeMs = context.websocketSerializeMs;

--- a/src/codexLatency.ts
+++ b/src/codexLatency.ts
@@ -76,11 +76,7 @@ export interface CodexLatencyContext {
   coalescedDeltaCount?: number;
   coalescingDelayP95Ms?: number;
   coalescingDelayMaxMs?: number;
-  presentedCharacters?: number;
-  averageCharactersPerReport?: number;
-  reportsPerSecond?: number;
-  rawReasoningFallbackCharactersAtToolCall?: number;
-  rawReasoningFallbackDiscardedAtToolCall?: boolean;
+  discardedReasoningCharactersAtToolCall?: number;
   pendingPresentationCharactersAtToolCall?: number;
   websocketSerializeMs?: number;
 }
@@ -195,20 +191,8 @@ export class CodexLatencyRecorder {
     if (context.coalescingDelayMaxMs !== undefined) {
       this.context.coalescingDelayMaxMs = context.coalescingDelayMaxMs;
     }
-    if (context.presentedCharacters !== undefined) {
-      this.context.presentedCharacters = context.presentedCharacters;
-    }
-    if (context.averageCharactersPerReport !== undefined) {
-      this.context.averageCharactersPerReport = context.averageCharactersPerReport;
-    }
-    if (context.reportsPerSecond !== undefined) {
-      this.context.reportsPerSecond = context.reportsPerSecond;
-    }
-    if (context.rawReasoningFallbackCharactersAtToolCall !== undefined) {
-      this.context.rawReasoningFallbackCharactersAtToolCall = context.rawReasoningFallbackCharactersAtToolCall;
-    }
-    if (context.rawReasoningFallbackDiscardedAtToolCall !== undefined) {
-      this.context.rawReasoningFallbackDiscardedAtToolCall = context.rawReasoningFallbackDiscardedAtToolCall;
+    if (context.discardedReasoningCharactersAtToolCall !== undefined) {
+      this.context.discardedReasoningCharactersAtToolCall = context.discardedReasoningCharactersAtToolCall;
     }
     if (context.pendingPresentationCharactersAtToolCall !== undefined) {
       this.context.pendingPresentationCharactersAtToolCall = context.pendingPresentationCharactersAtToolCall;

--- a/src/codexLatency.ts
+++ b/src/codexLatency.ts
@@ -13,14 +13,17 @@ export type CodexLatencyStage =
   | 'requestSent'
   | 'responseCreated'
   | 'firstBackendDelta'
+  | 'lastBackendDelta'
   | 'firstReasoning'
   | 'firstText'
+  | 'lastProgressReport'
   | 'firstToolCallAdded'
   | 'firstToolCallArgumentsDelta'
   | 'firstToolCallArgumentsDone'
   | 'firstToolCallReported'
   | 'firstToolCall'
-  | 'responseCompleted';
+  | 'responseCompleted'
+  | 'providerReturned';
 
 export interface CodexLatencyTrace {
   providerSetupMs: number;
@@ -34,17 +37,20 @@ export interface CodexLatencyTrace {
   requestToCreatedMs?: number;
   responseCreatedToFirstBackendDeltaMs?: number;
   firstBackendDeltaToFirstReportMs?: number;
+  lastBackendDeltaToResponseCompletedMs?: number;
+  lastProgressReportToResponseCompletedMs?: number;
   providerToFirstReportMs?: number;
   createdToFirstVisibleMs?: number;
   providerToFirstVisibleMs?: number;
   toolCallAddedToFirstArgumentsDeltaMs?: number;
   toolCallArgumentsToDoneMs?: number;
   toolCallDoneToReportedMs?: number;
+  responseCompletedToProviderReturnMs?: number;
   totalMs: number;
 }
 
 export interface CodexLatencyContext {
-  metricVersion?: 2;
+  metricVersion?: 4;
   connectionOrigin?: 'fresh' | 'preconnected' | 'prewarm' | 'previous-response';
   connectionReused?: boolean;
   previousResponseIdUsed?: boolean;
@@ -76,6 +82,12 @@ export interface CodexLatencyContext {
   coalescedDeltaCount?: number;
   coalescingDelayP95Ms?: number;
   coalescingDelayMaxMs?: number;
+  largestReportCharacters?: number;
+  boundaryDrainReportCount?: number;
+  boundaryDrainDurationMs?: number;
+  backendDeltaGapMaxMs?: number;
+  continuationSnapshotMs?: number;
+  continuationStoreMs?: number;
   discardedReasoningCharactersAtToolCall?: number;
   pendingPresentationCharactersAtToolCall?: number;
   websocketSerializeMs?: number;
@@ -104,6 +116,21 @@ export class CodexLatencyRecorder {
     if (!this.timestamps.has(stage)) {
       this.timestamps.set(stage, at);
     }
+  }
+
+  /** Records every backend text/reasoning delta while preserving first-delta latency. */
+  recordBackendDelta(at = Date.now()): void {
+    const previousAt = this.at('lastBackendDelta');
+    if (previousAt !== undefined) {
+      this.context.backendDeltaGapMaxMs = Math.max(this.context.backendDeltaGapMaxMs ?? 0, at - previousAt);
+    }
+    this.mark('firstBackendDelta', at);
+    this.timestamps.set('lastBackendDelta', at);
+  }
+
+  /** Records every visible report so the response tail can be attributed separately from presentation batching. */
+  recordProgressReport(at = Date.now()): void {
+    this.timestamps.set('lastProgressReport', at);
   }
 
   recordContext(context: CodexLatencyContext): void {
@@ -191,6 +218,21 @@ export class CodexLatencyRecorder {
     if (context.coalescingDelayMaxMs !== undefined) {
       this.context.coalescingDelayMaxMs = context.coalescingDelayMaxMs;
     }
+    if (context.largestReportCharacters !== undefined) {
+      this.context.largestReportCharacters = context.largestReportCharacters;
+    }
+    if (context.boundaryDrainReportCount !== undefined) {
+      this.context.boundaryDrainReportCount = context.boundaryDrainReportCount;
+    }
+    if (context.boundaryDrainDurationMs !== undefined) {
+      this.context.boundaryDrainDurationMs = context.boundaryDrainDurationMs;
+    }
+    if (context.continuationSnapshotMs !== undefined) {
+      this.context.continuationSnapshotMs = context.continuationSnapshotMs;
+    }
+    if (context.continuationStoreMs !== undefined) {
+      this.context.continuationStoreMs = context.continuationStoreMs;
+    }
     if (context.discardedReasoningCharactersAtToolCall !== undefined) {
       this.context.discardedReasoningCharactersAtToolCall = context.discardedReasoningCharactersAtToolCall;
     }
@@ -209,6 +251,7 @@ export class CodexLatencyRecorder {
     const requestSent = this.at('requestSent');
     const responseCreated = this.at('responseCreated');
     const firstBackendDelta = this.at('firstBackendDelta');
+    const lastBackendDelta = this.at('lastBackendDelta');
     const firstVisible = this.firstVisibleAt();
     const responseCompleted = this.at('responseCompleted') ?? completedAt;
 
@@ -225,6 +268,11 @@ export class CodexLatencyRecorder {
         requestToCreatedMs: this.optionalDuration(requestSent, responseCreated),
         responseCreatedToFirstBackendDeltaMs: this.optionalDuration(responseCreated, firstBackendDelta),
         firstBackendDeltaToFirstReportMs: this.optionalDuration(firstBackendDelta, firstVisible),
+        lastBackendDeltaToResponseCompletedMs: this.optionalDuration(lastBackendDelta, responseCompleted),
+        lastProgressReportToResponseCompletedMs: this.optionalDuration(
+          this.at('lastProgressReport'),
+          responseCompleted
+        ),
         providerToFirstReportMs: this.optionalDuration(providerEntry, firstVisible),
         createdToFirstVisibleMs: this.optionalDuration(responseCreated, firstVisible),
         providerToFirstVisibleMs: this.optionalDuration(providerEntry, firstVisible),
@@ -239,6 +287,10 @@ export class CodexLatencyRecorder {
         toolCallDoneToReportedMs: this.optionalDuration(
           this.at('firstToolCallArgumentsDone'),
           this.at('firstToolCallReported')
+        ),
+        responseCompletedToProviderReturnMs: this.optionalDuration(
+          this.at('responseCompleted'),
+          this.at('providerReturned')
         ),
         totalMs: this.duration(providerEntry, responseCompleted, completedAt)
       },

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -447,31 +447,37 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       ...requestOptions
     });
     latency.recordContext({ requestBuildMs: Math.max(0, performance.now() - requestBuildStartedAt) });
-    const markerHint = convertedMessages.statefulMarker.kind === 'valid'
-      && convertedMessages.statefulMarker.isLeadingStandalone
+    const statefulMarker = convertedMessages.statefulMarker;
+    const markerHint = statefulMarker.kind === 'valid'
+      && statefulMarker.isLeadingStandalone
       ? {
-          responseId: convertedMessages.statefulMarker.previousResponseId,
-          incrementalInput: convertedMessages.statefulMarker.incrementalInput
+          responseId: statefulMarker.previousResponseId,
+          incrementalInput: statefulMarker.incrementalInput
         }
       : undefined;
-    const candidateReusableBranch = convertedMessages.statefulMarker.kind === 'none'
-      ? this.responseBranchStore.findReusableBranch(reuseEnvelope, input)
-      : markerHint
-        ? this.responseBranchStore.findReusableBranch(reuseEnvelope, input, markerHint)
+    const useHistoryFallback = !markerHint
+      && (statefulMarker.kind === 'none' || !statefulMarker.isLeadingStandalone);
+    const candidateReusableBranch = markerHint
+      ? this.responseBranchStore.findReusableBranch(reuseEnvelope, input, markerHint)
+      : useHistoryFallback
+        ? this.responseBranchStore.findReusableBranch(reuseEnvelope, input)
         : undefined;
-    const reusableBranch = markerHint || !candidateReusableBranch
-      ? candidateReusableBranch
-      : hasExactLocalBranchHistory(
+    const localHistoryStatus = !markerHint && candidateReusableBranch
+      ? getExactLocalBranchHistoryStatus(
           candidateReusableBranch.state?.continuation,
           input,
           candidateReusableBranch.comparison.appendedInput
         )
+      : undefined;
+    const reusableBranch = markerHint || !candidateReusableBranch
+      ? candidateReusableBranch
+      : localHistoryStatus === 'compatible'
         ? candidateReusableBranch
         : undefined;
     if (markerHint && !reusableBranch) {
       throw new Error(STATEFUL_MARKER_LOCAL_ERROR);
     }
-    const reuseMissDiagnostic = reusableBranch || convertedMessages.statefulMarker.kind !== 'none'
+    const reuseMissDiagnostic = reusableBranch || markerHint
       ? undefined
       : this.responseBranchStore.explainReuseMiss(reuseEnvelope, input);
     latency.mark('branchResolved');
@@ -624,6 +630,16 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       maxOutputTokens: config.maxOutputTokens
     });
 
+    requestLogger.debug('response continuation eligibility', {
+      markerKind: statefulMarker.kind,
+      markerIsLeadingStandalone: statefulMarker.kind === 'none' ? false : statefulMarker.isLeadingStandalone,
+      markerContinuation: Boolean(markerHint),
+      historyFallback: useHistoryFallback,
+      candidateBranchFound: Boolean(candidateReusableBranch),
+      localHistoryStatus: localHistoryStatus ?? null,
+      reusableBranchFound: Boolean(reusableBranch)
+    });
+
     if (reuseMissDiagnostic) {
       this.outputChannel.debug('response reuse miss', {
         requestModel: selectedModel.requestModel,
@@ -736,6 +752,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         reportedAt = Date.now()
       ) => {
         progress.report(part);
+        latency.recordProgressReport(reportedAt);
         reportedVisibleOutput = true;
         recordFirstVisibleOutput(kind, reportedAt);
         if (kind === 'text') {
@@ -746,7 +763,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       };
 
       const presenter = new StreamPresenter(
-        (_kind, receivedAt) => latency.mark('firstBackendDelta', receivedAt)
+        (_kind, receivedAt) => latency.recordBackendDelta(receivedAt)
       );
       let loggedMissingThinkingPart = false;
       const reasoningPresenter = new ReasoningStreamPresenter((update) => {
@@ -763,9 +780,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           this.outputChannel.debug('Reasoning output received, but LanguageModelThinkingPart is unavailable.');
         }
       }, {
-        onBackendDelta: (receivedAt) => latency.mark('firstBackendDelta', receivedAt)
+        onBackendDelta: (receivedAt) => latency.recordBackendDelta(receivedAt)
       });
       let presentationMetricsRecorded = false;
+      let completedUsagePart: vscode.LanguageModelResponsePart | undefined;
       const recordPresentationMetrics = () => {
         if (presentationMetricsRecorded) {
           return;
@@ -773,12 +791,15 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         presentationMetricsRecorded = true;
         const metrics = mergeStreamPresentationMetrics(presenter.metrics(), reasoningPresenter.metrics());
         latency.recordContext({
-          metricVersion: 2,
+          metricVersion: 4,
           backendDeltaCount: metrics.backendDeltaCount,
           progressReportCount: metrics.progressReportCount,
           coalescedDeltaCount: metrics.coalescedDeltaCount,
           coalescingDelayP95Ms: metrics.coalescingDelayP95Ms,
-          coalescingDelayMaxMs: metrics.coalescingDelayMaxMs
+          coalescingDelayMaxMs: metrics.coalescingDelayMaxMs,
+          largestReportCharacters: metrics.largestReportCharacters,
+          boundaryDrainReportCount: metrics.boundaryDrainReportCount,
+          boundaryDrainDurationMs: metrics.boundaryDrainDurationMs
         });
         this.outputChannel.trace('response stream presentation', { ...metrics });
       };
@@ -868,7 +889,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             call_id: callId,
             name: toolPlan.mode === 'native-hosted' ? call.name : name,
             ...(toolPlan.mode === 'native-hosted' && call.namespace ? { namespace: call.namespace } : {}),
-            arguments: JSON.stringify(toolInput)
+            arguments: stableSerialize(toolInput)
           });
           const pendingPresentationCharacters = presenter.pendingCharacters;
           presenter.flushBoundary();
@@ -974,8 +995,6 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           flushReplayText();
           reasoningPresenter.close();
           this.markReportedToolCallsResponseCompleted(reportedToolCallIds);
-          presenter.flushBoundary();
-          recordPresentationMetrics();
           if (allowToolOutputContinuation && previousResponseIdUsed) {
             latency.recordContext({
               toolOutputContinuation: 'supported',
@@ -1008,10 +1027,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             transportConfigured: config.transport
           });
 
-          const usagePart = createUsageDataPart(response.usage);
-          if (usagePart) {
-            progress.report(usagePart);
-          }
+          completedUsagePart = createUsageDataPart(response.usage);
 
           if (response.usage) {
             this.usageSink?.record({
@@ -1025,8 +1041,6 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         },
         onResponseFailed: (message) => {
           reasoningPresenter.close();
-          presenter.flushBoundary();
-          recordPresentationMetrics();
           if (token.isCancellationRequested) {
             requestLogger.debug('response.cancelled', { requestModel: selectedModel.requestModel });
             return;
@@ -1080,7 +1094,14 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         }
       } finally {
         reasoningPresenter.close();
-        presenter.flushBoundary();
+        if (token.isCancellationRequested) {
+          presenter.flushBoundary();
+        } else {
+          await presenter.drainBoundary(() => token.isCancellationRequested);
+        }
+        if (completedUsagePart) {
+          progress.report(completedUsagePart);
+        }
         recordPresentationMetrics();
       }
       return { previousResponseIdUsed };
@@ -1254,6 +1275,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       ? createStatefulMarkerPayload(model.id, finalResponseId)
       : undefined;
     if (finalResponseId && statefulMarkerPayload) {
+      const continuationSnapshotStartedAt = performance.now();
       const recordedInput = markerCanonicalReplayInput ?? input;
       const builtFullRequest = buildCodexResponsesRequest({
         ...requestOptions,
@@ -1281,6 +1303,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         ),
         updatedAt: Date.now()
       };
+      const continuationSnapshotMs = Math.max(0, performance.now() - continuationSnapshotStartedAt);
+      const continuationStoreStartedAt = performance.now();
       activeBranchId = this.responseBranchStore.recordSuccess(
         reuseEnvelope,
         recordedInput,
@@ -1288,6 +1312,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         activeBranchId,
         branchState
       );
+      latency.recordContext({
+        continuationSnapshotMs,
+        continuationStoreMs: Math.max(0, performance.now() - continuationStoreStartedAt)
+      });
       if (!token.isCancellationRequested && !this.responseBranchStore.isReuseDisabled(reuseEnvelope)) {
         progress.report(createStatefulMarkerDataPart(statefulMarkerPayload));
       }
@@ -1296,6 +1324,18 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         requestModel: selectedModel.requestModel
       });
     }
+    const providerReturnedAt = Date.now();
+    latency.mark('providerReturned', providerReturnedAt);
+    const providerTail = latency.snapshot(providerReturnedAt);
+    requestLogger.debug('response provider tail', {
+      responseCompletedToProviderReturnMs: providerTail.trace.responseCompletedToProviderReturnMs ?? null,
+      progressReportCount: providerTail.context.progressReportCount ?? null,
+      largestReportCharacters: providerTail.context.largestReportCharacters ?? null,
+      boundaryDrainReportCount: providerTail.context.boundaryDrainReportCount ?? null,
+      boundaryDrainDurationMs: providerTail.context.boundaryDrainDurationMs ?? null,
+      continuationSnapshotMs: providerTail.context.continuationSnapshotMs ?? null,
+      continuationStoreMs: providerTail.context.continuationStoreMs ?? null
+    });
   }
 
   private notifyVirtualToolFallback(
@@ -2372,36 +2412,58 @@ function buildLegacyFallbackReplayInput(input: readonly ResponsesInputMessage[])
   return replay;
 }
 
-function hasExactLocalBranchHistory(
+type ExactLocalBranchHistoryStatus =
+  | 'compatible'
+  | 'missing-snapshot'
+  | 'empty-appended-input'
+  | 'appended-input-out-of-range'
+  | 'function-call-integrity-mismatch'
+  | 'appended-input-mismatch'
+  | 'previous-input-invalid'
+  | 'response-items-invalid'
+  | 'current-history-invalid'
+  | 'history-mismatch';
+
+function getExactLocalBranchHistoryStatus(
   snapshot: CodexBranchState['continuation'],
   currentInput: readonly ResponsesInputMessage[],
   appendedInput: readonly ResponsesInputMessage[]
-): boolean {
-  if (!snapshot
-    || appendedInput.length === 0
-    || appendedInput.length > currentInput.length
-    || !hasCanonicalReplayContinuationIntegrity(snapshot.responseItems, appendedInput)) {
-    return false;
+): ExactLocalBranchHistoryStatus {
+  if (!snapshot) {
+    return 'missing-snapshot';
+  }
+  if (appendedInput.length === 0) {
+    return 'empty-appended-input';
+  }
+  if (appendedInput.length > currentInput.length) {
+    return 'appended-input-out-of-range';
+  }
+  if (!hasCanonicalReplayContinuationIntegrity(snapshot.responseItems, appendedInput)) {
+    return 'function-call-integrity-mismatch';
   }
 
   const currentSuffix = currentInput.slice(currentInput.length - appendedInput.length);
   if (!haveEquivalentLocalReplayItems(currentSuffix, appendedInput)) {
-    return false;
+    return 'appended-input-mismatch';
   }
 
   const previousLocalInput = normalizeLocalReplayItems(snapshot.fullRequest.input as readonly unknown[]);
   if (!previousLocalInput) {
-    return false;
+    return 'previous-input-invalid';
   }
   const responseLocalInput = normalizeLocalReplayItems(snapshot.responseItems);
   if (!responseLocalInput || responseLocalInput.length === 0) {
-    return false;
+    return 'response-items-invalid';
   }
   const currentLocalHistory = normalizeLocalReplayItems(
     currentInput.slice(0, currentInput.length - appendedInput.length)
   );
-  return Boolean(currentLocalHistory
-    && stableSerialize([...previousLocalInput, ...responseLocalInput]) === stableSerialize(currentLocalHistory));
+  if (!currentLocalHistory) {
+    return 'current-history-invalid';
+  }
+  return stableSerialize([...previousLocalInput, ...responseLocalInput]) === stableSerialize(currentLocalHistory)
+    ? 'compatible'
+    : 'history-mismatch';
 }
 
 function haveEquivalentLocalReplayItems(

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -104,6 +104,11 @@ const TOOL_OUTPUT_CONTINUATION_CAPABILITY_TTL_MS = 30 * 60_000;
 const MAX_TOOL_OUTPUT_CONTINUATION_CAPABILITIES = 64;
 const MAX_LOCAL_TOKEN_ESTIMATE_DIAGNOSTICS = 64;
 const STATEFUL_MARKER_LOCAL_ERROR = 'Stateful continuation marker could not be resolved locally.';
+const TEXT_STREAM_MIN_REPORT_INTERVAL_MS = 80;
+const TEXT_STREAM_MAX_REPORT_INTERVAL_MS = 100;
+const TEXT_STREAM_TARGET_REPORT_CHARACTERS = 20;
+const TEXT_STREAM_MAX_REPORT_CHARACTERS = 64;
+const TEXT_STREAM_SMOOTHING_BUFFER_CHARACTERS = 1_024;
 // The WebSocket tool-output continuation path passed the real-backend release
 // gate: five consecutive store:false tool loops completed with a matching
 // previous_response_id and a single incremental function_call_output.
@@ -179,6 +184,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
   private readonly pendingReportedToolCalls = new Map<string, ReportedToolCall>();
   private readonly toolOutputContinuationCapabilities = new Map<string, ToolOutputContinuationCapability>();
   private readonly localTokenEstimateDiagnostics = new Set<string>();
+  private localTokenEstimateCount = 0;
+  private localTokenEstimateDurationMs = 0;
   private readonly modelCache = new CodexModelCache<ProviderModelCatalog>({
     freshTtlMs: MODEL_CACHE_FRESH_TTL_MS,
     staleTtlMs: MODEL_CACHE_STALE_TTL_MS
@@ -626,6 +633,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       toolCount: options.tools?.length ?? 0,
       toolMode: getToolModeName(options.toolMode),
       toolNames: summarizeToolNames(options.tools),
+      localTokenEstimatesSinceActivation: {
+        count: this.localTokenEstimateCount,
+        durationMs: this.localTokenEstimateDurationMs
+      },
       omitMaxOutputTokens: credentials.omitMaxOutputTokens,
       maxOutputTokens: config.maxOutputTokens
     });
@@ -763,7 +774,15 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       };
 
       const presenter = new StreamPresenter(
-        (_kind, receivedAt) => latency.recordBackendDelta(receivedAt)
+        (_kind, receivedAt) => latency.recordBackendDelta(receivedAt),
+        undefined,
+        {
+          minReportIntervalMs: TEXT_STREAM_MIN_REPORT_INTERVAL_MS,
+          maxReportIntervalMs: TEXT_STREAM_MAX_REPORT_INTERVAL_MS,
+          targetReportCharacters: TEXT_STREAM_TARGET_REPORT_CHARACTERS,
+          maxReportCharacters: TEXT_STREAM_MAX_REPORT_CHARACTERS,
+          smoothingBufferCharacters: TEXT_STREAM_SMOOTHING_BUFFER_CHARACTERS
+        }
       );
       let loggedMissingThinkingPart = false;
       const reasoningPresenter = new ReasoningStreamPresenter((update) => {
@@ -1427,16 +1446,27 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     token: vscode.CancellationToken
   ): Promise<number> {
     const config = getProviderConfig();
-    const credentials = await getApiCredentials(this.context, this.authManager);
-
-    if (!credentials || !supportsOfficialTokenCounting(config.baseURL)) {
-      const estimated = estimateTokenCount(text);
+    if (!supportsOfficialTokenCounting(config.baseURL)) {
+      const estimated = this.estimateTokenCountLocally(text);
       this.logLocalTokenEstimateDiagnosticOnce({
         baseURL: config.baseURL,
         modelId: model.id,
         requestModel: parseModelIdentifier(model.id || config.model).requestModel,
         count: estimated,
-        reason: credentials ? 'official-counting-unavailable-for-backend' : 'missing-credentials'
+        reason: 'official-counting-unavailable-for-backend'
+      });
+      return estimated;
+    }
+
+    const credentials = await getApiCredentials(this.context, this.authManager);
+    if (!credentials) {
+      const estimated = this.estimateTokenCountLocally(text);
+      this.logLocalTokenEstimateDiagnosticOnce({
+        baseURL: config.baseURL,
+        modelId: model.id,
+        requestModel: parseModelIdentifier(model.id || config.model).requestModel,
+        count: estimated,
+        reason: 'missing-credentials'
       });
       return estimated;
     }
@@ -1467,7 +1497,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       if (token.isCancellationRequested || isAbortError(error)) {
         throw error;
       }
-      const estimated = estimateTokenCount(text);
+      const estimated = this.estimateTokenCountLocally(text);
       const requestModel = parseModelIdentifier(model.id || config.model).requestModel;
       this.outputChannel.warn('provideTokenCount fell back to local estimate after counting request failure', {
         modelId: model.id,
@@ -1479,6 +1509,14 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       });
       return estimated;
     }
+  }
+
+  private estimateTokenCountLocally(text: string | vscode.LanguageModelChatRequestMessage): number {
+    const startedAt = performance.now();
+    const estimated = estimateTokenCount(text);
+    this.localTokenEstimateCount += 1;
+    this.localTokenEstimateDurationMs += Math.max(0, performance.now() - startedAt);
+    return estimated;
   }
 
   private logLocalTokenEstimateDiagnosticOnce(options: {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -778,10 +778,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           progressReportCount: metrics.progressReportCount,
           coalescedDeltaCount: metrics.coalescedDeltaCount,
           coalescingDelayP95Ms: metrics.coalescingDelayP95Ms,
-          coalescingDelayMaxMs: metrics.coalescingDelayMaxMs,
-          presentedCharacters: metrics.presentedCharacters,
-          averageCharactersPerReport: metrics.averageCharactersPerReport,
-          reportsPerSecond: metrics.reportsPerSecond
+          coalescingDelayMaxMs: metrics.coalescingDelayMaxMs
         });
         this.outputChannel.trace('response stream presentation', { ...metrics });
       };
@@ -873,20 +870,18 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             ...(toolPlan.mode === 'native-hosted' && call.namespace ? { namespace: call.namespace } : {}),
             arguments: JSON.stringify(toolInput)
           });
-          const textMetricsBeforeToolCall = presenter.metrics();
+          const pendingPresentationCharacters = presenter.pendingCharacters;
           presenter.flushBoundary();
+          const discardedReasoningCharacters = reasoningPresenter.startNextPhase();
           const reportedAt = Date.now();
           latency.mark('firstToolCall', reportedAt);
           reportVisiblePart('tool_call', new vscode.LanguageModelToolCallPart(callId, name, toolInput), reportedAt);
           latency.mark('firstToolCallReported', reportedAt);
           this.rememberReportedToolCall(callId, name, reportedAt);
           reportedToolCallIds.add(callId);
-          const textMetricsAtToolCall = presenter.metrics();
-          const reasoningBoundary = reasoningPresenter.startNextPhase({ rawFallback: 'discard' });
           latency.recordContext({
-            pendingPresentationCharactersAtToolCall: textMetricsBeforeToolCall.pendingPresentationCharacters,
-            rawReasoningFallbackCharactersAtToolCall: reasoningBoundary.rawFallbackCharacters,
-            rawReasoningFallbackDiscardedAtToolCall: reasoningBoundary.rawFallbackDiscarded
+            pendingPresentationCharactersAtToolCall: pendingPresentationCharacters,
+            discardedReasoningCharactersAtToolCall: discardedReasoningCharacters
           });
           const lifecycle = toolCallLifecycleAt.get(callId);
           this.outputChannel.trace('response tool call timing', {
@@ -895,12 +890,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             backendName: call.name,
             namespace: call.namespace ?? null,
             toolPlanMode: toolPlan.mode,
-            pendingPresentationCharacters: textMetricsBeforeToolCall.pendingPresentationCharacters,
-            rawReasoningFallbackCharacters: reasoningBoundary.rawFallbackCharacters,
-            rawReasoningFallbackDiscarded: reasoningBoundary.rawFallbackDiscarded,
-            progressReportCount: textMetricsAtToolCall.progressReportCount,
-            reportsPerSecond: textMetricsAtToolCall.reportsPerSecond,
-            averageCharactersPerReport: textMetricsAtToolCall.averageCharactersPerReport,
+            pendingPresentationCharacters,
+            discardedReasoningCharacters,
             toolArgumentsDoneToReportedMs: lifecycle?.argumentsDoneAt === undefined
               ? null
               : Math.max(0, reportedAt - lifecycle.argumentsDoneAt)

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -778,7 +778,10 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           progressReportCount: metrics.progressReportCount,
           coalescedDeltaCount: metrics.coalescedDeltaCount,
           coalescingDelayP95Ms: metrics.coalescingDelayP95Ms,
-          coalescingDelayMaxMs: metrics.coalescingDelayMaxMs
+          coalescingDelayMaxMs: metrics.coalescingDelayMaxMs,
+          presentedCharacters: metrics.presentedCharacters,
+          averageCharactersPerReport: metrics.averageCharactersPerReport,
+          reportsPerSecond: metrics.reportsPerSecond
         });
         this.outputChannel.trace('response stream presentation', { ...metrics });
       };
@@ -870,7 +873,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             ...(toolPlan.mode === 'native-hosted' && call.namespace ? { namespace: call.namespace } : {}),
             arguments: JSON.stringify(toolInput)
           });
-          reasoningPresenter.startNextPhase();
+          const textMetricsBeforeToolCall = presenter.metrics();
           presenter.flushBoundary();
           const reportedAt = Date.now();
           latency.mark('firstToolCall', reportedAt);
@@ -878,6 +881,13 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
           latency.mark('firstToolCallReported', reportedAt);
           this.rememberReportedToolCall(callId, name, reportedAt);
           reportedToolCallIds.add(callId);
+          const textMetricsAtToolCall = presenter.metrics();
+          const reasoningBoundary = reasoningPresenter.startNextPhase({ rawFallback: 'discard' });
+          latency.recordContext({
+            pendingPresentationCharactersAtToolCall: textMetricsBeforeToolCall.pendingPresentationCharacters,
+            rawReasoningFallbackCharactersAtToolCall: reasoningBoundary.rawFallbackCharacters,
+            rawReasoningFallbackDiscardedAtToolCall: reasoningBoundary.rawFallbackDiscarded
+          });
           const lifecycle = toolCallLifecycleAt.get(callId);
           this.outputChannel.trace('response tool call timing', {
             callId,
@@ -885,6 +895,12 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             backendName: call.name,
             namespace: call.namespace ?? null,
             toolPlanMode: toolPlan.mode,
+            pendingPresentationCharacters: textMetricsBeforeToolCall.pendingPresentationCharacters,
+            rawReasoningFallbackCharacters: reasoningBoundary.rawFallbackCharacters,
+            rawReasoningFallbackDiscarded: reasoningBoundary.rawFallbackDiscarded,
+            progressReportCount: textMetricsAtToolCall.progressReportCount,
+            reportsPerSecond: textMetricsAtToolCall.reportsPerSecond,
+            averageCharactersPerReport: textMetricsAtToolCall.averageCharactersPerReport,
             toolArgumentsDoneToReportedMs: lifecycle?.argumentsDoneAt === undefined
               ? null
               : Math.max(0, reportedAt - lifecycle.argumentsDoneAt)

--- a/src/reasoningStreamPresenter.ts
+++ b/src/reasoningStreamPresenter.ts
@@ -18,11 +18,6 @@ export interface ReasoningStreamPresenterOptions {
   onBackendDelta?: (at: number) => void;
 }
 
-export interface ReasoningPhaseBoundaryMetrics {
-  rawFallbackCharacters: number;
-  rawFallbackDiscarded: boolean;
-}
-
 const MAX_RAW_FALLBACK_CHARACTERS = 8_192;
 
 /** Owns one response's thinking presentation lifecycle, independently of transport and VS Code APIs. */
@@ -35,7 +30,6 @@ export class ReasoningStreamPresenter {
   private rawProgressReportCount = 0;
   private rawFirstBackendDeltaAt?: number;
   private rawFirstReportAt?: number;
-  private rawPresentedCharacters = 0;
   private hasPresentedSummary = false;
   private lastSummaryIdentity?: string;
   private readonly stream: StreamPresenter;
@@ -91,18 +85,18 @@ export class ReasoningStreamPresenter {
   }
 
   /** Starts a new visual reasoning phase after a tool call. */
-  startNextPhase(options: { rawFallback?: 'emit' | 'discard' } = {}): ReasoningPhaseBoundaryMetrics {
-    const boundary = this.finishPhase(options.rawFallback ?? 'emit');
+  startNextPhase(): number {
+    const discardedRawCharacters = this.finishPhase(false);
     this.phase += 1;
     this.mode = 'idle';
     this.hasPresentedSummary = false;
     this.lastSummaryIdentity = undefined;
-    return boundary;
+    return discardedRawCharacters;
   }
 
   close(): void {
     if (this.mode !== 'closed') {
-      this.finishPhase('emit');
+      this.finishPhase(true);
       this.mode = 'closed';
     }
   }
@@ -117,28 +111,24 @@ export class ReasoningStreamPresenter {
       ...summaryMetrics,
       backendDeltaCount: summaryMetrics.backendDeltaCount + this.rawBackendDeltaCount,
       progressReportCount: summaryMetrics.progressReportCount + this.rawProgressReportCount,
-      presentedCharacters: summaryMetrics.presentedCharacters + this.rawPresentedCharacters,
       firstBackendDeltaAt: firstDefined(summaryMetrics.firstBackendDeltaAt, this.rawFirstBackendDeltaAt),
       firstReportAt: firstDefined(summaryMetrics.firstReportAt, this.rawFirstReportAt)
     };
   }
 
-  private finishPhase(rawFallback: 'emit' | 'discard'): ReasoningPhaseBoundaryMetrics {
+  private finishPhase(emitRawFallback: boolean): number {
     if (this.mode === 'reasoning-text') {
       const rawFallbackCharacters = this.rawFallback?.text.length ?? 0;
-      if (rawFallback === 'emit') {
+      if (emitRawFallback) {
         this.emitRawFallback();
       } else {
         this.rawFallback = undefined;
         this.rawFallbackTruncated = false;
       }
-      return {
-        rawFallbackCharacters,
-        rawFallbackDiscarded: rawFallback === 'discard' && rawFallbackCharacters > 0
-      };
+      return emitRawFallback ? 0 : rawFallbackCharacters;
     }
     this.stream.flushBoundary();
-    return { rawFallbackCharacters: 0, rawFallbackDiscarded: false };
+    return 0;
   }
 
   private bufferRawFallback(delta: ReasoningStreamDelta): void {
@@ -177,7 +167,6 @@ export class ReasoningStreamPresenter {
       id
     });
     this.rawProgressReportCount += 1;
-    this.rawPresentedCharacters += rawFallback.text.length;
     this.rawFirstReportAt ??= reportedAt;
     this.rawFallbackTruncated = false;
   }

--- a/src/reasoningStreamPresenter.ts
+++ b/src/reasoningStreamPresenter.ts
@@ -18,6 +18,11 @@ export interface ReasoningStreamPresenterOptions {
   onBackendDelta?: (at: number) => void;
 }
 
+export interface ReasoningPhaseBoundaryMetrics {
+  rawFallbackCharacters: number;
+  rawFallbackDiscarded: boolean;
+}
+
 const MAX_RAW_FALLBACK_CHARACTERS = 8_192;
 
 /** Owns one response's thinking presentation lifecycle, independently of transport and VS Code APIs. */
@@ -30,6 +35,7 @@ export class ReasoningStreamPresenter {
   private rawProgressReportCount = 0;
   private rawFirstBackendDeltaAt?: number;
   private rawFirstReportAt?: number;
+  private rawPresentedCharacters = 0;
   private hasPresentedSummary = false;
   private lastSummaryIdentity?: string;
   private readonly stream: StreamPresenter;
@@ -85,17 +91,18 @@ export class ReasoningStreamPresenter {
   }
 
   /** Starts a new visual reasoning phase after a tool call. */
-  startNextPhase(): void {
-    this.finishPhase();
+  startNextPhase(options: { rawFallback?: 'emit' | 'discard' } = {}): ReasoningPhaseBoundaryMetrics {
+    const boundary = this.finishPhase(options.rawFallback ?? 'emit');
     this.phase += 1;
     this.mode = 'idle';
     this.hasPresentedSummary = false;
     this.lastSummaryIdentity = undefined;
+    return boundary;
   }
 
   close(): void {
     if (this.mode !== 'closed') {
-      this.finishPhase();
+      this.finishPhase('emit');
       this.mode = 'closed';
     }
   }
@@ -110,17 +117,28 @@ export class ReasoningStreamPresenter {
       ...summaryMetrics,
       backendDeltaCount: summaryMetrics.backendDeltaCount + this.rawBackendDeltaCount,
       progressReportCount: summaryMetrics.progressReportCount + this.rawProgressReportCount,
+      presentedCharacters: summaryMetrics.presentedCharacters + this.rawPresentedCharacters,
       firstBackendDeltaAt: firstDefined(summaryMetrics.firstBackendDeltaAt, this.rawFirstBackendDeltaAt),
       firstReportAt: firstDefined(summaryMetrics.firstReportAt, this.rawFirstReportAt)
     };
   }
 
-  private finishPhase(): void {
+  private finishPhase(rawFallback: 'emit' | 'discard'): ReasoningPhaseBoundaryMetrics {
     if (this.mode === 'reasoning-text') {
-      this.emitRawFallback();
-      return;
+      const rawFallbackCharacters = this.rawFallback?.text.length ?? 0;
+      if (rawFallback === 'emit') {
+        this.emitRawFallback();
+      } else {
+        this.rawFallback = undefined;
+        this.rawFallbackTruncated = false;
+      }
+      return {
+        rawFallbackCharacters,
+        rawFallbackDiscarded: rawFallback === 'discard' && rawFallbackCharacters > 0
+      };
     }
     this.stream.flushBoundary();
+    return { rawFallbackCharacters: 0, rawFallbackDiscarded: false };
   }
 
   private bufferRawFallback(delta: ReasoningStreamDelta): void {
@@ -159,6 +177,7 @@ export class ReasoningStreamPresenter {
       id
     });
     this.rawProgressReportCount += 1;
+    this.rawPresentedCharacters += rawFallback.text.length;
     this.rawFirstReportAt ??= reportedAt;
     this.rawFallbackTruncated = false;
   }

--- a/src/streamPresenter.ts
+++ b/src/streamPresenter.ts
@@ -11,7 +11,11 @@ export interface StreamPresentationMetrics {
   backendDeltaCount: number;
   progressReportCount: number;
   coalescedDeltaCount: number;
+  reportedCharacterCount: number;
   largestReportCharacters: number;
+  maxPendingCharacters: number;
+  catchUpReportCount: number;
+  reportGapMaxMs: number;
   boundaryDrainReportCount: number;
   boundaryDrainDurationMs: number;
   firstBackendDeltaAt?: number;
@@ -32,6 +36,8 @@ export interface StreamPresenterOptions {
   minReportIntervalMs?: number;
   maxReportIntervalMs?: number;
   maxReportCharacters?: number;
+  targetReportCharacters?: number;
+  smoothingBufferCharacters?: number;
   timerApi?: StreamPresenterTimer;
 }
 
@@ -41,8 +47,8 @@ interface PendingPresentationPart extends StreamPresentationPart {
   firstBufferedAt: number;
 }
 
-const DEFAULT_MIN_REPORT_INTERVAL_MS = 250;
-const DEFAULT_MAX_REPORT_INTERVAL_MS = 250;
+const DEFAULT_MIN_REPORT_INTERVAL_MS = 80;
+const DEFAULT_MAX_REPORT_INTERVAL_MS = 80;
 const DEFAULT_MAX_REPORT_CHARACTERS = 64;
 
 /**
@@ -61,7 +67,11 @@ export class StreamPresenter {
   private backendDeltaCount = 0;
   private progressReportCount = 0;
   private coalescedDeltaCount = 0;
+  private reportedCharacterCount = 0;
   private largestReportCharacters = 0;
+  private maxPendingCharacters = 0;
+  private catchUpReportCount = 0;
+  private reportGapMaxMs = 0;
   private boundaryDrainReportCount = 0;
   private boundaryDrainDurationMs = 0;
   private firstBackendDeltaAt?: number;
@@ -71,6 +81,8 @@ export class StreamPresenter {
   private readonly minReportIntervalMs: number;
   private readonly maxReportIntervalMs: number;
   private readonly maxReportCharacters: number;
+  private readonly targetReportCharacters: number;
+  private readonly smoothingBufferCharacters: number;
   private readonly timerApi: StreamPresenterTimer;
 
   constructor(
@@ -85,6 +97,11 @@ export class StreamPresenter {
       options.maxReportIntervalMs ?? DEFAULT_MAX_REPORT_INTERVAL_MS
     );
     this.maxReportCharacters = Math.max(1, options.maxReportCharacters ?? DEFAULT_MAX_REPORT_CHARACTERS);
+    this.targetReportCharacters = Math.min(
+      this.maxReportCharacters,
+      Math.max(1, options.targetReportCharacters ?? this.maxReportCharacters)
+    );
+    this.smoothingBufferCharacters = Math.max(0, options.smoothingBufferCharacters ?? 0);
     this.timerApi = options.timerApi ?? {
       set: (callback, delayMs) => setTimeout(callback, delayMs),
       clear: (timer) => clearTimeout(timer)
@@ -107,7 +124,7 @@ export class StreamPresenter {
     }
 
     if (!this.pending && this.lastReportedKey !== key) {
-      const [visibleText, remainingText] = splitAtCharacterBoundary(part.text, this.maxReportCharacters);
+      const [visibleText, remainingText] = splitAtCharacterBoundary(part.text, this.targetReportCharacters);
       this.report(part, visibleText, receivedAt);
       this.lastReportedKey = key;
       if (remainingText) {
@@ -118,6 +135,7 @@ export class StreamPresenter {
           deltaCount: 0,
           firstBufferedAt: receivedAt
         };
+        this.recordPendingDepth();
         this.schedulePending();
       }
       return;
@@ -134,6 +152,7 @@ export class StreamPresenter {
       this.pending.text += part.text;
       this.pending.deltaCount += 1;
     }
+    this.recordPendingDepth();
     this.schedulePending();
   }
 
@@ -141,7 +160,7 @@ export class StreamPresenter {
   flush(): void {
     this.clearTimer();
     while (this.pending) {
-      this.flushOne();
+      this.flushOne(true);
     }
   }
 
@@ -159,6 +178,9 @@ export class StreamPresenter {
     this.clearTimer();
     const startedAt = this.now();
     const initialReportCount = this.progressReportCount;
+    if (this.pending && this.pending.text.length <= this.targetReportCharacters) {
+      this.flushOne(true);
+    }
     while (this.pending) {
       if (shouldStop?.()) {
         this.flushBoundary();
@@ -168,7 +190,7 @@ export class StreamPresenter {
       if (delayMs > 0) {
         await this.wait(delayMs);
       }
-      this.flushOne();
+      this.flushOne(true);
     }
     this.boundaryDrainReportCount += this.progressReportCount - initialReportCount;
     this.boundaryDrainDurationMs += Math.max(0, this.now() - startedAt);
@@ -185,7 +207,11 @@ export class StreamPresenter {
       backendDeltaCount: this.backendDeltaCount,
       progressReportCount: this.progressReportCount,
       coalescedDeltaCount: this.coalescedDeltaCount,
+      reportedCharacterCount: this.reportedCharacterCount,
       largestReportCharacters: this.largestReportCharacters,
+      maxPendingCharacters: this.maxPendingCharacters,
+      catchUpReportCount: this.catchUpReportCount,
+      reportGapMaxMs: this.reportGapMaxMs,
       boundaryDrainReportCount: this.boundaryDrainReportCount,
       boundaryDrainDurationMs: this.boundaryDrainDurationMs,
       firstBackendDeltaAt: this.firstBackendDeltaAt,
@@ -196,16 +222,23 @@ export class StreamPresenter {
     };
   }
 
-  private flushOne(): void {
+  private flushOne(forceCatchUp = false): void {
     const pending = this.pending;
     if (!pending) {
       return;
     }
 
-    const [visibleText, remainingText] = splitAtCharacterBoundary(pending.text, this.maxReportCharacters);
+    const catchUp = forceCatchUp || this.shouldCatchUp(pending.text.length);
+    const reportCharacters = catchUp
+      ? this.maxReportCharacters
+      : this.targetReportCharacters;
+    const [visibleText, remainingText] = splitAtCharacterBoundary(pending.text, reportCharacters);
     const reportedAt = this.now();
     this.coalescedDeltaCount += Math.max(0, pending.deltaCount - 1);
     this.coalescingDelaysMs.push(Math.max(0, reportedAt - pending.firstBufferedAt));
+    if (catchUp) {
+      this.catchUpReportCount += 1;
+    }
     this.report(pending, visibleText, reportedAt);
     this.lastReportedKey = pending.key;
 
@@ -220,7 +253,11 @@ export class StreamPresenter {
   private report(part: StreamPresentationPart, text: string, reportedAt: number): void {
     part.emit(text);
     this.progressReportCount += 1;
+    this.reportedCharacterCount += text.length;
     this.largestReportCharacters = Math.max(this.largestReportCharacters, text.length);
+    if (this.lastReportAt !== undefined) {
+      this.reportGapMaxMs = Math.max(this.reportGapMaxMs, reportedAt - this.lastReportAt);
+    }
     this.firstReportAt ??= reportedAt;
     this.lastReportAt = reportedAt;
     this.onReport?.(part.kind, reportedAt);
@@ -234,7 +271,7 @@ export class StreamPresenter {
     this.clearTimer();
     const now = this.now();
     const lastReportAt = this.lastReportAt ?? now;
-    const deadline = pending.text.length >= this.maxReportCharacters
+    const deadline = this.shouldCatchUp(pending.text.length)
       ? lastReportAt + this.minReportIntervalMs
       : lastReportAt + this.maxReportIntervalMs;
     const delayMs = Math.max(0, deadline - now);
@@ -244,6 +281,16 @@ export class StreamPresenter {
       return;
     }
     this.armTimer(delayMs);
+  }
+
+  private shouldCatchUp(pendingCharacters: number): boolean {
+    return this.smoothingBufferCharacters > 0
+      ? pendingCharacters > this.smoothingBufferCharacters
+      : pendingCharacters >= this.maxReportCharacters;
+  }
+
+  private recordPendingDepth(): void {
+    this.maxPendingCharacters = Math.max(this.maxPendingCharacters, this.pending?.text.length ?? 0);
   }
 
   private armTimer(delayMs: number): void {
@@ -287,7 +334,11 @@ export function mergeStreamPresentationMetrics(
     backendDeltaCount: metrics.reduce((total, metric) => total + metric.backendDeltaCount, 0),
     progressReportCount: metrics.reduce((total, metric) => total + metric.progressReportCount, 0),
     coalescedDeltaCount: metrics.reduce((total, metric) => total + metric.coalescedDeltaCount, 0),
+    reportedCharacterCount: metrics.reduce((total, metric) => total + metric.reportedCharacterCount, 0),
     largestReportCharacters: Math.max(0, ...metrics.map((metric) => metric.largestReportCharacters)),
+    maxPendingCharacters: Math.max(0, ...metrics.map((metric) => metric.maxPendingCharacters)),
+    catchUpReportCount: metrics.reduce((total, metric) => total + metric.catchUpReportCount, 0),
+    reportGapMaxMs: Math.max(0, ...metrics.map((metric) => metric.reportGapMaxMs)),
     boundaryDrainReportCount: metrics.reduce((total, metric) => total + metric.boundaryDrainReportCount, 0),
     boundaryDrainDurationMs: Math.max(0, ...metrics.map((metric) => metric.boundaryDrainDurationMs)),
     firstBackendDeltaAt: firstDefined(metrics.map((metric) => metric.firstBackendDeltaAt)),

--- a/src/streamPresenter.ts
+++ b/src/streamPresenter.ts
@@ -42,8 +42,8 @@ interface PendingPresentationPart extends StreamPresentationPart {
 }
 
 const DEFAULT_MIN_REPORT_INTERVAL_MS = 250;
-const DEFAULT_MAX_REPORT_INTERVAL_MS = 2_000;
-const DEFAULT_MAX_REPORT_CHARACTERS = 512;
+const DEFAULT_MAX_REPORT_INTERVAL_MS = 250;
+const DEFAULT_MAX_REPORT_CHARACTERS = 64;
 
 /**
  * Presents one response stream as a paced sequence of bounded updates.

--- a/src/streamPresenter.ts
+++ b/src/streamPresenter.ts
@@ -11,6 +11,9 @@ export interface StreamPresentationMetrics {
   backendDeltaCount: number;
   progressReportCount: number;
   coalescedDeltaCount: number;
+  largestReportCharacters: number;
+  boundaryDrainReportCount: number;
+  boundaryDrainDurationMs: number;
   firstBackendDeltaAt?: number;
   firstReportAt?: number;
   coalescingDelayP95Ms?: number;
@@ -24,39 +27,69 @@ export interface StreamPresenterTimer {
   clear(timer: ReturnType<typeof setTimeout>): void;
 }
 
+export interface StreamPresenterOptions {
+  now?: () => number;
+  minReportIntervalMs?: number;
+  maxReportIntervalMs?: number;
+  maxReportCharacters?: number;
+  timerApi?: StreamPresenterTimer;
+}
+
 interface PendingPresentationPart extends StreamPresentationPart {
   key: string;
   deltaCount: number;
   firstBufferedAt: number;
 }
 
+const DEFAULT_MIN_REPORT_INTERVAL_MS = 250;
+const DEFAULT_MAX_REPORT_INTERVAL_MS = 2_000;
+const DEFAULT_MAX_REPORT_CHARACTERS = 512;
+
 /**
- * Presents one response stream without changing its event order. The first
- * part of a logical stream is emitted immediately; later adjacent deltas are
- * briefly coalesced to keep Extension Host and Chat rendering work bounded.
+ * Presents one response stream as a paced sequence of bounded updates.
+ *
+ * VS Code's progress reporter has no consumer acknowledgement, so emitting
+ * either every backend delta or one large final delta can build an invisible
+ * queue in Copilot Chat. This presenter bounds both update frequency and
+ * update size, then explicitly drains the final queue before completion.
  */
 export class StreamPresenter {
   private pending?: PendingPresentationPart;
   private timer?: ReturnType<typeof setTimeout>;
   private lastReportedKey?: string;
+  private lastReportAt?: number;
   private backendDeltaCount = 0;
   private progressReportCount = 0;
   private coalescedDeltaCount = 0;
+  private largestReportCharacters = 0;
+  private boundaryDrainReportCount = 0;
+  private boundaryDrainDurationMs = 0;
   private firstBackendDeltaAt?: number;
   private firstReportAt?: number;
   private readonly coalescingDelaysMs: number[] = [];
+  private readonly now: () => number;
+  private readonly minReportIntervalMs: number;
+  private readonly maxReportIntervalMs: number;
+  private readonly maxReportCharacters: number;
+  private readonly timerApi: StreamPresenterTimer;
 
   constructor(
     private readonly onBackendDelta?: (kind: StreamPresentationKind, at: number) => void,
     private readonly onReport?: (kind: StreamPresentationKind, at: number) => void,
-    private readonly now: () => number = Date.now,
-    private readonly maxDelayMs = 32,
-    private readonly maxCharacters = 768,
-    private readonly timerApi: StreamPresenterTimer = {
+    options: StreamPresenterOptions = {}
+  ) {
+    this.now = options.now ?? Date.now;
+    this.minReportIntervalMs = Math.max(0, options.minReportIntervalMs ?? DEFAULT_MIN_REPORT_INTERVAL_MS);
+    this.maxReportIntervalMs = Math.max(
+      this.minReportIntervalMs,
+      options.maxReportIntervalMs ?? DEFAULT_MAX_REPORT_INTERVAL_MS
+    );
+    this.maxReportCharacters = Math.max(1, options.maxReportCharacters ?? DEFAULT_MAX_REPORT_CHARACTERS);
+    this.timerApi = options.timerApi ?? {
       set: (callback, delayMs) => setTimeout(callback, delayMs),
       clear: (timer) => clearTimeout(timer)
-    }
-  ) {}
+    };
+  }
 
   push(part: StreamPresentationPart): void {
     if (!part.text) {
@@ -73,48 +106,73 @@ export class StreamPresenter {
       this.flush();
     }
 
-    if (!this.pending) {
-      if (this.lastReportedKey !== key) {
-        this.report(part, part.text, receivedAt);
-        this.lastReportedKey = key;
-        return;
+    if (!this.pending && this.lastReportedKey !== key) {
+      const [visibleText, remainingText] = splitAtCharacterBoundary(part.text, this.maxReportCharacters);
+      this.report(part, visibleText, receivedAt);
+      this.lastReportedKey = key;
+      if (remainingText) {
+        this.pending = {
+          ...part,
+          text: remainingText,
+          key,
+          deltaCount: 0,
+          firstBufferedAt: receivedAt
+        };
+        this.schedulePending();
       }
+      return;
+    }
 
+    if (!this.pending) {
       this.pending = {
         ...part,
         key,
         deltaCount: 1,
         firstBufferedAt: receivedAt
       };
-      this.armTimer();
-      return;
+    } else {
+      this.pending.text += part.text;
+      this.pending.deltaCount += 1;
     }
-
-    this.pending.text += part.text;
-    this.pending.deltaCount += 1;
-    if (this.pending.text.length >= this.maxCharacters) {
-      this.flush();
-    }
+    this.schedulePending();
   }
 
+  /** Immediately flushes all pending text, retaining bounded report sizes. */
   flush(): void {
-    const pending = this.pending;
-    if (!pending) {
-      return;
-    }
-
-    this.pending = undefined;
     this.clearTimer();
-    const reportedAt = this.now();
-    this.coalescedDeltaCount += Math.max(0, pending.deltaCount - 1);
-    this.coalescingDelaysMs.push(Math.max(0, reportedAt - pending.firstBufferedAt));
-    this.report(pending, pending.text, reportedAt);
-    this.lastReportedKey = pending.key;
+    while (this.pending) {
+      this.flushOne();
+    }
   }
 
+  /** Immediately completes a semantic phase, such as the boundary before a tool call. */
   flushBoundary(): void {
     this.flush();
-    this.lastReportedKey = undefined;
+    this.resetBoundary();
+  }
+
+  /**
+   * Paces any final backlog before allowing the provider response to finish.
+   * This prevents a large final report from becoming post-completion UI work.
+   */
+  async drainBoundary(shouldStop?: () => boolean): Promise<void> {
+    this.clearTimer();
+    const startedAt = this.now();
+    const initialReportCount = this.progressReportCount;
+    while (this.pending) {
+      if (shouldStop?.()) {
+        this.flushBoundary();
+        break;
+      }
+      const delayMs = Math.max(0, (this.lastReportAt ?? this.now()) + this.minReportIntervalMs - this.now());
+      if (delayMs > 0) {
+        await this.wait(delayMs);
+      }
+      this.flushOne();
+    }
+    this.boundaryDrainReportCount += this.progressReportCount - initialReportCount;
+    this.boundaryDrainDurationMs += Math.max(0, this.now() - startedAt);
+    this.resetBoundary();
   }
 
   get pendingCharacters(): number {
@@ -127,6 +185,9 @@ export class StreamPresenter {
       backendDeltaCount: this.backendDeltaCount,
       progressReportCount: this.progressReportCount,
       coalescedDeltaCount: this.coalescedDeltaCount,
+      largestReportCharacters: this.largestReportCharacters,
+      boundaryDrainReportCount: this.boundaryDrainReportCount,
+      boundaryDrainDurationMs: this.boundaryDrainDurationMs,
       firstBackendDeltaAt: this.firstBackendDeltaAt,
       firstReportAt: this.firstReportAt,
       coalescingDelayP95Ms: percentile(delays, 0.95),
@@ -135,15 +196,62 @@ export class StreamPresenter {
     };
   }
 
+  private flushOne(): void {
+    const pending = this.pending;
+    if (!pending) {
+      return;
+    }
+
+    const [visibleText, remainingText] = splitAtCharacterBoundary(pending.text, this.maxReportCharacters);
+    const reportedAt = this.now();
+    this.coalescedDeltaCount += Math.max(0, pending.deltaCount - 1);
+    this.coalescingDelaysMs.push(Math.max(0, reportedAt - pending.firstBufferedAt));
+    this.report(pending, visibleText, reportedAt);
+    this.lastReportedKey = pending.key;
+
+    if (!remainingText) {
+      this.pending = undefined;
+      return;
+    }
+    pending.text = remainingText;
+    pending.deltaCount = 0;
+  }
+
   private report(part: StreamPresentationPart, text: string, reportedAt: number): void {
     part.emit(text);
     this.progressReportCount += 1;
+    this.largestReportCharacters = Math.max(this.largestReportCharacters, text.length);
     this.firstReportAt ??= reportedAt;
+    this.lastReportAt = reportedAt;
     this.onReport?.(part.kind, reportedAt);
   }
 
-  private armTimer(): void {
-    this.timer = this.timerApi.set(() => this.flush(), this.maxDelayMs);
+  private schedulePending(): void {
+    const pending = this.pending;
+    if (!pending) {
+      return;
+    }
+    this.clearTimer();
+    const now = this.now();
+    const lastReportAt = this.lastReportAt ?? now;
+    const deadline = pending.text.length >= this.maxReportCharacters
+      ? lastReportAt + this.minReportIntervalMs
+      : lastReportAt + this.maxReportIntervalMs;
+    const delayMs = Math.max(0, deadline - now);
+    if (delayMs === 0) {
+      this.flushOne();
+      this.schedulePending();
+      return;
+    }
+    this.armTimer(delayMs);
+  }
+
+  private armTimer(delayMs: number): void {
+    this.timer = this.timerApi.set(() => {
+      this.timer = undefined;
+      this.flushOne();
+      this.schedulePending();
+    }, delayMs);
     this.timer.unref?.();
   }
 
@@ -153,6 +261,20 @@ export class StreamPresenter {
     }
     this.timerApi.clear(this.timer);
     this.timer = undefined;
+  }
+
+  private resetBoundary(): void {
+    this.lastReportedKey = undefined;
+    this.lastReportAt = undefined;
+  }
+
+  private async wait(delayMs: number): Promise<void> {
+    await new Promise<void>((resolve) => {
+      this.timer = this.timerApi.set(() => {
+        this.timer = undefined;
+        resolve();
+      }, delayMs);
+    });
   }
 }
 
@@ -165,12 +287,27 @@ export function mergeStreamPresentationMetrics(
     backendDeltaCount: metrics.reduce((total, metric) => total + metric.backendDeltaCount, 0),
     progressReportCount: metrics.reduce((total, metric) => total + metric.progressReportCount, 0),
     coalescedDeltaCount: metrics.reduce((total, metric) => total + metric.coalescedDeltaCount, 0),
+    largestReportCharacters: Math.max(0, ...metrics.map((metric) => metric.largestReportCharacters)),
+    boundaryDrainReportCount: metrics.reduce((total, metric) => total + metric.boundaryDrainReportCount, 0),
+    boundaryDrainDurationMs: Math.max(0, ...metrics.map((metric) => metric.boundaryDrainDurationMs)),
     firstBackendDeltaAt: firstDefined(metrics.map((metric) => metric.firstBackendDeltaAt)),
     firstReportAt: firstDefined(metrics.map((metric) => metric.firstReportAt)),
     coalescingDelayP95Ms: percentile(delays, 0.95),
     coalescingDelayMaxMs: delays.at(-1),
     coalescingDelaysMs: delays
   };
+}
+
+function splitAtCharacterBoundary(text: string, maxCharacters: number): [string, string] {
+  if (text.length <= maxCharacters) {
+    return [text, ''];
+  }
+  let splitAt = maxCharacters;
+  const lastCodeUnit = text.charCodeAt(splitAt - 1);
+  if (lastCodeUnit >= 0xD800 && lastCodeUnit <= 0xDBFF) {
+    splitAt = splitAt === 1 ? 2 : splitAt - 1;
+  }
+  return [text.slice(0, splitAt), text.slice(splitAt)];
 }
 
 function percentile(values: readonly number[], fraction: number): number | undefined {

--- a/src/streamPresenter.ts
+++ b/src/streamPresenter.ts
@@ -15,6 +15,12 @@ export interface StreamPresentationMetrics {
   firstReportAt?: number;
   coalescingDelayP95Ms?: number;
   coalescingDelayMaxMs?: number;
+  presentedCharacters: number;
+  pendingPresentationCharacters: number;
+  averageCharactersPerReport?: number;
+  reportsPerSecond?: number;
+  /** Internal sample timestamp used when several presenters share one response. */
+  sampledAt: number;
   /** Internal timing samples used when several presenters share one response. */
   coalescingDelaysMs: readonly number[];
 }
@@ -44,14 +50,15 @@ export class StreamPresenter {
   private coalescedDeltaCount = 0;
   private firstBackendDeltaAt?: number;
   private firstReportAt?: number;
+  private presentedCharacters = 0;
   private readonly coalescingDelaysMs: number[] = [];
 
   constructor(
     private readonly onBackendDelta?: (kind: StreamPresentationKind, at: number) => void,
     private readonly onReport?: (kind: StreamPresentationKind, at: number) => void,
     private readonly now: () => number = Date.now,
-    private readonly maxDelayMs = 8,
-    private readonly maxCharacters = 256,
+    private readonly maxDelayMs = 32,
+    private readonly maxCharacters = 768,
     private readonly timerApi: StreamPresenterTimer = {
       set: (callback, delayMs) => setTimeout(callback, delayMs),
       clear: (timer) => clearTimeout(timer)
@@ -119,6 +126,10 @@ export class StreamPresenter {
 
   metrics(): StreamPresentationMetrics {
     const delays = [...this.coalescingDelaysMs].sort((left, right) => left - right);
+    const sampledAt = this.now();
+    const elapsedMs = this.firstBackendDeltaAt === undefined
+      ? undefined
+      : Math.max(1, sampledAt - this.firstBackendDeltaAt);
     return {
       backendDeltaCount: this.backendDeltaCount,
       progressReportCount: this.progressReportCount,
@@ -127,12 +138,22 @@ export class StreamPresenter {
       firstReportAt: this.firstReportAt,
       coalescingDelayP95Ms: percentile(delays, 0.95),
       coalescingDelayMaxMs: delays.at(-1),
+      presentedCharacters: this.presentedCharacters,
+      pendingPresentationCharacters: this.pending?.text.length ?? 0,
+      averageCharactersPerReport: this.progressReportCount === 0
+        ? undefined
+        : Math.round(this.presentedCharacters / this.progressReportCount),
+      reportsPerSecond: elapsedMs === undefined
+        ? undefined
+        : roundToTenths((this.progressReportCount * 1_000) / elapsedMs),
+      sampledAt,
       coalescingDelaysMs: delays
     };
   }
 
   private report(part: StreamPresentationPart, text: string, reportedAt: number): void {
     part.emit(text);
+    this.presentedCharacters += text.length;
     this.progressReportCount += 1;
     this.firstReportAt ??= reportedAt;
     this.onReport?.(part.kind, reportedAt);
@@ -157,16 +178,36 @@ export function mergeStreamPresentationMetrics(
   ...metrics: readonly StreamPresentationMetrics[]
 ): StreamPresentationMetrics {
   const delays = metrics.flatMap((metric) => metric.coalescingDelaysMs).sort((left, right) => left - right);
+  const presentedCharacters = metrics.reduce((total, metric) => total + metric.presentedCharacters, 0);
+  const progressReportCount = metrics.reduce((total, metric) => total + metric.progressReportCount, 0);
+  const firstBackendDeltaAt = firstDefined(metrics.map((metric) => metric.firstBackendDeltaAt));
+  const lastSampleAt = Math.max(...metrics.map((metric) => metric.sampledAt));
   return {
     backendDeltaCount: metrics.reduce((total, metric) => total + metric.backendDeltaCount, 0),
-    progressReportCount: metrics.reduce((total, metric) => total + metric.progressReportCount, 0),
+    progressReportCount,
     coalescedDeltaCount: metrics.reduce((total, metric) => total + metric.coalescedDeltaCount, 0),
-    firstBackendDeltaAt: firstDefined(metrics.map((metric) => metric.firstBackendDeltaAt)),
+    firstBackendDeltaAt,
     firstReportAt: firstDefined(metrics.map((metric) => metric.firstReportAt)),
     coalescingDelayP95Ms: percentile(delays, 0.95),
     coalescingDelayMaxMs: delays.at(-1),
+    presentedCharacters,
+    pendingPresentationCharacters: metrics.reduce(
+      (total, metric) => total + metric.pendingPresentationCharacters,
+      0
+    ),
+    averageCharactersPerReport: progressReportCount === 0
+      ? undefined
+      : Math.round(presentedCharacters / progressReportCount),
+    reportsPerSecond: firstBackendDeltaAt === undefined
+      ? undefined
+      : roundToTenths((progressReportCount * 1_000) / Math.max(1, lastSampleAt - firstBackendDeltaAt)),
+    sampledAt: lastSampleAt,
     coalescingDelaysMs: delays
   };
+}
+
+function roundToTenths(value: number): number {
+  return Math.round(value * 10) / 10;
 }
 
 function percentile(values: readonly number[], fraction: number): number | undefined {

--- a/src/streamPresenter.ts
+++ b/src/streamPresenter.ts
@@ -15,12 +15,6 @@ export interface StreamPresentationMetrics {
   firstReportAt?: number;
   coalescingDelayP95Ms?: number;
   coalescingDelayMaxMs?: number;
-  presentedCharacters: number;
-  pendingPresentationCharacters: number;
-  averageCharactersPerReport?: number;
-  reportsPerSecond?: number;
-  /** Internal sample timestamp used when several presenters share one response. */
-  sampledAt: number;
   /** Internal timing samples used when several presenters share one response. */
   coalescingDelaysMs: readonly number[];
 }
@@ -50,7 +44,6 @@ export class StreamPresenter {
   private coalescedDeltaCount = 0;
   private firstBackendDeltaAt?: number;
   private firstReportAt?: number;
-  private presentedCharacters = 0;
   private readonly coalescingDelaysMs: number[] = [];
 
   constructor(
@@ -124,12 +117,12 @@ export class StreamPresenter {
     this.lastReportedKey = undefined;
   }
 
+  get pendingCharacters(): number {
+    return this.pending?.text.length ?? 0;
+  }
+
   metrics(): StreamPresentationMetrics {
     const delays = [...this.coalescingDelaysMs].sort((left, right) => left - right);
-    const sampledAt = this.now();
-    const elapsedMs = this.firstBackendDeltaAt === undefined
-      ? undefined
-      : Math.max(1, sampledAt - this.firstBackendDeltaAt);
     return {
       backendDeltaCount: this.backendDeltaCount,
       progressReportCount: this.progressReportCount,
@@ -138,22 +131,12 @@ export class StreamPresenter {
       firstReportAt: this.firstReportAt,
       coalescingDelayP95Ms: percentile(delays, 0.95),
       coalescingDelayMaxMs: delays.at(-1),
-      presentedCharacters: this.presentedCharacters,
-      pendingPresentationCharacters: this.pending?.text.length ?? 0,
-      averageCharactersPerReport: this.progressReportCount === 0
-        ? undefined
-        : Math.round(this.presentedCharacters / this.progressReportCount),
-      reportsPerSecond: elapsedMs === undefined
-        ? undefined
-        : roundToTenths((this.progressReportCount * 1_000) / elapsedMs),
-      sampledAt,
       coalescingDelaysMs: delays
     };
   }
 
   private report(part: StreamPresentationPart, text: string, reportedAt: number): void {
     part.emit(text);
-    this.presentedCharacters += text.length;
     this.progressReportCount += 1;
     this.firstReportAt ??= reportedAt;
     this.onReport?.(part.kind, reportedAt);
@@ -178,36 +161,16 @@ export function mergeStreamPresentationMetrics(
   ...metrics: readonly StreamPresentationMetrics[]
 ): StreamPresentationMetrics {
   const delays = metrics.flatMap((metric) => metric.coalescingDelaysMs).sort((left, right) => left - right);
-  const presentedCharacters = metrics.reduce((total, metric) => total + metric.presentedCharacters, 0);
-  const progressReportCount = metrics.reduce((total, metric) => total + metric.progressReportCount, 0);
-  const firstBackendDeltaAt = firstDefined(metrics.map((metric) => metric.firstBackendDeltaAt));
-  const lastSampleAt = Math.max(...metrics.map((metric) => metric.sampledAt));
   return {
     backendDeltaCount: metrics.reduce((total, metric) => total + metric.backendDeltaCount, 0),
-    progressReportCount,
+    progressReportCount: metrics.reduce((total, metric) => total + metric.progressReportCount, 0),
     coalescedDeltaCount: metrics.reduce((total, metric) => total + metric.coalescedDeltaCount, 0),
-    firstBackendDeltaAt,
+    firstBackendDeltaAt: firstDefined(metrics.map((metric) => metric.firstBackendDeltaAt)),
     firstReportAt: firstDefined(metrics.map((metric) => metric.firstReportAt)),
     coalescingDelayP95Ms: percentile(delays, 0.95),
     coalescingDelayMaxMs: delays.at(-1),
-    presentedCharacters,
-    pendingPresentationCharacters: metrics.reduce(
-      (total, metric) => total + metric.pendingPresentationCharacters,
-      0
-    ),
-    averageCharactersPerReport: progressReportCount === 0
-      ? undefined
-      : Math.round(presentedCharacters / progressReportCount),
-    reportsPerSecond: firstBackendDeltaAt === undefined
-      ? undefined
-      : roundToTenths((progressReportCount * 1_000) / Math.max(1, lastSampleAt - firstBackendDeltaAt)),
-    sampledAt: lastSampleAt,
     coalescingDelaysMs: delays
   };
-}
-
-function roundToTenths(value: number): number {
-  return Math.round(value * 10) / 10;
 }
 
 function percentile(values: readonly number[], fraction: number): number | undefined {

--- a/test/smokeCodexLatency.mjs
+++ b/test/smokeCodexLatency.mjs
@@ -33,16 +33,21 @@ try {
   latency.mark('requestSent', 1_135);
   latency.mark('responseCreated', 1_200);
   latency.mark('firstBackendDelta', 1_220);
+  latency.recordBackendDelta(1_220);
   latency.mark('firstReasoning', 1_225);
+  latency.recordProgressReport(1_225);
   latency.mark('firstText', 1_240);
+  latency.recordProgressReport(1_240);
+  latency.recordBackendDelta(1_260);
   latency.mark('firstToolCallAdded', 1_250);
   latency.mark('firstToolCallArgumentsDelta', 1_260);
   latency.mark('firstToolCallArgumentsDone', 1_290);
   latency.mark('firstToolCallReported', 1_294);
   latency.mark('firstToolCall', 1_294);
   latency.mark('responseCompleted', 1_300);
+  latency.mark('providerReturned', 1_315);
   latency.recordContext({
-    metricVersion: 2,
+    metricVersion: 4,
     connectionOrigin: 'prewarm',
     connectionReused: false,
     previousResponseIdUsed: true,
@@ -62,6 +67,11 @@ try {
     coalescedDeltaCount: 9,
     coalescingDelayP95Ms: 8,
     coalescingDelayMaxMs: 10,
+    largestReportCharacters: 512,
+    boundaryDrainReportCount: 2,
+    boundaryDrainDurationMs: 500,
+    continuationSnapshotMs: 2.5,
+    continuationStoreMs: 1.5,
     websocketSerializeMs: 1.5,
     reasoningEffort: 'low',
     serviceTier: 'auto'
@@ -79,17 +89,21 @@ try {
   assertEqual(snapshot.trace.requestToCreatedMs, 65, 'request to created duration');
   assertEqual(snapshot.trace.responseCreatedToFirstBackendDeltaMs, 20, 'created to first backend delta duration');
   assertEqual(snapshot.trace.firstBackendDeltaToFirstReportMs, 5, 'backend delta to first report duration');
+  assertEqual(snapshot.trace.lastBackendDeltaToResponseCompletedMs, 40, 'last backend delta to completed duration');
+  assertEqual(snapshot.trace.lastProgressReportToResponseCompletedMs, 60, 'last report to completed duration');
   assertEqual(snapshot.trace.providerToFirstReportMs, 225, 'provider to first report duration');
   assertEqual(snapshot.trace.createdToFirstVisibleMs, 25, 'created to first visible duration');
   assertEqual(snapshot.trace.providerToFirstVisibleMs, 225, 'provider to first visible duration');
   assertEqual(snapshot.trace.toolCallAddedToFirstArgumentsDeltaMs, 10, 'tool call added to first arguments duration');
   assertEqual(snapshot.trace.toolCallArgumentsToDoneMs, 30, 'tool arguments to done duration');
   assertEqual(snapshot.trace.toolCallDoneToReportedMs, 4, 'tool call done to reported duration');
+  assertEqual(snapshot.trace.responseCompletedToProviderReturnMs, 15, 'completed to provider return duration');
   assertEqual(snapshot.trace.totalMs, 300, 'total duration');
   assertEqual(snapshot.firstVisibleStage, 'firstReasoning', 'first visible stage');
   assertEqual(snapshot.stageOffsetsMs.responseCompleted, 300, 'completed stage offset');
   assertEqual(snapshot.stageOffsetsMs.firstToolCallAdded, 250, 'tool call added stage offset');
   assertEqual(snapshot.stageOffsetsMs.firstToolCallReported, 294, 'tool call reported stage offset');
+  assertEqual(snapshot.stageOffsetsMs.providerReturned, 315, 'provider returned stage offset');
   assertEqual(snapshot.context.connectionOrigin, 'prewarm', 'connection origin context');
   assertEqual(snapshot.context.incrementalInputCount, 1, 'incremental input context');
   assertEqual(snapshot.context.modelDiscoveryCacheState, 'stale', 'model cache context');
@@ -98,10 +112,16 @@ try {
   assertEqual(snapshot.context.legacyToolSchemaCacheHit, true, 'legacy tool schema cache context');
   assertEqual(snapshot.context.nativeToolCatalogCacheHit, true, 'native tool catalog cache context');
   assertEqual(snapshot.context.requestBuildMs, 4.5, 'request build context');
-  assertEqual(snapshot.context.metricVersion, 2, 'metric version context');
+  assertEqual(snapshot.context.metricVersion, 4, 'metric version context');
+  assertEqual(snapshot.context.backendDeltaGapMaxMs, 40, 'largest backend delta gap context');
+  assertEqual(snapshot.context.continuationSnapshotMs, 2.5, 'continuation snapshot context');
+  assertEqual(snapshot.context.continuationStoreMs, 1.5, 'continuation store context');
   assertEqual(snapshot.context.backendDeltaCount, 12, 'backend delta count context');
   assertEqual(snapshot.context.progressReportCount, 4, 'progress report count context');
   assertEqual(snapshot.context.coalescingDelayP95Ms, 8, 'coalescing delay context');
+  assertEqual(snapshot.context.largestReportCharacters, 512, 'largest report size context');
+  assertEqual(snapshot.context.boundaryDrainReportCount, 2, 'boundary drain report count context');
+  assertEqual(snapshot.context.boundaryDrainDurationMs, 500, 'boundary drain duration context');
   assertEqual(snapshot.context.websocketSerializeMs, 1.5, 'WebSocket serialization context');
   console.log('Smoke test passed: latency tracing records redacted stage durations deterministically.');
 } finally {

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -6087,8 +6087,11 @@ async function runProviderModelIdDoesNotBlockColdDiscoverySmokeTest() {
 
 async function runLocalTokenEstimateDiagnosticSmokeTest() {
   const originalBaseURL = configValues.baseURL;
+  const originalCredentialsSource = configValues.credentialsSource;
   const logs = [];
+  let credentialSnapshotCount = 0;
   configValues.baseURL = 'https://chatgpt.com/backend-api/codex/responses';
+  configValues.credentialsSource = 'codexAuth';
   const provider = new CodexModelProvider(
     {
       secrets: {
@@ -6102,7 +6105,17 @@ async function runLocalTokenEstimateDiagnosticSmokeTest() {
     undefined,
     undefined,
     undefined,
-    undefined
+    {
+      async getCredentialSnapshot() {
+        credentialSnapshotCount += 1;
+        return {
+          source: 'legacyCodexFile',
+          accessToken: 'local-estimate-token',
+          revision: 'local-estimate-revision',
+          refreshable: false
+        };
+      }
+    }
   );
   const model = {
     id: 'codex::gpt-5.6-luna',
@@ -6118,10 +6131,12 @@ async function runLocalTokenEstimateDiagnosticSmokeTest() {
     await provider.provideTokenCount(model, '12345678', token);
     const localEstimateLogs = logs.filter((entry) => entry.level === 'trace'
       && entry.message.includes('provideTokenCount using local estimate (first occurrence)'));
+    assertEqual(credentialSnapshotCount, 0, 'local token estimates bypass credential resolution');
     assertEqual(localEstimateLogs.length, 1, 'known local token-count estimate is logged only once');
     assertEqual(localEstimateLogs[0].message.includes('subsequentOccurrencesSuppressed'), true, 'local estimate log explains suppression');
   } finally {
     configValues.baseURL = originalBaseURL;
+    configValues.credentialsSource = originalCredentialsSource;
   }
 }
 

--- a/test/smokeProviderFallback.mjs
+++ b/test/smokeProviderFallback.mjs
@@ -221,6 +221,7 @@ try {
   await runProviderFallbackSmokeTest();
   await runInterleavedResponsePresentationSmokeTest();
   await runStatefulMarkerRoundTripSmokeTest();
+  await runNonLeadingStatefulMarkerHistoryReuseSmokeTest();
   await runStatefulMarkerContinuationRecoverySmokeTest();
   await runStatefulMarkerOpaqueRecoverySmokeTest();
   await runStatefulMarkerToolOutputReplaySmokeTest();
@@ -1720,6 +1721,104 @@ async function runStatefulMarkerRoundTripSmokeTest() {
     } finally {
       Date.now = originalNow;
     }
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function runNonLeadingStatefulMarkerHistoryReuseSmokeTest() {
+  const responseRequests = [];
+  const replies = [
+    ['history seed reply', 'resp_non_leading_marker_seed', 'msg_non_leading_marker_seed'],
+    ['history continuation reply', 'resp_non_leading_marker_continued', 'msg_non_leading_marker_continued']
+  ];
+  const server = createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url?.startsWith('/backend-api/codex/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ models: [createMockModel('gpt-5.6-sol', 'GPT-5.6-Sol')] }));
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    responseRequests.push(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+    const reply = replies[responseRequests.length - 1];
+    if (!reply) {
+      response.writeHead(500, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: { message: 'Unexpected non-leading marker request.' } }));
+      return;
+    }
+    writeSseResponseWithOutputItem(response, reply[0], reply[1], reply[2]);
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  configValues.baseURL = `http://127.0.0.1:${address.port}/backend-api/codex/responses`;
+  configValues.transport = 'http';
+  const provider = new CodexModelProvider(
+    {
+      secrets: { async get() { return 'test-api-key'; } },
+      subscriptions: []
+    },
+    createOutputChannel(),
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  );
+
+  try {
+    const token = createCancellationToken();
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, token);
+    const model = models.find((item) => item.id === 'codex::gpt-5.6-sol');
+    if (!model) {
+      throw new Error('Expected model for non-leading stateful marker history reuse coverage.');
+    }
+
+    const seedParts = [];
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        createSystemMessage('History reuse instructions'),
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('History seed')] }
+      ],
+      {},
+      { report(part) { seedParts.push(part); } },
+      token
+    );
+    const seedTextPart = seedParts.find((part) => part instanceof LanguageModelTextPart);
+    if (!seedTextPart) {
+      throw new Error('Expected visible seed response text for non-leading marker history reuse coverage.');
+    }
+    const seedMarkerPart = getSingleStatefulMarkerPart(seedParts, 'non-leading marker seed completion');
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [
+        createSystemMessage('History reuse instructions'),
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('History seed')] },
+        {
+          role: vscodeMock.LanguageModelChatMessageRole.Assistant,
+          content: [seedTextPart, seedMarkerPart]
+        },
+        { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('History delta')] }
+      ],
+      {},
+      { report() {} },
+      token
+    );
+
+    assertEqual(responseRequests.length, 2, 'non-leading marker history continuation request count');
+    assertEqual(
+      responseRequests[1].previous_response_id,
+      'resp_non_leading_marker_seed',
+      'non-leading marker uses the locally verified history response id'
+    );
+    assertEqual(JSON.stringify(responseRequests[1].input), JSON.stringify([
+      { role: 'user', content: 'History delta', type: 'message' }
+    ]), 'non-leading marker sends only the locally verified delta');
   } finally {
     await closeServer(server);
   }
@@ -4139,6 +4238,7 @@ async function runNativeHostedToolOutputContinuationRecoverySmokeTest() {
   const sockets = new Set();
   const warnings = [];
   let httpResponseRequestCount = 0;
+  let connectionCount = 0;
   let selectedNamespace;
   let selectedTool;
   const server = createServer((request, response) => {
@@ -4163,6 +4263,7 @@ async function runNativeHostedToolOutputContinuationRecoverySmokeTest() {
     });
   });
   webSocketServer.on('connection', (webSocket) => {
+    connectionCount += 1;
     sockets.add(webSocket);
     webSocket.once('close', () => sockets.delete(webSocket));
     webSocket.on('message', (data) => {
@@ -4179,6 +4280,7 @@ async function runNativeHostedToolOutputContinuationRecoverySmokeTest() {
           }));
           return;
         }
+        webSocket.send(JSON.stringify({ type: 'response.output_text.delta', delta: 'I will inspect the native tool output.' }));
         webSocket.send(JSON.stringify({
           type: 'response.output_item.done',
           output_index: 0,
@@ -4200,7 +4302,7 @@ async function runNativeHostedToolOutputContinuationRecoverySmokeTest() {
           call_id: 'call_native_ws_replay',
           name: selectedTool,
           namespace: selectedNamespace,
-          arguments: '{"value":"websocket"}'
+          arguments: '{"zebra":"last","alpha":"first","middle":"middle"}'
         };
         webSocket.send(JSON.stringify({ type: 'response.output_item.added', output_index: 0, item }));
         webSocket.send(JSON.stringify({
@@ -4236,7 +4338,7 @@ async function runNativeHostedToolOutputContinuationRecoverySmokeTest() {
           error: {
             type: 'invalid_request_error',
             code: 'previous_response_not_found',
-            message: 'Native WebSocket context-downgrade continuation expired.',
+            message: 'Native WebSocket tool-output continuation expired.',
             param: 'previous_response_id'
           },
           status: 400
@@ -4358,8 +4460,13 @@ async function runNativeHostedToolOutputContinuationRecoverySmokeTest() {
       throw new Error('Expected one mapped native WebSocket tool call.');
     }
     assertEqual(toolCall.name, selectedTool, 'native WebSocket namespaced call maps to the selected VS Code tool');
+    assertEqual(
+      firstParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
+      'I will inspect the native tool output.',
+      'native WebSocket continuation seed includes visible text before the tool call'
+    );
 
-    const downgradedParts = [];
+    const continuedParts = [];
     await withSmokeTimeout(
       provider.provideLanguageModelChatResponse(
         model,
@@ -4367,44 +4474,45 @@ async function runNativeHostedToolOutputContinuationRecoverySmokeTest() {
           { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Run a deferred native WebSocket tool.')] },
           {
             role: vscodeMock.LanguageModelChatMessageRole.Assistant,
-            content: [new vscodeMock.LanguageModelToolCallPart('call_native_ws_replay', selectedTool, { value: 'websocket' })]
+            content: [
+              new vscodeMock.LanguageModelTextPart('I will inspect the native tool output.'),
+              new vscodeMock.LanguageModelToolCallPart('call_native_ws_replay', selectedTool, {
+                alpha: 'first',
+                middle: 'middle',
+                zebra: 'last'
+              })
+            ]
           },
           {
             role: vscodeMock.LanguageModelChatMessageRole.Assistant,
             content: [new vscodeMock.LanguageModelToolResultPart('call_native_ws_replay', [new vscodeMock.LanguageModelTextPart('native websocket output')])]
           }
         ],
-        { tools },
-        { report(part) { downgradedParts.push(part); } },
+        { tools, modelConfiguration: { contextSize: 950000 } },
+        { report(part) { continuedParts.push(part); } },
         token
       ),
       token,
-      'native WebSocket context-downgrade canonical replay'
+      'native WebSocket stable tool-argument continuation'
     );
 
-    assertEqual(frames.length, 2, 'native WebSocket context downgrade sends one canonical replay frame after the initial request');
-    assertEqual('previous_response_id' in frames[1], false, 'native WebSocket context downgrade keeps previous response reuse disabled');
+    assertEqual(frames.length, 2, 'native WebSocket stable tool arguments send one continuation frame after the initial request');
+    assertEqual(frames[1].previous_response_id, 'resp_native_ws_tool', 'native WebSocket tool result reuses the completed response id');
     assertEqual(
       JSON.stringify(frames[1].input),
       JSON.stringify([
-        { role: 'user', content: 'Run a deferred native WebSocket tool.', type: 'message' },
-        {
-          type: 'function_call',
-          call_id: 'call_native_ws_replay',
-          name: selectedTool,
-          arguments: '{"value":"websocket"}'
-        },
         { type: 'function_call_output', call_id: 'call_native_ws_replay', output: 'native websocket output' }
       ]),
-      'native WebSocket context downgrade sends exact ordered canonical call and output'
+      'native WebSocket tool-result continuation sends only the incremental output'
     );
-    assertEqual(frames[1].input.filter((item) => item.type === 'tool_search_output').length, 0, 'unmarked native WebSocket context downgrade excludes hidden Tool Search output');
-    assertEqual(frames[1].input.filter((item) => item.type === 'function_call').length, 1, 'native WebSocket context downgrade includes one namespaced call');
-    assertEqual(frames[1].input.filter((item) => item.type === 'function_call_output').length, 1, 'native WebSocket context downgrade includes one matching output');
+    assertEqual(connectionCount, 1, 'native WebSocket tool-result continuation reuses the existing socket');
+    assertEqual(frames[1].input.filter((item) => item.type === 'tool_search_output').length, 0, 'native WebSocket continuation excludes hidden Tool Search output');
+    assertEqual(frames[1].input.filter((item) => item.type === 'function_call').length, 0, 'native WebSocket continuation excludes already acknowledged function calls');
+    assertEqual(frames[1].input.filter((item) => item.type === 'function_call_output').length, 1, 'native WebSocket continuation includes one matching output');
     assertEqual(
-      downgradedParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
+      continuedParts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
       'Native WebSocket tool result received.',
-      'native WebSocket context downgrade reports the completed replay response'
+      'native WebSocket tool-result continuation reports the completed response'
     );
 
     const recoveredParts = [];
@@ -4415,40 +4523,54 @@ async function runNativeHostedToolOutputContinuationRecoverySmokeTest() {
           { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Run a deferred native WebSocket tool.')] },
           {
             role: vscodeMock.LanguageModelChatMessageRole.Assistant,
-            content: [new vscodeMock.LanguageModelToolCallPart('call_native_ws_replay', selectedTool, { value: 'websocket' })]
+            content: [
+              new vscodeMock.LanguageModelTextPart('I will inspect the native tool output.'),
+              new vscodeMock.LanguageModelToolCallPart('call_native_ws_replay', selectedTool, {
+                alpha: 'first',
+                middle: 'middle',
+                zebra: 'last'
+              })
+            ]
           },
           {
             role: vscodeMock.LanguageModelChatMessageRole.Assistant,
             content: [new vscodeMock.LanguageModelToolResultPart('call_native_ws_replay', [new vscodeMock.LanguageModelTextPart('native websocket output')])]
           },
           { role: vscodeMock.LanguageModelChatMessageRole.Assistant, content: [new vscodeMock.LanguageModelTextPart('Native WebSocket tool result received.')] },
-          { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Continue after the context downgrade.')] }
+          { role: vscodeMock.LanguageModelChatMessageRole.User, content: [new vscodeMock.LanguageModelTextPart('Continue after the tool result.')] }
         ],
-        { tools },
+        { tools, modelConfiguration: { contextSize: 950000 } },
         { report(part) { recoveredParts.push(part); } },
         token
       ),
       token,
-      'native WebSocket context-downgrade continuation recovery'
+      'native WebSocket tool-output continuation recovery'
     );
 
-    assertEqual(frames.length, 4, 'native WebSocket recovery sends incremental continuation and canonical retry after downgrade replay');
-    assertEqual(frames[2].previous_response_id, 'resp_native_ws_result', 'post-downgrade follow-up first uses the new completed response id');
+    assertEqual(frames.length, 4, 'native WebSocket recovery sends an incremental continuation and canonical retry');
+    assertEqual(frames[2].previous_response_id, 'resp_native_ws_result', 'post-tool follow-up first uses the new completed response id');
     assertEqual(
       JSON.stringify(frames[2].input),
-      JSON.stringify([{ role: 'user', content: 'Continue after the context downgrade.', type: 'message' }]),
-      'post-downgrade continuation sends only appended user input'
+      JSON.stringify([{ role: 'user', content: 'Continue after the tool result.', type: 'message' }]),
+      'post-tool continuation sends only appended user input'
     );
-    assertEqual('previous_response_id' in frames[3], false, 'post-downgrade continuation-miss retry omits the stale response id');
+    assertEqual('previous_response_id' in frames[3], false, 'tool-output continuation-miss retry omits the stale response id');
     assertEqual(
-      JSON.stringify(frames[3].input),
+      JSON.stringify(frames[3].input.filter((item) => item.type !== 'tool_search_output')),
       JSON.stringify([
         { role: 'user', content: 'Run a deferred native WebSocket tool.', type: 'message' },
         {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'I will inspect the native tool output.' }]
+        },
+        {
+          id: 'fc_native_ws_replay',
           type: 'function_call',
           call_id: 'call_native_ws_replay',
           name: selectedTool,
-          arguments: '{"value":"websocket"}'
+          namespace: selectedNamespace,
+          arguments: '{"alpha":"first","middle":"middle","zebra":"last"}'
         },
         { type: 'function_call_output', call_id: 'call_native_ws_replay', output: 'native websocket output' },
         {
@@ -4456,30 +4578,25 @@ async function runNativeHostedToolOutputContinuationRecoverySmokeTest() {
           role: 'assistant',
           content: [{ type: 'output_text', text: 'Native WebSocket tool result received.' }]
         },
-        { role: 'user', content: 'Continue after the context downgrade.', type: 'message' }
+        { role: 'user', content: 'Continue after the tool result.', type: 'message' }
       ]),
-      'post-downgrade continuation-miss retry sends exact ordered canonical replay'
+      'tool-output continuation-miss retry sends exact ordered canonical replay outside the trusted Tool Search result'
     );
-    assertEqual(frames[3].input.filter((item) => item.type === 'tool_search_output').length, 0, 'post-downgrade recovery cannot import hidden Tool Search output without a marker');
+    assertEqual(frames[3].input.filter((item) => item.type === 'tool_search_output').length, 1, 'tool-output recovery preserves one trusted Tool Search result');
     assertEqual(
       frames[3].input.filter((item) => item.type === 'function_call').length,
       1,
-      'post-downgrade recovery contains exactly one namespaced function call'
+      'tool-output recovery contains exactly one namespaced function call'
     );
     assertEqual(
       frames[3].input.filter((item) => item.type === 'function_call_output').length,
       1,
-      'post-downgrade recovery contains exactly one matching output'
+      'tool-output recovery contains exactly one matching output'
     );
     assertEqual(
       warnings.filter((entry) => entry.message === 'response continuation reset').length,
       1,
-      'post-downgrade continuation miss executes generic continuation recovery'
-    );
-    assertEqual(
-      warnings.some((entry) => entry.message === 'response tool-output continuation reset'),
-      false,
-      'budget downgrade never executes tool-output incremental recovery'
+      'post-tool continuation miss executes generic continuation recovery'
     );
     assertEqual(httpResponseRequestCount, 0, 'structured WebSocket continuation miss never falls back to HTTP');
     assertEqual(

--- a/test/smokeReasoningStreamPresenter.mjs
+++ b/test/smokeReasoningStreamPresenter.mjs
@@ -55,10 +55,9 @@ try {
   toolBoundaryPresenter.push({
     source: 'reasoning-text', text: 'raw reasoning before a tool', itemId: 'rs_tool', partIndex: 0, outputIndex: 0
   });
-  const boundaryMetrics = toolBoundaryPresenter.startNextPhase({ rawFallback: 'discard' });
+  const discardedRawCharacters = toolBoundaryPresenter.startNextPhase();
   assertEqual(toolBoundary.length, 0, 'a tool boundary does not enqueue raw reasoning ahead of the tool loop');
-  assertEqual(boundaryMetrics.rawFallbackCharacters, 27, 'tool-boundary telemetry records buffered reasoning size');
-  assertEqual(boundaryMetrics.rawFallbackDiscarded, true, 'tool-boundary telemetry records fallback suppression');
+  assertEqual(discardedRawCharacters, 27, 'tool-boundary telemetry records discarded reasoning size');
   console.log('Smoke test passed: reasoning summary streaming uses VS Code-safe aggregation and bounded raw fallback.');
 } finally {
   await loaded.dispose();

--- a/test/smokeReasoningStreamPresenter.mjs
+++ b/test/smokeReasoningStreamPresenter.mjs
@@ -49,6 +49,16 @@ try {
     }]),
     'raw reasoning is emitted only as the bounded no-summary fallback'
   );
+
+  const toolBoundary = [];
+  const toolBoundaryPresenter = new ReasoningStreamPresenter((update) => toolBoundary.push(update));
+  toolBoundaryPresenter.push({
+    source: 'reasoning-text', text: 'raw reasoning before a tool', itemId: 'rs_tool', partIndex: 0, outputIndex: 0
+  });
+  const boundaryMetrics = toolBoundaryPresenter.startNextPhase({ rawFallback: 'discard' });
+  assertEqual(toolBoundary.length, 0, 'a tool boundary does not enqueue raw reasoning ahead of the tool loop');
+  assertEqual(boundaryMetrics.rawFallbackCharacters, 27, 'tool-boundary telemetry records buffered reasoning size');
+  assertEqual(boundaryMetrics.rawFallbackDiscarded, true, 'tool-boundary telemetry records fallback suppression');
   console.log('Smoke test passed: reasoning summary streaming uses VS Code-safe aggregation and bounded raw fallback.');
 } finally {
   await loaded.dispose();

--- a/test/smokeStreamPresenter.mjs
+++ b/test/smokeStreamPresenter.mjs
@@ -93,6 +93,86 @@ try {
   assertEqual(backend.length, 7, 'backend callback retains every delta');
   assertEqual(reported[0].at, 1_000, 'first report remains synchronous');
 
+  let defaultScheduled;
+  const defaultEmitted = [];
+  const defaultPresenter = new StreamPresenter(undefined, undefined, {
+    now: () => now,
+    timerApi: {
+      set(callback, delayMs) {
+        const timer = {
+          callback,
+          delayMs,
+          dueAt: now + delayMs
+        };
+        defaultScheduled = timer;
+        return timer;
+      },
+      clear(timer) {
+        if (defaultScheduled === timer) {
+          defaultScheduled = undefined;
+        }
+      }
+    }
+  });
+  now = 5_000;
+  defaultPresenter.push({
+    kind: 'text',
+    identity: 'text',
+    text: 'x'.repeat(100),
+    emit: (presented) => defaultEmitted.push(presented)
+  });
+  assertEqual(defaultEmitted[0].length, 64, 'default first report stays within the Chat playback budget');
+  assertEqual(defaultPresenter.pendingCharacters, 36, 'default presenter queues text beyond the playback budget');
+  assertEqual(defaultScheduled?.dueAt, 5_250, 'default queued text advances at the bounded report cadence');
+
+  let observedScheduled;
+  const observedTimers = {
+    set(callback, delayMs) {
+      const timer = {
+        callback() {
+          if (observedScheduled === timer) {
+            observedScheduled = undefined;
+          }
+          callback();
+        },
+        dueAt: now + delayMs
+      };
+      observedScheduled = timer;
+      return timer;
+    },
+    clear(timer) {
+      if (observedScheduled === timer) {
+        observedScheduled = undefined;
+      }
+    }
+  };
+  const observedPresenter = new StreamPresenter(undefined, undefined, {
+    now: () => now,
+    timerApi: observedTimers
+  });
+  now = 7_000;
+  const observedStreamEndsAt = now + 12_000;
+  let observedNextDeltaAt = now;
+  while (observedNextDeltaAt <= observedStreamEndsAt) {
+    while (observedScheduled && observedScheduled.dueAt <= observedNextDeltaAt) {
+      now = observedScheduled.dueAt;
+      observedScheduled.callback();
+    }
+    now = observedNextDeltaAt;
+    observedPresenter.push({
+      kind: 'text',
+      identity: 'text',
+      text: 'x',
+      emit() {}
+    });
+    observedNextDeltaAt += 7;
+  }
+  assertEqual(
+    observedPresenter.pendingCharacters <= 64,
+    true,
+    'default pacing keeps up with the observed backend character rate'
+  );
+
   let boundedScheduled;
   const boundedEmitted = [];
   const boundedTimers = {

--- a/test/smokeStreamPresenter.mjs
+++ b/test/smokeStreamPresenter.mjs
@@ -10,7 +10,17 @@ try {
   const reported = [];
   const timers = {
     set(callback, delayMs) {
-      scheduled = { callback, delayMs };
+      const timer = {
+        callback() {
+          if (scheduled === timer) {
+            scheduled = undefined;
+          }
+          callback();
+        },
+        delayMs,
+        dueAt: now + delayMs
+      };
+      scheduled = timer;
       return scheduled;
     },
     clear(timer) {
@@ -22,10 +32,13 @@ try {
   const presenter = new StreamPresenter(
     (kind, at) => backend.push({ kind, at }),
     (kind, at) => reported.push({ kind, at }),
-    () => now,
-    32,
-    768,
-    timers
+    {
+      now: () => now,
+      minReportIntervalMs: 64,
+      maxReportIntervalMs: 256,
+      maxReportCharacters: 4,
+      timerApi: timers
+    }
   );
   const text = (value) => presenter.push({
     kind: 'text',
@@ -42,90 +55,178 @@ try {
   text('b');
   now = 1_003;
   text('c');
-  assertEqual(scheduled?.delayMs, 32, 'later delta aligns with the Extension Host batching interval');
+  assertEqual(scheduled?.dueAt, 1_256, 'small deltas use the maximum presentation latency');
   assertEqual(emitted.length, 1, 'small adjacent deltas are buffered');
 
-  now = 1_033;
+  now = 1_256;
   scheduled.callback();
   assertEqual(JSON.stringify(emitted), JSON.stringify([
     { kind: 'text', text: 'a' },
     { kind: 'text', text: 'bc' }
   ]), 'timer flush preserves text order');
 
-  now = 1_010;
-  text('d');
+  now = 1_257;
+  text('de');
+  now = 1_258;
+  text('fg');
+  assertEqual(scheduled?.dueAt, 1_320, 'a full chunk advances to the minimum presentation interval');
+  now = 1_320;
+  scheduled.callback();
+  assertEqual(emitted.at(-1)?.text, 'defg', 'a full chunk is emitted without exceeding its bound');
+
+  now = 1_321;
+  text('h');
   presenter.flushBoundary();
-  now = 1_011;
-  text('e');
-  assertEqual(JSON.stringify(emitted), JSON.stringify([
-    { kind: 'text', text: 'a' },
-    { kind: 'text', text: 'bc' },
-    { kind: 'text', text: 'd' },
-    { kind: 'text', text: 'e' }
-  ]), 'a boundary flushes and makes the next logical stream immediate');
+  now = 1_322;
+  text('i');
+  assertEqual(emitted.at(-2)?.text, 'h', 'a semantic boundary flushes pending text');
+  assertEqual(emitted.at(-1)?.text, 'i', 'a new semantic phase starts immediately');
 
   const metrics = presenter.metrics();
-  assertEqual(metrics.backendDeltaCount, 5, 'all backend deltas are counted');
-  assertEqual(metrics.progressReportCount, 4, 'report count reflects coalescing');
-  assertEqual(metrics.coalescedDeltaCount, 1, 'only collapsed delta reports are counted');
+  assertEqual(metrics.backendDeltaCount, 7, 'all backend deltas are counted');
+  assertEqual(metrics.progressReportCount, 5, 'report count reflects coalescing');
+  assertEqual(metrics.coalescedDeltaCount, 2, 'collapsed backend deltas are counted');
+  assertEqual(metrics.largestReportCharacters, 4, 'reported text never exceeds the configured bound');
   assertEqual(metrics.firstBackendDeltaAt, 1_000, 'first backend delta timestamp');
   assertEqual(metrics.firstReportAt, 1_000, 'first report timestamp');
-  assertEqual(metrics.coalescingDelayP95Ms, 32, 'coalescing delay uses the deterministic clock');
-  assertEqual(JSON.stringify(backend), JSON.stringify([
-    { kind: 'text', at: 1_000 },
-    { kind: 'text', at: 1_001 },
-    { kind: 'text', at: 1_003 },
-    { kind: 'text', at: 1_010 },
-    { kind: 'text', at: 1_011 }
-  ]), 'backend callbacks retain every delta');
+  assertEqual(metrics.coalescingDelayP95Ms, 255, 'coalescing delay uses the deterministic clock');
+  assertEqual(backend.length, 7, 'backend callback retains every delta');
   assertEqual(reported[0].at, 1_000, 'first report remains synchronous');
 
-  const thresholdEmitted = [];
-  const thresholdPresenter = new StreamPresenter(
-    undefined,
-    undefined,
-    () => now,
-    32,
-    3,
-    { set: () => ({ unref() {} }), clear() {} }
-  );
-  const thresholdText = (value) => thresholdPresenter.push({
+  let boundedScheduled;
+  const boundedEmitted = [];
+  const boundedTimers = {
+    set(callback, delayMs) {
+      const timer = {
+        callback() {
+          if (boundedScheduled === timer) {
+            boundedScheduled = undefined;
+          }
+          callback();
+        },
+        delayMs,
+        dueAt: now + delayMs
+      };
+      boundedScheduled = timer;
+      return boundedScheduled;
+    },
+    clear(timer) {
+      if (boundedScheduled === timer) {
+        boundedScheduled = undefined;
+      }
+    }
+  };
+  const boundedPresenter = new StreamPresenter(undefined, undefined, {
+    now: () => now,
+    minReportIntervalMs: 250,
+    maxReportIntervalMs: 2_000,
+    maxReportCharacters: 512,
+    timerApi: boundedTimers
+  });
+  const boundedText = (value) => boundedPresenter.push({
     kind: 'text',
     identity: 'text',
     text: value,
-    emit: (presented) => thresholdEmitted.push(presented)
+    emit: (presented) => boundedEmitted.push(presented)
   });
-  thresholdText('a');
-  thresholdText('b');
-  thresholdText('cd');
-  assertEqual(JSON.stringify(thresholdEmitted), JSON.stringify(['a', 'bcd']), 'character threshold flushes without waiting for a timer');
+  now = 10_000;
+  const streamEndsAt = now + 60_000;
+  let nextDeltaAt = now;
+  let boundedCharacters = 0;
+  while (nextDeltaAt <= streamEndsAt) {
+    while (boundedScheduled && boundedScheduled.dueAt <= nextDeltaAt) {
+      now = boundedScheduled.dueAt;
+      boundedScheduled.callback();
+    }
+    now = nextDeltaAt;
+    boundedText('x');
+    boundedCharacters += 1;
+    nextDeltaAt += 10;
+  }
+  now = streamEndsAt;
+  boundedPresenter.flushBoundary();
+  assertEqual(boundedEmitted.join('').length, boundedCharacters, 'a one-minute dense stream preserves every character');
+  assertEqual(boundedEmitted.length <= 32, true, 'a one-minute dense stream keeps UI updates bounded');
+  assertEqual(boundedPresenter.metrics().largestReportCharacters <= 512, true, 'a dense stream never creates a large tail block');
 
-  const backpressureEmitted = [];
-  const backpressurePresenter = new StreamPresenter(
-    undefined,
-    undefined,
-    () => now,
-    32,
-    768,
-    { set: () => ({ unref() {} }), clear() {} }
-  );
+  let drainScheduled;
+  const drained = [];
+  const drainTimers = {
+    set(callback, delayMs) {
+      const timer = {
+        callback() {
+          if (drainScheduled === timer) {
+            drainScheduled = undefined;
+          }
+          callback();
+        },
+        delayMs,
+        dueAt: now + delayMs
+      };
+      drainScheduled = timer;
+      return drainScheduled;
+    },
+    clear(timer) {
+      if (drainScheduled === timer) {
+        drainScheduled = undefined;
+      }
+    }
+  };
+  const drainPresenter = new StreamPresenter(undefined, undefined, {
+    now: () => now,
+    minReportIntervalMs: 250,
+    maxReportIntervalMs: 2_000,
+    maxReportCharacters: 512,
+    timerApi: drainTimers
+  });
+  now = 100_000;
   for (let index = 0; index < 1_000; index += 1) {
-    backpressurePresenter.push({
+    drainPresenter.push({
       kind: 'text',
       identity: 'text',
       text: 'ab',
-      emit: (presented) => backpressureEmitted.push(presented)
+      emit: (presented) => drained.push(presented)
     });
   }
-  assertEqual(
-    backpressurePresenter.pendingCharacters,
-    462,
-    'backpressure metrics expose characters waiting at a semantic boundary'
-  );
-  backpressurePresenter.flushBoundary();
-  assertEqual(backpressureEmitted.join('').length, 2_000, 'a tiny-delta burst preserves all streamed text');
-  assertEqual(backpressureEmitted.length, 4, 'a tiny-delta burst is downsampled before reaching Chat UI');
-  console.log('Smoke test passed: stream presentation coalesces adjacent deltas without delaying a new logical stream.');
+  assertEqual(drainPresenter.pendingCharacters, 1_998, 'a burst remains queued instead of flooding the UI');
+  const drainPromise = drainPresenter.drainBoundary();
+  while (drainPresenter.pendingCharacters > 0) {
+    while (!drainScheduled && drainPresenter.pendingCharacters > 0) {
+      await Promise.resolve();
+    }
+    if (drainPresenter.pendingCharacters === 0) {
+      break;
+    }
+    const current = drainScheduled;
+    now = current.dueAt;
+    current.callback();
+  }
+  await drainPromise;
+  const drainMetrics = drainPresenter.metrics();
+  assertEqual(drained.join('').length, 2_000, 'completion drain preserves every buffered character');
+  assertEqual(drained.length, 5, 'completion drain uses bounded chunks');
+  assertEqual(drainMetrics.largestReportCharacters, 512, 'completion drain has a strict chunk-size ceiling');
+  assertEqual(drainMetrics.boundaryDrainReportCount, 4, 'completion drain reports its paced tail work');
+  assertEqual(drainMetrics.boundaryDrainDurationMs, 1_000, 'completion waits for paced tail delivery');
+
+  const unicode = [];
+  const unicodePresenter = new StreamPresenter(undefined, undefined, {
+    now: () => now,
+    minReportIntervalMs: 0,
+    maxReportIntervalMs: 0,
+    maxReportCharacters: 2,
+    timerApi: { set: () => ({ unref() {} }), clear() {} }
+  });
+  unicodePresenter.push({
+    kind: 'text',
+    identity: 'text',
+    text: 'a😀b',
+    emit: (presented) => unicode.push(presented)
+  });
+  unicodePresenter.flushBoundary();
+  assertEqual(unicode.join(''), 'a😀b', 'bounded chunks do not split a Unicode surrogate pair');
+
+  console.log('Smoke test passed: stream presentation uses a paced bounded queue and drains completion backlog.');
 } finally {
   await loaded.dispose();
 }

--- a/test/smokeStreamPresenter.mjs
+++ b/test/smokeStreamPresenter.mjs
@@ -123,7 +123,7 @@ try {
   });
   assertEqual(defaultEmitted[0].length, 64, 'default first report stays within the Chat playback budget');
   assertEqual(defaultPresenter.pendingCharacters, 36, 'default presenter queues text beyond the playback budget');
-  assertEqual(defaultScheduled?.dueAt, 5_250, 'default queued text advances at the bounded report cadence');
+  assertEqual(defaultScheduled?.dueAt, 5_080, 'default queued text advances at a smooth bounded cadence');
 
   let observedScheduled;
   const observedTimers = {
@@ -171,6 +171,16 @@ try {
     observedPresenter.pendingCharacters <= 64,
     true,
     'default pacing keeps up with the observed backend character rate'
+  );
+  assertEqual(
+    observedPresenter.metrics().progressReportCount >= 120,
+    true,
+    'default pacing presents a sustained stream at ten or more updates per second'
+  );
+  assertEqual(
+    observedPresenter.metrics().progressReportCount <= 160,
+    true,
+    'default pacing remains bounded below fourteen updates per second'
   );
 
   let boundedScheduled;
@@ -288,6 +298,74 @@ try {
   assertEqual(drainMetrics.largestReportCharacters, 512, 'completion drain has a strict chunk-size ceiling');
   assertEqual(drainMetrics.boundaryDrainReportCount, 4, 'completion drain reports its paced tail work');
   assertEqual(drainMetrics.boundaryDrainDurationMs, 1_000, 'completion waits for paced tail delivery');
+
+  let smoothingScheduled;
+  const smoothed = [];
+  const smoothingTimers = {
+    set(callback, delayMs) {
+      const timer = {
+        callback() {
+          if (smoothingScheduled === timer) {
+            smoothingScheduled = undefined;
+          }
+          callback();
+        },
+        dueAt: now + delayMs
+      };
+      smoothingScheduled = timer;
+      return timer;
+    },
+    clear(timer) {
+      if (smoothingScheduled === timer) {
+        smoothingScheduled = undefined;
+      }
+    }
+  };
+  const smoothingPresenter = new StreamPresenter(undefined, undefined, {
+    now: () => now,
+    minReportIntervalMs: 80,
+    maxReportIntervalMs: 100,
+    maxReportCharacters: 64,
+    targetReportCharacters: 20,
+    smoothingBufferCharacters: 100,
+    timerApi: smoothingTimers
+  });
+  now = 200_000;
+  smoothingPresenter.push({
+    kind: 'text',
+    identity: 'text',
+    text: 'x'.repeat(240),
+    emit: (presented) => smoothed.push({ at: now, text: presented })
+  });
+  while (smoothingScheduled?.dueAt <= 200_560) {
+    now = smoothingScheduled.dueAt;
+    smoothingScheduled.callback();
+  }
+  assertEqual(
+    JSON.stringify(smoothed.slice(-4).map((part) => part.at)),
+    JSON.stringify([200_260, 200_360, 200_460, 200_560]),
+    'a buffered burst keeps presenting through a backend delta gap'
+  );
+  assertEqual(smoothingPresenter.pendingCharacters, 12, 'normal playback retains a small smoothing reserve');
+  const smoothingDrainPromise = smoothingPresenter.drainBoundary();
+  while (smoothingPresenter.pendingCharacters > 0) {
+    while (!smoothingScheduled && smoothingPresenter.pendingCharacters > 0) {
+      await Promise.resolve();
+    }
+    if (smoothingPresenter.pendingCharacters === 0) {
+      break;
+    }
+    now = smoothingScheduled.dueAt;
+    smoothingScheduled.callback();
+  }
+  await smoothingDrainPromise;
+  assertEqual(smoothed.map((part) => part.text).join('').length, 240, 'buffered playback preserves every character');
+  const smoothingMetrics = smoothingPresenter.metrics();
+  assertEqual(smoothingMetrics.reportedCharacterCount, 240, 'buffered playback reports its aggregate character count');
+  assertEqual(smoothingMetrics.maxPendingCharacters, 220, 'buffered playback reports its peak reserve depth');
+  assertEqual(smoothingMetrics.catchUpReportCount, 3, 'buffered playback reports threshold and completion catch-up frames');
+  assertEqual(smoothingMetrics.reportGapMaxMs, 100, 'buffered playback reports its largest visible frame gap');
+  assertEqual(smoothingMetrics.boundaryDrainDurationMs, 0, 'completion immediately emits one small remaining frame');
 
   const unicode = [];
   const unicodePresenter = new StreamPresenter(undefined, undefined, {

--- a/test/smokeStreamPresenter.mjs
+++ b/test/smokeStreamPresenter.mjs
@@ -23,8 +23,8 @@ try {
     (kind, at) => backend.push({ kind, at }),
     (kind, at) => reported.push({ kind, at }),
     () => now,
-    8,
-    256,
+    32,
+    768,
     timers
   );
   const text = (value) => presenter.push({
@@ -42,10 +42,10 @@ try {
   text('b');
   now = 1_003;
   text('c');
-  assertEqual(scheduled?.delayMs, 8, 'later delta uses an eight millisecond timer');
+  assertEqual(scheduled?.delayMs, 32, 'later delta aligns with the Extension Host batching interval');
   assertEqual(emitted.length, 1, 'small adjacent deltas are buffered');
 
-  now = 1_009;
+  now = 1_033;
   scheduled.callback();
   assertEqual(JSON.stringify(emitted), JSON.stringify([
     { kind: 'text', text: 'a' },
@@ -70,7 +70,7 @@ try {
   assertEqual(metrics.coalescedDeltaCount, 1, 'only collapsed delta reports are counted');
   assertEqual(metrics.firstBackendDeltaAt, 1_000, 'first backend delta timestamp');
   assertEqual(metrics.firstReportAt, 1_000, 'first report timestamp');
-  assertEqual(metrics.coalescingDelayP95Ms, 8, 'coalescing delay uses the deterministic clock');
+  assertEqual(metrics.coalescingDelayP95Ms, 32, 'coalescing delay uses the deterministic clock');
   assertEqual(JSON.stringify(backend), JSON.stringify([
     { kind: 'text', at: 1_000 },
     { kind: 'text', at: 1_001 },
@@ -85,7 +85,7 @@ try {
     undefined,
     undefined,
     () => now,
-    8,
+    32,
     3,
     { set: () => ({ unref() {} }), clear() {} }
   );
@@ -99,6 +99,32 @@ try {
   thresholdText('b');
   thresholdText('cd');
   assertEqual(JSON.stringify(thresholdEmitted), JSON.stringify(['a', 'bcd']), 'character threshold flushes without waiting for a timer');
+
+  const backpressureEmitted = [];
+  const backpressurePresenter = new StreamPresenter(
+    undefined,
+    undefined,
+    () => now,
+    32,
+    768,
+    { set: () => ({ unref() {} }), clear() {} }
+  );
+  for (let index = 0; index < 1_000; index += 1) {
+    backpressurePresenter.push({
+      kind: 'text',
+      identity: 'text',
+      text: 'ab',
+      emit: (presented) => backpressureEmitted.push(presented)
+    });
+  }
+  assertEqual(
+    backpressurePresenter.metrics().pendingPresentationCharacters,
+    462,
+    'backpressure metrics expose characters waiting at a semantic boundary'
+  );
+  backpressurePresenter.flushBoundary();
+  assertEqual(backpressureEmitted.join('').length, 2_000, 'a tiny-delta burst preserves all streamed text');
+  assertEqual(backpressureEmitted.length, 4, 'a tiny-delta burst is downsampled before reaching Chat UI');
   console.log('Smoke test passed: stream presentation coalesces adjacent deltas without delaying a new logical stream.');
 } finally {
   await loaded.dispose();

--- a/test/smokeStreamPresenter.mjs
+++ b/test/smokeStreamPresenter.mjs
@@ -118,7 +118,7 @@ try {
     });
   }
   assertEqual(
-    backpressurePresenter.metrics().pendingPresentationCharacters,
+    backpressurePresenter.pendingCharacters,
     462,
     'backpressure metrics expose characters waiting at a semantic boundary'
   );


### PR DESCRIPTION
## Summary

- smooth Chat text playback with a bounded, adaptive presentation queue:
  - target small updates of about 20 characters for normal playback
  - cap individual text reports at 64 characters
  - pace reports on an 80–100 ms cadence
  - switch to larger catch-up chunks only when the pending presentation backlog exceeds 1,024 characters
- drain the remaining presentation queue before the provider returns, then publish usage data, so Copilot Chat does not receive a large post-completion text tail
- preserve immediate semantic boundaries for tool calls while avoiding raw-reasoning fallback output being queued ahead of tool execution
- stabilize response continuation reuse across normal history replay and Native Tool Search:
  - allow locally verified history fallback when a valid stateful marker is present but not leading/standalone
  - use key-stable serialization for function-call arguments so equivalent tool calls are not rejected because of object-key order
  - keep WebSocket tool-output continuation on the completed `previous_response_id` and existing socket when the local history is compatible
  - expose detailed continuation eligibility / local-history diagnostics
- avoid unnecessary credential lookup when the configured backend cannot use the official token-counting endpoint, and record local token-estimate count / duration diagnostics
- expand latency and presentation telemetry with report size, pending depth, catch-up activity, report gaps, completion-drain work, backend tail timing, and continuation snapshot/store cost

## Why

`progress.report()` does not provide acknowledgement or backpressure from Copilot Chat's downstream consumer. Reporting every backend delta creates excessive UI work, while over-coalescing produces visible pauses followed by large bursts or a long playback tail after the backend response has already completed.

The adaptive presenter keeps normal output visually smooth with small, frequent updates, but can catch up with bounded larger chunks if producer throughput temporarily outruns presentation. Any residual queue is drained before provider completion so the extension does not hand Copilot Chat a large amount of deferred presentation work.

The same PR also fixes continuation-reuse cases discovered while exercising long tool-enabled conversations. Continuation now depends on exact locally verified request/history compatibility rather than marker placement or JSON object-key ordering, while preserving the existing request-envelope and canonical-history safety checks.

## Continuation reuse

Continuation remains conservative:

- a leading standalone stateful marker is still treated as the authoritative continuation hint
- otherwise, a stored branch is reused only when its reconstructed local history is exactly compatible with the current conversation
- Native Tool Search function-call arguments use the same key-stable representation for stored response items and local replay comparison
- eligible WebSocket tool-result turns reuse the completed response id and the existing connection, sending only the incremental `function_call_output`
- continuation misses retain the existing recovery path instead of importing incompatible local history

Additional diagnostics report marker shape, history-fallback selection, candidate-branch presence, `localHistoryStatus`, continuation snapshot/store time, and provider-tail timing.

## Token counting

For backends that cannot use the official token-counting endpoint, `provideTokenCount()` now returns the existing local estimate before attempting to load API credentials. This removes unnecessary credential work from a path that can only fall back locally anyway.

The provider also records aggregate local-estimate count and duration since activation to make token-counting overhead visible in request diagnostics.

## Runtime verification

Earlier real Extension Development Host testing, before the final playback-tuning pass, verified the core continuation and completion-drain behavior across consecutive conversations:

- continued model turns reported compatible local history
- eligible follow-up turns reused `previous_response_id` and the existing WebSocket
- no HTTP fallback or response failure occurred in those runs
- the earlier minutes-long post-response UI tail was no longer observed

The final head further tunes the presentation cadence/chunking and adds token-counting diagnostics, so the older per-report size and timing measurements are intentionally not presented as measurements of the final tuning.

## Validation

Current head (`4147ab3`) passes the repository Pull Request CI, including:

- changed-file whitespace checks
- TypeScript checks
- extension compilation
- smoke tests
- Extension Host smoke test

Targeted smoke coverage includes adaptive stream pacing and bounded catch-up behavior, completion draining, Unicode-safe chunking, continuation history fallback, stable Native Tool Search argument replay, WebSocket tool-output continuation/recovery, reasoning/tool boundaries, latency telemetry, and local token-estimate diagnostics.