### PR TITLE
feat: add hosted Codex web search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Codex For Copilot is a lightweight VS Code Language Model Provider that connects
 - **Automatic model discovery** — exposes available upstream Codex models with configurable fallbacks.
 - **Fast streaming transport** — supports reusable WebSocket sessions with HTTP fallback.
 - **VS Code tool support** — forwards built-in, extension, and MCP tool calls through the Responses API.
+- **Hosted Web Search** — optionally gives Codex live web access through OpenAI's native Responses tool, with clickable sources.
 - **Optional Native Tool Search** — lets compatible Codex models search selected Agent tools on demand when you explicitly enable it.
 - **Conversation continuity** — reuses compatible response branches for efficient follow-up turns.
 - **Usage visibility** — shows available account limits or Credits in the status bar when supplied by the backend.
@@ -45,6 +46,8 @@ The extension stores imported and signed-in ChatGPT credentials in VS Code Secre
 
 Open VS Code Chat, choose **Codex** from the model picker, and start chatting or using Agent mode.
 
+To give a request live web access, enable **Web Search** in the Chat tools picker or reference `#webSearch` in the prompt. The Codex backend executes the search directly; the extension does not expose it as a VS Code function call.
+
 ## Tool discovery
 
 The extension uses **VS Code Virtual Tool Groups by default**. VS Code organizes selected Agent tools into groups and reveals a group when the model needs it.
@@ -52,6 +55,8 @@ The extension uses **VS Code Virtual Tool Groups by default**. VS Code organizes
 **Native Tool Search is optional.** When enabled, it temporarily disables VS Code Virtual Tool Groups and instead lets the Codex backend search the selected tool catalog and load matching tools on demand. Both methods solve the same problem—avoiding loading every tool into the model at once—but VS Code performs the grouping in the default mode, while Codex performs the search in Native Tool Search mode.
 
 Use **`Codex: Enable Native Tool Search`** to opt in. The extension saves the previous VS Code grouping setting. Use **`Codex: Use VS Code Virtual Tool Groups`** to disable Native Tool Search and restore that setting. Tool execution, confirmation, workspace trust, and permissions remain handled by VS Code in both modes.
+
+Hosted Web Search is independent from Native Tool Search. It remains available when Native Tool Search is disabled and is only combined with selected client tools in the final Responses API `tools` array.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Open VS Code Chat, choose **Codex** from the model picker, and start chatting or
 
 To give a request live web access, enable **Web Search** in the Chat tools picker or reference `#webSearch` in the prompt. The Codex backend executes the search directly; the extension does not expose it as a VS Code function call.
 
+Web Search settings under **Settings → Extensions → Codex** let you choose live or cached access, search context size, and an optional domain allowlist. You can also choose whether Chat shows compact statuses, search/open/find actions, or actions with clickable source pages.
+
 ## Tool discovery
 
 The extension uses **VS Code Virtual Tool Groups by default**. VS Code organizes selected Agent tools into groups and reveals a group when the model needs it.
@@ -99,6 +101,7 @@ Most users can keep the defaults. Advanced settings are available under **Settin
 - fallback model and model visibility
 - reasoning effort and service tier
 - request compression and WebSocket prewarming
+- Web Search access, context, domains, and status detail
 
 For a proxy-required network, set VS Code's `http.proxy` setting or the Extension Host's `HTTPS_PROXY`/`HTTP_PROXY` environment variable. The provider applies that proxy consistently to model discovery, account usage, HTTP Responses requests, token counting, and WebSocket requests; `NO_PROXY` remains honored.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "https-proxy-agent": "^7.0.6",
-        "openai": "^6.44.0",
+        "openai": "^7.8.0",
         "undici": "^7.29.0",
         "ws": "^8.21.0"
       },
@@ -3369,15 +3369,34 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.44.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
-      "integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-7.8.0.tgz",
+      "integrity": "sha512-/2g9JzdnXNcjX1W/UlSNu+OdSFDAaAVt0n9Onom0kPenH54o59G2WrX/xjTnr26UHNSh6hxcAf58doGYRme2rw==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      },
       "peerDependencies": {
-        "ws": "^8.18.0",
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "undici": ">=5 <9",
+        "ws": "^8.21.0",
         "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "undici": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "test:real-backend": "node test/realBackendProbe.mjs",
     "test:benchmark-backend": "node test/benchmarkBackend.mjs",
     "test:benchmark-provider": "node test/benchmarkProviderBackend.mjs",
-    "test:codex-parity": "node test/smokeCodexProtocol.mjs && node test/smokeCodexIdentity.mjs && node test/smokeCodexRequestBuilder.mjs && node test/smokeCodexToolSchemaCache.mjs && node test/smokeCodexTurnLifecycle.mjs && node test/smokeCodexHttpLifecycle.mjs && node test/smokeCodexWebSocketLifecycle.mjs && node test/smokeCodexPreconnection.mjs && node test/smokeCodexPrewarmBudget.mjs && node test/smokeCodexCancellation.mjs && node test/smokeCodexFallback.mjs && node test/smokeCodexCompression.mjs && node test/smokeNativeToolPolicy.mjs && node test/smokeNativeToolCatalog.mjs && node test/smokeNativeToolNamespaces.mjs && node test/smokeNativeToolCallMapper.mjs && node test/smokeNativeToolSearchEvents.mjs && node test/smokeNativeToolSearchLogging.mjs && node test/smokeNativeToolContinuation.mjs && node test/smokeNativeToolFallback.mjs && node test/smokeNativeToolOptIn.mjs && node test/smokeNativeToolGroupingBridge.mjs && node test/smokeNativeToolSearchStatus.mjs",
+    "test:codex-parity": "node test/smokeCodexProtocol.mjs && node test/smokeCodexIdentity.mjs && node test/smokeCodexRequestBuilder.mjs && node test/smokeHostedWebSearch.mjs && node test/smokeCodexToolSchemaCache.mjs && node test/smokeCodexTurnLifecycle.mjs && node test/smokeCodexHttpLifecycle.mjs && node test/smokeCodexWebSocketLifecycle.mjs && node test/smokeCodexPreconnection.mjs && node test/smokeCodexPrewarmBudget.mjs && node test/smokeCodexCancellation.mjs && node test/smokeCodexFallback.mjs && node test/smokeCodexCompression.mjs && node test/smokeNativeToolPolicy.mjs && node test/smokeNativeToolCatalog.mjs && node test/smokeNativeToolNamespaces.mjs && node test/smokeNativeToolCallMapper.mjs && node test/smokeNativeToolSearchEvents.mjs && node test/smokeNativeToolSearchLogging.mjs && node test/smokeNativeToolContinuation.mjs && node test/smokeNativeToolFallback.mjs && node test/smokeNativeToolOptIn.mjs && node test/smokeNativeToolGroupingBridge.mjs && node test/smokeNativeToolSearchStatus.mjs",
     "test:smoke": "npm run test:codex-parity && node test/smokeCodexLogger.mjs && node test/smokeReasoningEffort.mjs && node test/smokeCodexLatency.mjs && node test/smokeStreamPresenter.mjs && node test/smokeReasoningStreamPresenter.mjs && node test/smokeCodexModelCache.mjs && node test/smokeResponsesClient.mjs && node test/smokeProviderFallback.mjs && node test/smokeConversationReuse.mjs && node test/smokeAccountUsage.mjs && node test/smokeAuth.mjs",
     "watch": "tsc -watch -p ./",
     "vscode:prepublish": "npm run compile"
   },
   "dependencies": {
     "https-proxy-agent": "^7.0.6",
-    "openai": "^6.44.0",
+    "openai": "^7.8.0",
     "undici": "^7.29.0",
     "ws": "^8.21.0"
   },
@@ -67,6 +67,26 @@
         "vendor": "codex-for-copilot",
         "displayName": "Codex",
         "managementCommand": "codexModelProvider.manage"
+      }
+    ],
+    "languageModelTools": [
+      {
+        "name": "codexForCopilot_searchWeb",
+        "displayName": "Web Search",
+        "modelDescription": "Lets a Codex For Copilot model search the public web through OpenAI's hosted Responses web_search tool. Search is executed by the Codex backend, so this tool has no client-side arguments or function result.",
+        "userDescription": "Search the web using the Codex backend.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "webSearch",
+        "icon": "$(globe)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        },
+        "tags": [
+          "web",
+          "search"
+        ]
       }
     ],
     "commands": [

--- a/package.json
+++ b/package.json
@@ -238,6 +238,61 @@
           ],
           "description": "Controls Zstandard compression for large ChatGPT Codex Responses requests."
         },
+        "codexModelProvider.webSearchExternalAccess": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow hosted Web Search to fetch live internet content. Disable this to use only cached or indexed content."
+        },
+        "codexModelProvider.webSearchContextSize": {
+          "type": "string",
+          "default": "default",
+          "enum": [
+            "default",
+            "low",
+            "medium",
+            "high"
+          ],
+          "enumDescriptions": [
+            "Let the backend use its default search context size.",
+            "Use less search-result context for quick lookups.",
+            "Use a balanced amount of search-result context.",
+            "Use more search-result context for detailed answers."
+          ],
+          "description": "Amount of web search result context made available to the model. This does not guarantee a source count."
+        },
+        "codexModelProvider.webSearchAllowedDomains": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$"
+          },
+          "maxItems": 100,
+          "uniqueItems": true,
+          "description": "Optional Web Search domain allowlist. Enter domain names without http://, https://, paths, or wildcards; matching subdomains are included."
+        },
+        "codexModelProvider.webSearchStatusDetail": {
+          "type": "string",
+          "default": "actionsAndSources",
+          "enum": [
+            "compact",
+            "actions",
+            "actionsAndSources"
+          ],
+          "enumDescriptions": [
+            "Show only a compact completed Web Search status.",
+            "Show search queries, opened pages, and find-in-page actions.",
+            "Show actions plus clickable source pages returned by search calls."
+          ],
+          "description": "Controls how much completed hosted Web Search activity is shown in Chat."
+        },
+        "codexModelProvider.webSearchStatusMaxSources": {
+          "type": "number",
+          "default": 3,
+          "minimum": 0,
+          "maximum": 10,
+          "description": "Maximum clickable source pages shown on each detailed Web Search status line. Set to 0 to hide sources while keeping action details."
+        },
         "codexModelProvider.protocolProfile": {
           "type": "string",
           "default": "auto",

--- a/src/codexLatency.ts
+++ b/src/codexLatency.ts
@@ -58,6 +58,8 @@ export interface CodexLatencyContext {
   fullInputCount?: number;
   requestBodyBytes?: number;
   toolCount?: number;
+  hostedToolCount?: number;
+  hostedWebSearch?: boolean;
   toolSchemaBytes?: number;
   legacyToolSchemaCacheHit?: boolean;
   nativeToolCatalogCacheHit?: boolean;
@@ -157,6 +159,12 @@ export class CodexLatencyRecorder {
     }
     if (context.toolCount !== undefined) {
       this.context.toolCount = context.toolCount;
+    }
+    if (context.hostedToolCount !== undefined) {
+      this.context.hostedToolCount = context.hostedToolCount;
+    }
+    if (context.hostedWebSearch !== undefined) {
+      this.context.hostedWebSearch = context.hostedWebSearch;
     }
     if (context.toolSchemaBytes !== undefined) {
       this.context.toolSchemaBytes = context.toolSchemaBytes;

--- a/src/codexRequestBuilder.ts
+++ b/src/codexRequestBuilder.ts
@@ -1,10 +1,16 @@
 import { performance } from 'node:perf_hooks';
-import type { ResponseCreateParamsStreaming, ToolChoiceOptions } from 'openai/resources/responses/responses';
+import type {
+  ResponseCreateParamsStreaming,
+  ResponseIncludable,
+  Tool,
+  ToolChoiceOptions
+} from 'openai/resources/responses/responses';
 import type { Reasoning } from 'openai/resources/shared';
 import * as vscode from 'vscode';
 import type { ResponsesInputMessage } from './convertMessages';
 import { resolveCodexToolSchemas } from './codexToolSchemaCache';
 import type { CodexToolPlan } from './nativeToolSearch/nativeToolTypes';
+import { hasHostedWebSearch } from './hostedTools/hostedToolPlan';
 import {
   buildCodexClientMetadataProjection,
   buildCodexProtocolSnapshot,
@@ -30,6 +36,7 @@ export interface CodexRequestBuilderOptions {
   input: ResponsesInputMessage[];
   tools?: readonly vscode.LanguageModelChatTool[];
   toolPlan?: CodexToolPlan;
+  hostedTools?: readonly Tool[];
   toolMode?: vscode.LanguageModelChatToolMode;
   reasoning?: Reasoning;
   serviceTier?: 'default' | 'priority';
@@ -72,7 +79,9 @@ export function buildCodexResponsesRequestWithMetrics(
   const startedAt = performance.now();
   const legacyToolSchemas = options.toolPlan ? undefined : resolveCodexToolSchemas(options.tools);
   const toolPlan = options.toolPlan;
-  const tools = toolPlan?.responseTools ?? legacyToolSchemas?.responseTools ?? [];
+  const clientTools = toolPlan?.responseTools ?? legacyToolSchemas?.responseTools ?? [];
+  const hostedTools = options.hostedTools ?? [];
+  const tools: readonly Tool[] = [...clientTools, ...hostedTools];
   const protocolSnapshot = options.compatibilityEnabled && options.identity
     ? buildCodexProtocolSnapshot({
         identity: options.identity,
@@ -85,12 +94,18 @@ export function buildCodexResponsesRequestWithMetrics(
   const metadata = protocolSnapshot
     ? buildCodexClientMetadataProjection(protocolSnapshot, options.websocketRequestStartedAt)
     : undefined;
+  const include: ResponseIncludable[] = [
+    ...(options.compatibilityEnabled && options.includeEncryptedReasoning !== false
+      ? ['reasoning.encrypted_content' as const]
+      : []),
+    ...(hasHostedWebSearch(hostedTools) ? ['web_search_call.action.sources' as const] : [])
+  ];
   const compatibilityFields = options.compatibilityEnabled
     ? {
-        include: options.includeEncryptedReasoning === false ? [] : ['reasoning.encrypted_content'],
+        ...(include.length > 0 ? { include } : {}),
         ...(options.textVerbosity ? { text: { verbosity: options.textVerbosity } } : {})
       }
-    : {};
+    : include.length > 0 ? { include } : {};
   const identityFields = options.compatibilityEnabled && options.identity
     ? {
         prompt_cache_key: options.identity.threadId,
@@ -123,7 +138,8 @@ export function buildCodexResponsesRequestWithMetrics(
     request,
     metrics: {
       requestBuildMs: Math.max(0, performance.now() - startedAt),
-      toolSchemaBytes: toolPlan?.toolSchemaBytes ?? legacyToolSchemas?.toolSchemaBytes ?? 0,
+      toolSchemaBytes: (toolPlan?.toolSchemaBytes ?? legacyToolSchemas?.toolSchemaBytes ?? 0)
+        + Buffer.byteLength(JSON.stringify(hostedTools)),
       legacyToolSchemaCacheHit: toolPlan?.legacyToolSchemaCacheHit ?? legacyToolSchemas?.cacheHit,
       nativeToolCatalogCacheHit: toolPlan?.nativeToolCatalogCacheHit
     }
@@ -215,7 +231,7 @@ function sanitizeResponseItemIdForOutbound(item: ResponsesInputMessage): Respons
 }
 
 function isAcceptedResponsesItemId(id: string): boolean {
-  return /^(msg|fc|fco|rs|item)_[A-Za-z0-9_-]+$/.test(id);
+  return /^(msg|fc|fco|rs|ws|item)_[A-Za-z0-9_-]+$/.test(id);
 }
 
 function mapToolChoice(toolMode: vscode.LanguageModelChatToolMode | undefined): ToolChoiceOptions {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,14 @@ export interface ModelPricing {
   output?: number;
 }
 
+export interface WebSearchConfig {
+  externalWebAccess: boolean;
+  contextSize?: 'low' | 'medium' | 'high';
+  allowedDomains: string[];
+  statusDetail: 'compact' | 'actions' | 'actionsAndSources';
+  statusMaxSources: number;
+}
+
 export interface ProviderConfig {
   baseURL: string;
   clientVersion: string;
@@ -19,6 +27,7 @@ export interface ProviderConfig {
   protocol: CodexProtocolSettings;
   nativeToolSearch: 'auto' | 'enabled' | 'disabled';
   nativeToolSearchMaxToolsPerNamespace: number;
+  webSearch: WebSearchConfig;
   model: string;
   includeHiddenModels: boolean;
   disabledModels: string[];
@@ -52,6 +61,13 @@ export function getProviderConfig(): ProviderConfig {
     nativeToolSearchMaxToolsPerNamespace: normalizeNativeToolSearchMaxToolsPerNamespace(
       config.get('nativeToolSearchMaxToolsPerNamespace', MAX_NAMESPACE_FUNCTIONS)
     ),
+    webSearch: {
+      externalWebAccess: config.get('webSearchExternalAccess', true),
+      contextSize: normalizeWebSearchContextSize(config.get('webSearchContextSize', 'default')),
+      allowedDomains: normalizeWebSearchDomains(config.get('webSearchAllowedDomains', [])),
+      statusDetail: normalizeWebSearchStatusDetail(config.get('webSearchStatusDetail', 'actionsAndSources')),
+      statusMaxSources: normalizeWebSearchStatusMaxSources(config.get('webSearchStatusMaxSources', 3))
+    },
     model: config.get('model', 'gpt-5.5'),
     includeHiddenModels: config.get('includeHiddenModels', false),
     disabledModels: normalizeStringList(config.get('disabledModels', [])),
@@ -80,6 +96,39 @@ function normalizeNativeToolSearchMaxToolsPerNamespace(value: unknown): number {
     return MAX_NAMESPACE_FUNCTIONS;
   }
   return Math.min(MAX_NAMESPACE_FUNCTIONS, Math.max(1, Math.floor(value)));
+}
+
+function normalizeWebSearchContextSize(value: unknown): WebSearchConfig['contextSize'] {
+  return value === 'low' || value === 'medium' || value === 'high' ? value : undefined;
+}
+
+function normalizeWebSearchStatusDetail(value: unknown): WebSearchConfig['statusDetail'] {
+  return value === 'compact' || value === 'actions' ? value : 'actionsAndSources';
+}
+
+function normalizeWebSearchStatusMaxSources(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 3;
+  }
+  return Math.min(10, Math.max(0, Math.floor(value)));
+}
+
+function normalizeWebSearchDomains(value: unknown): string[] {
+  return [...new Set(normalizeStringList(value)
+    .map((domain) => domain.toLowerCase())
+    .filter(isDomainName))]
+    .slice(0, 100);
+}
+
+function isDomainName(value: string): boolean {
+  if (value.length === 0 || value.length > 253 || value.includes('://') || value.includes('/')) {
+    return false;
+  }
+  return value.split('.').every((label) => (
+    label.length > 0
+    && label.length <= 63
+    && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+  ));
 }
 
 function normalizeTransport(value: string): ProviderConfig['transport'] {

--- a/src/convertMessages.ts
+++ b/src/convertMessages.ts
@@ -339,17 +339,18 @@ function normalizeDanglingFunctionCallsForReplay(input: ResponsesInputMessage[])
       continue;
     }
 
+    const callId = firstNonEmptyString(item.call_id);
     if (isReplayableFunctionCall(item)) {
-      replayableFunctionCallIds.add(item.call_id);
-    } else {
-      malformedFunctionCallIds.add(item.call_id);
+      replayableFunctionCallIds.add(callId);
+    } else if (callId) {
+      malformedFunctionCallIds.add(callId);
     }
   }
   const outputCallIds = new Set(
     input
       .filter((item) => item.type === 'function_call_output')
-      .filter((item) => replayableFunctionCallIds.has(item.call_id))
-      .map((item) => item.call_id)
+      .map((item) => firstNonEmptyString(item.call_id))
+      .filter((callId) => replayableFunctionCallIds.has(callId))
   );
   const normalized: ResponsesInputMessage[] = [];
 
@@ -359,7 +360,7 @@ function normalizeDanglingFunctionCallsForReplay(input: ResponsesInputMessage[])
         continue;
       }
 
-      if (outputCallIds.has(item.call_id)) {
+      if (outputCallIds.has(firstNonEmptyString(item.call_id))) {
         normalized.push(item);
         continue;
       }
@@ -373,7 +374,8 @@ function normalizeDanglingFunctionCallsForReplay(input: ResponsesInputMessage[])
     }
 
     if (item.type === 'function_call_output') {
-      if (firstNonEmptyString(item.call_id) && !malformedFunctionCallIds.has(item.call_id)) {
+      const callId = firstNonEmptyString(item.call_id);
+      if (callId && !malformedFunctionCallIds.has(callId)) {
         normalized.push(item);
       }
       continue;
@@ -850,19 +852,23 @@ function inferComparisonImageMediaType(imageURL: string | undefined): string | u
 }
 
 function canonicalizeHistoryCallId(
-  callId: string,
+  callId: unknown,
   state: {
     callIdAliases: Map<string, string>;
     nextCallOrdinal: number;
   }
 ): string {
-  const existingAlias = state.callIdAliases.get(callId);
+  const normalizedCallId = firstNonEmptyString(callId);
+  if (!normalizedCallId) {
+    return '';
+  }
+  const existingAlias = state.callIdAliases.get(normalizedCallId);
   if (existingAlias) {
     return existingAlias;
   }
 
   const alias = `call_${state.nextCallOrdinal++}`;
-  state.callIdAliases.set(callId, alias);
+  state.callIdAliases.set(normalizedCallId, alias);
   return alias;
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import {
 } from './nativeToolSearch/nativeToolGroupingBridge';
 import { getNativeToolSearchRuntimeStatus } from './nativeToolSearch/nativeToolSearchStatus';
 import { getLastEffectiveCodexProtocol } from './codexProtocol';
+import { registerWebSearchMarkerTool } from './hostedTools/webSearchTool';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const outputChannel = vscode.window.createOutputChannel('Codex Model Provider', { log: true });
@@ -77,6 +78,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       authenticationProvider,
       { supportsMultipleAccounts: true }
     ),
+    registerWebSearchMarkerTool(),
     vscode.lm.registerLanguageModelChatProvider('codex-for-copilot', provider),
     vscode.commands.registerCommand('codexModelProvider.openDebugLogs', () => {
       logger.debug('command.open-logs');

--- a/src/hostedTools/hostedToolEvents.ts
+++ b/src/hostedTools/hostedToolEvents.ts
@@ -1,0 +1,170 @@
+import type {
+  ResponseFunctionWebSearch,
+  ResponseOutputText,
+  ResponsesServerEvent
+} from 'openai/resources/responses/responses';
+
+export interface HostedToolLifecycleEvent {
+  tool: 'web_search';
+  phase: 'in_progress' | 'searching' | 'completed';
+  itemId: string;
+  outputIndex: number;
+  sequenceNumber: number;
+}
+
+export interface WebSearchSource {
+  url: string;
+  title?: string;
+}
+
+export function projectHostedToolLifecycleEvent(
+  event: ResponsesServerEvent
+): HostedToolLifecycleEvent | undefined {
+  switch (event.type) {
+    case 'response.web_search_call.in_progress':
+      return toWebSearchLifecycleEvent(event, 'in_progress');
+    case 'response.web_search_call.searching':
+      return toWebSearchLifecycleEvent(event, 'searching');
+    case 'response.web_search_call.completed':
+      return toWebSearchLifecycleEvent(event, 'completed');
+    default:
+      return undefined;
+  }
+}
+
+export function extractWebSearchSources(item: unknown): WebSearchSource[] {
+  if (!isRecord(item)) {
+    return [];
+  }
+
+  if (item.type === 'web_search_call') {
+    const action = isRecord(item.action) ? item.action : undefined;
+    if (action?.type !== 'search' || !Array.isArray(action.sources)) {
+      return [];
+    }
+    return action.sources.flatMap((source) => {
+      if (!isRecord(source) || source.type !== 'url' || !isHttpURL(source.url)) {
+        return [];
+      }
+      return [{ url: source.url }];
+    });
+  }
+
+  if (item.type !== 'message' || !Array.isArray(item.content)) {
+    return [];
+  }
+  return item.content.flatMap((content) => extractOutputTextSources(content));
+}
+
+export function projectWebSearchReplayItem(item: unknown): ResponseFunctionWebSearch | undefined {
+  if (!isRecord(item)
+    || item.type !== 'web_search_call'
+    || !isNonEmptyString(item.id)
+    || item.status !== 'completed'
+    || !isWebSearchAction(item.action)) {
+    return undefined;
+  }
+  return {
+    type: 'web_search_call',
+    id: item.id,
+    status: 'completed',
+    action: structuredClone(item.action)
+  } as ResponseFunctionWebSearch;
+}
+
+export function formatWebSearchSources(sources: readonly WebSearchSource[]): string | undefined {
+  const uniqueSources = new Map<string, WebSearchSource>();
+  for (const source of sources) {
+    if (!isHttpURL(source.url)) {
+      continue;
+    }
+    const existing = uniqueSources.get(source.url);
+    if (!existing || (!existing.title && source.title)) {
+      uniqueSources.set(source.url, source);
+    }
+  }
+  if (uniqueSources.size === 0) {
+    return undefined;
+  }
+
+  const lines = [...uniqueSources.values()].slice(0, 20).map((source) => {
+    const normalizedURL = new URL(source.url).href;
+    const label = escapeMarkdownLabel(source.title?.trim() || new URL(normalizedURL).hostname);
+    return `- [${label}](<${normalizedURL}>)`;
+  });
+  return `\n\nSources:\n${lines.join('\n')}`;
+}
+
+function toWebSearchLifecycleEvent(
+  event: Extract<ResponsesServerEvent, { item_id: string; output_index: number; sequence_number: number }>,
+  phase: HostedToolLifecycleEvent['phase']
+): HostedToolLifecycleEvent {
+  return {
+    tool: 'web_search',
+    phase,
+    itemId: event.item_id,
+    outputIndex: event.output_index,
+    sequenceNumber: event.sequence_number
+  };
+}
+
+function extractOutputTextSources(content: unknown): WebSearchSource[] {
+  if (!isRecord(content) || content.type !== 'output_text' || !Array.isArray(content.annotations)) {
+    return [];
+  }
+  return content.annotations.flatMap((annotation) => {
+    if (!isRecord(annotation)
+      || annotation.type !== 'url_citation'
+      || !isHttpURL(annotation.url)) {
+      return [];
+    }
+    const citation = annotation as unknown as ResponseOutputText.URLCitation;
+    return [{
+      url: citation.url,
+      ...(isNonEmptyString(citation.title) ? { title: citation.title } : {})
+    }];
+  });
+}
+
+function isWebSearchAction(value: unknown): value is ResponseFunctionWebSearch['action'] {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (value.type === 'search') {
+    return (value.query === undefined || typeof value.query === 'string')
+      && (value.queries === undefined || (Array.isArray(value.queries) && value.queries.every((query) => typeof query === 'string')))
+      && (value.sources === undefined || (Array.isArray(value.sources) && value.sources.every((source) => (
+        isRecord(source) && source.type === 'url' && isHttpURL(source.url)
+      ))));
+  }
+  if (value.type === 'open_page') {
+    return value.url === undefined || value.url === null || isHttpURL(value.url);
+  }
+  return value.type === 'find_in_page'
+    && typeof value.pattern === 'string'
+    && isHttpURL(value.url);
+}
+
+function isHttpURL(value: unknown): value is string {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function escapeMarkdownLabel(value: string): string {
+  return value.replace(/[\\\[\]]/g, '\\$&');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}

--- a/src/hostedTools/hostedToolEvents.ts
+++ b/src/hostedTools/hostedToolEvents.ts
@@ -3,6 +3,7 @@ import type {
   ResponseOutputText,
   ResponsesServerEvent
 } from 'openai/resources/responses/responses';
+import type { WebSearchConfig } from '../config';
 
 export interface HostedToolLifecycleEvent {
   tool: 'web_search';
@@ -15,6 +16,114 @@ export interface HostedToolLifecycleEvent {
 export interface WebSearchSource {
   url: string;
   title?: string;
+}
+
+export interface WebSearchActivity {
+  itemId: string;
+  action: ResponseFunctionWebSearch['action'];
+  sources: WebSearchSource[];
+}
+
+export interface WebSearchStatusPresentation {
+  value: string;
+  itemId: string;
+  actionType?: ResponseFunctionWebSearch['action']['type'];
+}
+
+export class WebSearchStatusPresenter {
+  private readonly reportedItemIds = new Set<string>();
+  private readonly completedLifecycleItemIds = new Set<string>();
+
+  constructor(
+    private readonly settings: Pick<WebSearchConfig, 'statusDetail' | 'statusMaxSources'>
+  ) {}
+
+  present(item: unknown): WebSearchStatusPresentation | undefined {
+    const activity = projectWebSearchActivity(item);
+    if (!activity || this.reportedItemIds.has(activity.itemId)) {
+      return undefined;
+    }
+    this.completedLifecycleItemIds.delete(activity.itemId);
+    this.reportedItemIds.add(activity.itemId);
+    return {
+      value: formatWebSearchActivity(activity, this.settings),
+      itemId: activity.itemId,
+      actionType: activity.action.type
+    };
+  }
+
+  noteCompletedLifecycle(event: HostedToolLifecycleEvent): boolean {
+    if (event.phase !== 'completed'
+      || this.reportedItemIds.has(event.itemId)
+      || this.completedLifecycleItemIds.has(event.itemId)) {
+      return false;
+    }
+    this.completedLifecycleItemIds.add(event.itemId);
+    return true;
+  }
+
+  presentLifecycleFallback(itemId: string): WebSearchStatusPresentation | undefined {
+    if (!this.completedLifecycleItemIds.delete(itemId) || this.reportedItemIds.has(itemId)) {
+      return undefined;
+    }
+    this.reportedItemIds.add(itemId);
+    return {
+      value: '**Searched the web**',
+      itemId
+    };
+  }
+
+  reset(): void {
+    this.reportedItemIds.clear();
+    this.completedLifecycleItemIds.clear();
+  }
+}
+
+export function projectWebSearchActivity(item: unknown): WebSearchActivity | undefined {
+  if (!isRecord(item)
+    || item.type !== 'web_search_call'
+    || item.status !== 'completed'
+    || !isNonEmptyString(item.id)
+    || !isWebSearchAction(item.action)) {
+    return undefined;
+  }
+  return {
+    itemId: item.id,
+    action: structuredClone(item.action),
+    sources: extractWebSearchSources(item)
+  };
+}
+
+export function formatWebSearchActivity(
+  activity: WebSearchActivity,
+  settings: Pick<WebSearchConfig, 'statusDetail' | 'statusMaxSources'>
+): string {
+  if (settings.statusDetail === 'compact') {
+    return '**Searched the web**';
+  }
+
+  const { action } = activity;
+  if (action.type === 'open_page') {
+    return action.url && isHttpURL(action.url)
+      ? `**Opened a web page** · ${formatURLLink(action.url)}`
+      : '**Opened a web page**';
+  }
+  if (action.type === 'find_in_page') {
+    return `**Searched within a web page** · “${escapeMarkdownText(truncateInline(action.pattern, 160))}” · ${formatURLLink(action.url)}`;
+  }
+
+  const queries = [...new Set([
+    ...(action.queries ?? []),
+    ...(action.query ? [action.query] : [])
+  ].map((query) => query.trim()).filter(Boolean))];
+  const shownQueries = queries.slice(0, 3).map((query) => `“${escapeMarkdownText(truncateInline(query, 160))}”`);
+  const querySuffix = shownQueries.length > 0
+    ? ` · ${shownQueries.join(' · ')}${queries.length > shownQueries.length ? ` · +${queries.length - shownQueries.length} queries` : ''}`
+    : '';
+  const sourceSuffix = settings.statusDetail === 'actionsAndSources'
+    ? formatInlineSources(activity.sources, settings.statusMaxSources)
+    : '';
+  return `**Searched the web**${querySuffix}${sourceSuffix}`;
 }
 
 export function projectHostedToolLifecycleEvent(
@@ -70,29 +179,6 @@ export function projectWebSearchReplayItem(item: unknown): ResponseFunctionWebSe
     status: 'completed',
     action: structuredClone(item.action)
   } as ResponseFunctionWebSearch;
-}
-
-export function formatWebSearchSources(sources: readonly WebSearchSource[]): string | undefined {
-  const uniqueSources = new Map<string, WebSearchSource>();
-  for (const source of sources) {
-    if (!isHttpURL(source.url)) {
-      continue;
-    }
-    const existing = uniqueSources.get(source.url);
-    if (!existing || (!existing.title && source.title)) {
-      uniqueSources.set(source.url, source);
-    }
-  }
-  if (uniqueSources.size === 0) {
-    return undefined;
-  }
-
-  const lines = [...uniqueSources.values()].slice(0, 20).map((source) => {
-    const normalizedURL = new URL(source.url).href;
-    const label = escapeMarkdownLabel(source.title?.trim() || new URL(normalizedURL).hostname);
-    return `- [${label}](<${normalizedURL}>)`;
-  });
-  return `\n\nSources:\n${lines.join('\n')}`;
 }
 
 function toWebSearchLifecycleEvent(
@@ -157,8 +243,31 @@ function isHttpURL(value: unknown): value is string {
   }
 }
 
-function escapeMarkdownLabel(value: string): string {
-  return value.replace(/[\\\[\]]/g, '\\$&');
+function formatInlineSources(sources: readonly WebSearchSource[], maxSources: number): string {
+  if (maxSources <= 0) {
+    return '';
+  }
+  const urls = [...new Set(sources.map((source) => source.url).filter(isHttpURL))];
+  if (urls.length === 0) {
+    return '';
+  }
+  const shown = urls.slice(0, maxSources).map(formatURLLink);
+  return ` · ${shown.join(' · ')}${urls.length > shown.length ? ` · +${urls.length - shown.length} sources` : ''}`;
+}
+
+function formatURLLink(value: string): string {
+  const url = new URL(value);
+  const path = url.pathname === '/' ? '' : truncateInline(url.pathname, 48);
+  return `[${escapeMarkdownText(`${url.hostname}${path}`)}](<${url.href}>)`;
+}
+
+function truncateInline(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 1)}…` : normalized;
+}
+
+function escapeMarkdownText(value: string): string {
+  return value.replace(/[\\`*_{}\[\]()#+.!|<>-]/g, '\\$&');
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/hostedTools/hostedToolPlan.ts
+++ b/src/hostedTools/hostedToolPlan.ts
@@ -1,5 +1,6 @@
 import type { Tool, WebSearchTool } from 'openai/resources/responses/responses';
 import type * as vscode from 'vscode';
+import type { WebSearchConfig } from '../config';
 
 export const CODEX_WEB_SEARCH_TOOL_NAME = 'codexForCopilot_searchWeb';
 
@@ -9,17 +10,13 @@ export interface HostedToolPlan {
   webSearchEnabled: boolean;
 }
 
-const WEB_SEARCH_TOOL = Object.freeze({
-  type: 'web_search',
-  external_web_access: true
-} satisfies WebSearchTool);
-
 /**
  * Separates VS Code-executed tools from selection markers for OpenAI-hosted
  * tools. Hosted tools never enter the function schema or Native Tool Search.
  */
 export function resolveHostedToolPlan(
-  tools: readonly vscode.LanguageModelChatTool[] | undefined
+  tools: readonly vscode.LanguageModelChatTool[] | undefined,
+  settings?: Pick<WebSearchConfig, 'externalWebAccess' | 'contextSize' | 'allowedDomains'>
 ): HostedToolPlan {
   if (!tools || tools.length === 0) {
     return {
@@ -41,9 +38,22 @@ export function resolveHostedToolPlan(
 
   return {
     clientTools: Object.freeze(clientTools),
-    responseTools: webSearchEnabled ? Object.freeze([WEB_SEARCH_TOOL]) : Object.freeze([]),
+    responseTools: webSearchEnabled ? Object.freeze([buildWebSearchTool(settings)]) : Object.freeze([]),
     webSearchEnabled
   };
+}
+
+export function buildWebSearchTool(
+  settings?: Pick<WebSearchConfig, 'externalWebAccess' | 'contextSize' | 'allowedDomains'>
+): Readonly<WebSearchTool> {
+  return Object.freeze({
+    type: 'web_search',
+    external_web_access: settings?.externalWebAccess ?? true,
+    ...(settings?.contextSize ? { search_context_size: settings.contextSize } : {}),
+    ...(settings && settings.allowedDomains.length > 0
+      ? { filters: { allowed_domains: [...settings.allowedDomains] } }
+      : {})
+  } satisfies WebSearchTool);
 }
 
 export function hasHostedWebSearch(tools: readonly Tool[] | undefined): boolean {

--- a/src/hostedTools/hostedToolPlan.ts
+++ b/src/hostedTools/hostedToolPlan.ts
@@ -1,0 +1,51 @@
+import type { Tool, WebSearchTool } from 'openai/resources/responses/responses';
+import type * as vscode from 'vscode';
+
+export const CODEX_WEB_SEARCH_TOOL_NAME = 'codexForCopilot_searchWeb';
+
+export interface HostedToolPlan {
+  clientTools: readonly vscode.LanguageModelChatTool[];
+  responseTools: readonly Tool[];
+  webSearchEnabled: boolean;
+}
+
+const WEB_SEARCH_TOOL = Object.freeze({
+  type: 'web_search',
+  external_web_access: true
+} satisfies WebSearchTool);
+
+/**
+ * Separates VS Code-executed tools from selection markers for OpenAI-hosted
+ * tools. Hosted tools never enter the function schema or Native Tool Search.
+ */
+export function resolveHostedToolPlan(
+  tools: readonly vscode.LanguageModelChatTool[] | undefined
+): HostedToolPlan {
+  if (!tools || tools.length === 0) {
+    return {
+      clientTools: Object.freeze([]),
+      responseTools: Object.freeze([]),
+      webSearchEnabled: false
+    };
+  }
+
+  const clientTools: vscode.LanguageModelChatTool[] = [];
+  let webSearchEnabled = false;
+  for (const tool of tools) {
+    if (tool.name === CODEX_WEB_SEARCH_TOOL_NAME) {
+      webSearchEnabled = true;
+      continue;
+    }
+    clientTools.push(tool);
+  }
+
+  return {
+    clientTools: Object.freeze(clientTools),
+    responseTools: webSearchEnabled ? Object.freeze([WEB_SEARCH_TOOL]) : Object.freeze([]),
+    webSearchEnabled
+  };
+}
+
+export function hasHostedWebSearch(tools: readonly Tool[] | undefined): boolean {
+  return tools?.some((tool) => tool.type === 'web_search' || tool.type === 'web_search_2025_08_26') ?? false;
+}

--- a/src/hostedTools/webSearchTool.ts
+++ b/src/hostedTools/webSearchTool.ts
@@ -1,0 +1,12 @@
+import * as vscode from 'vscode';
+import { CODEX_WEB_SEARCH_TOOL_NAME } from './hostedToolPlan';
+
+export function registerWebSearchMarkerTool(): vscode.Disposable {
+  return vscode.lm.registerTool(CODEX_WEB_SEARCH_TOOL_NAME, {
+    invoke: () => new vscode.LanguageModelToolResult([
+      new vscode.LanguageModelTextPart(
+        'Web Search is executed by the Codex hosted Responses tool. Select a Codex For Copilot model to use it.'
+      )
+    ])
+  });
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -692,6 +692,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       allowToolOutputContinuation = false
     ) => {
       let pendingResponseText = '';
+      let reportedWebSearchStatusCount = 0;
       const webSearchStatusPresenter = new WebSearchStatusPresenter(config.webSearch);
       const webSearchFallbackTimers = new Map<string, ReturnType<typeof setTimeout>>();
       const attemptInitialBranchState: CodexBranchState = {
@@ -702,6 +703,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       const resetAttemptState = () => {
         replayResponseItems.length = 0;
         pendingResponseText = '';
+        reportedWebSearchStatusCount = 0;
         for (const timer of webSearchFallbackTimers.values()) {
           clearTimeout(timer);
         }
@@ -798,8 +800,12 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         if (!webSearchStatus) {
           return;
         }
+        // VS Code groups consecutive ThinkingParts into one expandable section.
+        // Keep individual hosted searches visually distinct inside that group.
+        const value = `${reportedWebSearchStatusCount > 0 ? '\n\n' : ''}${webSearchStatus.value}`;
+        reportedWebSearchStatusCount += 1;
         const thinkingPart = createThinkingPart(
-          webSearchStatus.value,
+          value,
           `hosted-tool:web_search:${webSearchStatus.itemId}`,
           {
             source: 'hosted-tool',

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -65,9 +65,9 @@ import { summarizeNativeToolSearchItem } from './nativeToolSearch/nativeToolLogg
 import { recordNativeToolSearchRuntimeStatus } from './nativeToolSearch/nativeToolSearchStatus';
 import { resolveHostedToolPlan } from './hostedTools/hostedToolPlan';
 import {
-  formatWebSearchSources,
   projectWebSearchReplayItem,
-  type WebSearchSource
+  WebSearchStatusPresenter,
+  type HostedToolLifecycleEvent
 } from './hostedTools/hostedToolEvents';
 import { StreamPresenter, mergeStreamPresentationMetrics } from './streamPresenter';
 import { ReasoningStreamPresenter } from './reasoningStreamPresenter';
@@ -115,6 +115,7 @@ const TEXT_STREAM_MAX_REPORT_INTERVAL_MS = 100;
 const TEXT_STREAM_TARGET_REPORT_CHARACTERS = 20;
 const TEXT_STREAM_MAX_REPORT_CHARACTERS = 64;
 const TEXT_STREAM_SMOOTHING_BUFFER_CHARACTERS = 1_024;
+const WEB_SEARCH_STATUS_DETAIL_GRACE_MS = 300;
 // The WebSocket tool-output continuation path passed the real-backend release
 // gate: five consecutive store:false tool loops completed with a matching
 // previous_response_id and a single incremental function_call_output.
@@ -365,7 +366,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     const observedToolResults = this.consumeReportedToolResults(input);
     latency.mark('messagesConverted');
     const requestBuildStartedAt = performance.now();
-    const hostedToolPlan = resolveHostedToolPlan(options.tools);
+    const hostedToolPlan = resolveHostedToolPlan(options.tools, config.webSearch);
     const selectedClientTools = hostedToolPlan.clientTools;
     const nativeToolSearchKey = nativeToolSearchCapabilityKey(
       normalizeBaseURL(config.baseURL), authIdentity, selectedModel.requestModel
@@ -691,7 +692,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       allowToolOutputContinuation = false
     ) => {
       let pendingResponseText = '';
-      const webSearchSources = new Map<string, WebSearchSource>();
+      const webSearchStatusPresenter = new WebSearchStatusPresenter(config.webSearch);
+      const webSearchFallbackTimers = new Map<string, ReturnType<typeof setTimeout>>();
       const attemptInitialBranchState: CodexBranchState = {
         ...branchState,
         identity: { ...branchState.identity },
@@ -700,7 +702,11 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       const resetAttemptState = () => {
         replayResponseItems.length = 0;
         pendingResponseText = '';
-        webSearchSources.clear();
+        for (const timer of webSearchFallbackTimers.values()) {
+          clearTimeout(timer);
+        }
+        webSearchFallbackTimers.clear();
+        webSearchStatusPresenter.reset();
         completedResponseId = undefined;
         branchState = {
           ...attemptInitialBranchState,
@@ -786,6 +792,39 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         } else if (kind === 'reasoning') {
           latency.mark('firstReasoning', reportedAt);
         }
+      };
+
+      const reportWebSearchStatus = (webSearchStatus: ReturnType<WebSearchStatusPresenter['present']>) => {
+        if (!webSearchStatus) {
+          return;
+        }
+        const thinkingPart = createThinkingPart(
+          webSearchStatus.value,
+          `hosted-tool:web_search:${webSearchStatus.itemId}`,
+          {
+            source: 'hosted-tool',
+            tool: 'web_search',
+            phase: 'completed',
+            itemId: webSearchStatus.itemId,
+            ...(webSearchStatus.actionType ? { actionType: webSearchStatus.actionType } : {})
+          }
+        );
+        if (thinkingPart) {
+          reportVisiblePart('reasoning', thinkingPart);
+        }
+      };
+
+      const scheduleWebSearchLifecycleFallback = (event: HostedToolLifecycleEvent) => {
+        if (!webSearchStatusPresenter.noteCompletedLifecycle(event)) {
+          return;
+        }
+        const timer = setTimeout(() => {
+          webSearchFallbackTimers.delete(event.itemId);
+          if (!token.isCancellationRequested) {
+            reportWebSearchStatus(webSearchStatusPresenter.presentLifecycleFallback(event.itemId));
+          }
+        }, WEB_SEARCH_STATUS_DETAIL_GRACE_MS);
+        webSearchFallbackTimers.set(event.itemId, timer);
       };
 
       const presenter = new StreamPresenter(
@@ -977,27 +1016,18 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
             requestModel: selectedModel.requestModel,
             ...event
           });
-          const status = event.phase === 'completed' ? 'Searched the web' : 'Searching the web…';
-          const thinkingPart = createThinkingPart(status, `hosted-tool:${event.tool}:${event.itemId}`, {
-            source: 'hosted-tool',
-            tool: event.tool,
-            phase: event.phase,
-            itemId: event.itemId,
-            outputIndex: event.outputIndex
-          });
-          if (thinkingPart) {
-            reportVisiblePart('reasoning', thinkingPart);
-          }
-        },
-        onWebSearchSources: (sources) => {
-          for (const source of sources) {
-            const existing = webSearchSources.get(source.url);
-            if (!existing || (!existing.title && source.title)) {
-              webSearchSources.set(source.url, source);
-            }
-          }
+          scheduleWebSearchLifecycleFallback(event);
         },
         onRawResponseItem: (item) => {
+          const webSearchStatus = webSearchStatusPresenter.present(item);
+          if (webSearchStatus) {
+            const fallbackTimer = webSearchFallbackTimers.get(webSearchStatus.itemId);
+            if (fallbackTimer) {
+              clearTimeout(fallbackTimer);
+              webSearchFallbackTimers.delete(webSearchStatus.itemId);
+            }
+            reportWebSearchStatus(webSearchStatus);
+          }
           const toolSearchEvent = summarizeNativeToolSearchItem(item);
           if (toolSearchEvent) {
             this.outputChannel.debug('native Tool Search event', toolSearchEvent);
@@ -1154,16 +1184,14 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         }
       } finally {
         reasoningPresenter.close();
+        for (const timer of webSearchFallbackTimers.values()) {
+          clearTimeout(timer);
+        }
+        webSearchFallbackTimers.clear();
         if (token.isCancellationRequested) {
           presenter.flushBoundary();
         } else {
           await presenter.drainBoundary(() => token.isCancellationRequested);
-        }
-        const sourcesMarkdown = completedResponseId
-          ? formatWebSearchSources([...webSearchSources.values()])
-          : undefined;
-        if (sourcesMarkdown && !token.isCancellationRequested) {
-          reportVisiblePart('text', new vscode.LanguageModelTextPart(sourcesMarkdown));
         }
         if (completedUsagePart) {
           progress.report(completedUsagePart);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -63,6 +63,12 @@ import { getVirtualToolPlaceholderNames } from './nativeToolSearch/nativeToolPol
 import { buildCanonicalReplayInput, createCanonicalReplayRequest } from './nativeToolSearch/nativeToolReplay';
 import { summarizeNativeToolSearchItem } from './nativeToolSearch/nativeToolLogging';
 import { recordNativeToolSearchRuntimeStatus } from './nativeToolSearch/nativeToolSearchStatus';
+import { resolveHostedToolPlan } from './hostedTools/hostedToolPlan';
+import {
+  formatWebSearchSources,
+  projectWebSearchReplayItem,
+  type WebSearchSource
+} from './hostedTools/hostedToolEvents';
 import { StreamPresenter, mergeStreamPresentationMetrics } from './streamPresenter';
 import { ReasoningStreamPresenter } from './reasoningStreamPresenter';
 import {
@@ -359,11 +365,13 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     const observedToolResults = this.consumeReportedToolResults(input);
     latency.mark('messagesConverted');
     const requestBuildStartedAt = performance.now();
+    const hostedToolPlan = resolveHostedToolPlan(options.tools);
+    const selectedClientTools = hostedToolPlan.clientTools;
     const nativeToolSearchKey = nativeToolSearchCapabilityKey(
       normalizeBaseURL(config.baseURL), authIdentity, selectedModel.requestModel
     );
     let toolPlan = resolveCodexToolPlan({
-      tools: options.tools,
+      tools: selectedClientTools,
       model: selectedModel.requestModel,
       compatibilityEnabled: compatibilityProfile.enabled,
       nativeToolSearch: config.nativeToolSearch,
@@ -371,7 +379,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       extensions: (vscode as typeof vscode & { extensions?: { all?: readonly vscode.Extension<any>[] } }).extensions?.all ?? [],
       nativeToolSearchSupported: canUseNativeToolSearch(selectedModel.requestModel, nativeToolSearchKey)
     });
-    const virtualToolPlaceholderNames = getVirtualToolPlaceholderNames(options.tools);
+    const virtualToolPlaceholderNames = getVirtualToolPlaceholderNames(selectedClientTools);
     if (virtualToolPlaceholderNames.length > 0) {
       this.outputChannel.warn('native Tool Search falling back to VS Code Virtual Tools', {
         virtualPlaceholderCount: virtualToolPlaceholderNames.length,
@@ -418,7 +426,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       compatibilityEnabled: compatibilityProfile.enabled,
       model: selectedModel.requestModel,
       instructions: combineRequestInstructions(config.instructions, convertedMessages.systemInstructions),
-      tools: options.tools,
+      tools: selectedClientTools,
+      hostedTools: hostedToolPlan.responseTools,
       toolPlan,
       toolMode: options.toolMode,
       reasoning: reasoningEffort ? toResponsesReasoning(reasoningEffort) : undefined,
@@ -433,7 +442,9 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     const toolSchemas = toolPlan;
     latency.recordContext({
       fullInputCount: input.length,
-      toolCount: options.tools?.length ?? 0,
+      toolCount: selectedClientTools.length,
+      hostedToolCount: hostedToolPlan.responseTools.length,
+      hostedWebSearch: hostedToolPlan.webSearchEnabled,
       toolSchemaBytes: toolSchemas.toolSchemaBytes,
       legacyToolSchemaCacheHit: toolPlan.legacyToolSchemaCacheHit,
       nativeToolCatalogCacheHit: toolPlan.nativeToolCatalogCacheHit,
@@ -630,9 +641,11 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       messageCount: messages.length,
       inputItemCount: input.length,
       observedToolResults: observedToolResults.map(({ resultObservedAt: _resultObservedAt, ...toolResult }) => toolResult),
-      toolCount: options.tools?.length ?? 0,
+      toolCount: selectedClientTools.length,
+      hostedToolCount: hostedToolPlan.responseTools.length,
+      hostedWebSearch: hostedToolPlan.webSearchEnabled,
       toolMode: getToolModeName(options.toolMode),
-      toolNames: summarizeToolNames(options.tools),
+      toolNames: summarizeToolNames(selectedClientTools),
       localTokenEstimatesSinceActivation: {
         count: this.localTokenEstimateCount,
         durationMs: this.localTokenEstimateDurationMs
@@ -678,6 +691,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       allowToolOutputContinuation = false
     ) => {
       let pendingResponseText = '';
+      const webSearchSources = new Map<string, WebSearchSource>();
       const attemptInitialBranchState: CodexBranchState = {
         ...branchState,
         identity: { ...branchState.identity },
@@ -686,6 +700,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       const resetAttemptState = () => {
         replayResponseItems.length = 0;
         pendingResponseText = '';
+        webSearchSources.clear();
         completedResponseId = undefined;
         branchState = {
           ...attemptInitialBranchState,
@@ -850,6 +865,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         input: requestInput,
         tools: requestOptions.tools,
         toolPlan: requestOptions.toolPlan,
+        hostedTools: requestOptions.hostedTools,
         toolMode: requestOptions.toolMode,
         reasoning: requestOptions.reasoning,
         maxOutputTokens: requestOptions.maxOutputTokens,
@@ -955,6 +971,31 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
               });
             }
           });
+        },
+        onHostedToolLifecycleEvent: (event) => {
+          this.outputChannel.trace('response hosted tool lifecycle', {
+            requestModel: selectedModel.requestModel,
+            ...event
+          });
+          const status = event.phase === 'completed' ? 'Searched the web' : 'Searching the web…';
+          const thinkingPart = createThinkingPart(status, `hosted-tool:${event.tool}:${event.itemId}`, {
+            source: 'hosted-tool',
+            tool: event.tool,
+            phase: event.phase,
+            itemId: event.itemId,
+            outputIndex: event.outputIndex
+          });
+          if (thinkingPart) {
+            reportVisiblePart('reasoning', thinkingPart);
+          }
+        },
+        onWebSearchSources: (sources) => {
+          for (const source of sources) {
+            const existing = webSearchSources.get(source.url);
+            if (!existing || (!existing.title && source.title)) {
+              webSearchSources.set(source.url, source);
+            }
+          }
         },
         onRawResponseItem: (item) => {
           const toolSearchEvent = summarizeNativeToolSearchItem(item);
@@ -1118,6 +1159,12 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         } else {
           await presenter.drainBoundary(() => token.isCancellationRequested);
         }
+        const sourcesMarkdown = completedResponseId
+          ? formatWebSearchSources([...webSearchSources.values()])
+          : undefined;
+        if (sourcesMarkdown && !token.isCancellationRequested) {
+          reportVisiblePart('text', new vscode.LanguageModelTextPart(sourcesMarkdown));
+        }
         if (completedUsagePart) {
           progress.report(completedUsagePart);
         }
@@ -1161,7 +1208,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       if (toolPlan.mode === 'native-hosted' && !reportedVisibleOutput && isNativeToolSearchUnsupportedError(error)) {
         markNativeToolSearchUnsupported(nativeToolSearchKey);
         toolPlan = resolveCodexToolPlan({
-          tools: options.tools,
+          tools: selectedClientTools,
           model: selectedModel.requestModel,
           compatibilityEnabled: compatibilityProfile.enabled,
           nativeToolSearch: 'disabled',
@@ -1699,12 +1746,16 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         continue;
       }
 
-      const reportedCall = this.pendingReportedToolCalls.get(item.call_id);
+      const callId = typeof item.call_id === 'string' ? item.call_id.trim() : '';
+      if (!callId) {
+        continue;
+      }
+      const reportedCall = this.pendingReportedToolCalls.get(callId);
       if (!reportedCall) {
         continue;
       }
 
-      this.pendingReportedToolCalls.delete(item.call_id);
+      this.pendingReportedToolCalls.delete(callId);
       observed.push({
         callId: reportedCall.callId,
         name: reportedCall.name,
@@ -2306,7 +2357,7 @@ export function hasCanonicalReplayContinuationIntegrity(
     if (item.type !== 'function_call_output') {
       continue;
     }
-    const callId = item.call_id.trim();
+    const callId = typeof item.call_id === 'string' ? item.call_id.trim() : '';
     if (!callId || !functionCallIds.has(callId) || outputCounts.has(callId)) {
       return false;
     }
@@ -2321,6 +2372,10 @@ const INVALID_LOCAL_REPLAY_ITEM = Symbol('invalid-local-replay-item');
 function projectSafeRawReplayItem(item: unknown, toolPlan: CodexToolPlan): ResponsesInputMessage | undefined {
   if (!isReplayRecord(item)) {
     return undefined;
+  }
+  const webSearchItem = projectWebSearchReplayItem(item);
+  if (webSearchItem) {
+    return webSearchItem;
   }
   if (item.type === 'reasoning') {
     const summary = projectReasoningSummary(item.summary);
@@ -2538,6 +2593,7 @@ function normalizeLocalReplayItem(
   const record = item as Record<string, unknown>;
   if (record.type === 'tool_search_call'
     || record.type === 'tool_search_output'
+    || record.type === 'web_search_call'
     || record.type === 'reasoning') {
     return OMIT_LOCAL_REPLAY_ITEM;
   }

--- a/src/responseBranchStore.ts
+++ b/src/responseBranchStore.ts
@@ -432,7 +432,7 @@ function hasContinuationIntegrity(
   const outputCallIds = new Set(
     appendedInput
       .filter((item) => item.type === 'function_call_output')
-      .map((item) => item.call_id.trim())
+      .map((item) => typeof item.call_id === 'string' ? item.call_id.trim() : '')
       .filter(Boolean)
   );
   return [...functionCallIds].every((callId) => outputCallIds.has(callId));

--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -10,7 +10,8 @@ import { ResponsesWS, type ResponsesWSClientOptions } from 'openai/resources/res
 import type {
   ResponsesClientEvent,
   ResponsesServerEvent,
-  ResponseUsage
+  ResponseUsage,
+  Tool
 } from 'openai/resources/responses/responses';
 import type { Reasoning } from 'openai/resources/shared';
 import * as vscode from 'vscode';
@@ -42,6 +43,12 @@ import {
 } from './codexConnectionManager';
 import type { CodexWebSocketHandshake, CodexWebSocketPreconnectionObserver } from './codexWebSocketSession';
 import type { CodexFunctionCallEvent, CodexToolPlan } from './nativeToolSearch/nativeToolTypes';
+import {
+  extractWebSearchSources,
+  projectHostedToolLifecycleEvent,
+  type HostedToolLifecycleEvent,
+  type WebSearchSource
+} from './hostedTools/hostedToolEvents';
 
 const OPENAI_DEFAULT_MAX_RETRIES = 2;
 const OPENAI_DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
@@ -132,6 +139,7 @@ export interface StreamResponseTextOptions {
   input: ResponsesInputMessage[];
   tools?: readonly vscode.LanguageModelChatTool[];
   toolPlan?: CodexToolPlan;
+  hostedTools?: readonly Tool[];
   toolMode?: vscode.LanguageModelChatToolMode;
   reasoning?: Reasoning;
   maxOutputTokens: number;
@@ -143,6 +151,8 @@ export interface StreamResponseTextOptions {
   onToolCallArgumentsDelta?: (callId: string, name: string) => void;
   onToolCallArgumentsDone?: (callId: string, name: string) => void;
   onToolCall?: (call: CodexFunctionCallEvent) => void;
+  onHostedToolLifecycleEvent?: (event: HostedToolLifecycleEvent) => void;
+  onWebSearchSources?: (sources: readonly WebSearchSource[]) => void;
   onRawResponseItem?: (item: unknown) => void;
   onTurnState?: (turnState: string) => void;
   onWebSocketHandshake?: (handshake: CodexWebSocketHandshake) => void;
@@ -876,6 +886,7 @@ function createRequestBuilderOptions(options: StreamResponseTextOptions): CodexR
     input: options.input,
     tools: options.tools,
     toolPlan: options.toolPlan,
+    hostedTools: options.hostedTools,
     toolMode: options.toolMode,
     reasoning: options.reasoning,
     serviceTier: options.serviceTier,
@@ -988,6 +999,12 @@ export function createResponsesServerEventHandler(
   };
 
   return (event) => {
+    const hostedToolEvent = projectHostedToolLifecycleEvent(event);
+    if (hostedToolEvent) {
+      options.onHostedToolLifecycleEvent?.(hostedToolEvent);
+      return;
+    }
+
     const reasoningEvent = event as unknown as Record<string, unknown>;
     if (reasoningEvent.type === 'response.reasoning_summary_part.added') {
       const itemId = typeof reasoningEvent.item_id === 'string' ? reasoningEvent.item_id : '';
@@ -1151,6 +1168,10 @@ function handleResponsesServerEvent(
 ): void {
   if (event.type === 'response.output_item.done') {
     options.onRawResponseItem?.(event.item);
+    const webSearchSources = extractWebSearchSources(event.item);
+    if (webSearchSources.length > 0) {
+      options.onWebSearchSources?.(webSearchSources);
+    }
   }
 
   if (event.type === 'response.output_text.delta') {
@@ -1244,7 +1265,7 @@ function shouldFallbackToHttp(
   return error instanceof WebSocketTransportUnavailableError && error.fallbackAllowed;
 }
 
-function getMismatchedModelNotFoundName(error: { error?: { message?: string | null } | undefined; message: string } | string | undefined, requestedModel: string): string | undefined {
+function getMismatchedModelNotFoundName(error: unknown, requestedModel: string): string | undefined {
   const missingModel = getModelNotFoundName(error);
   if (!missingModel || missingModel === requestedModel) {
     return undefined;

--- a/test/smokeCodexRequestBuilder.mjs
+++ b/test/smokeCodexRequestBuilder.mjs
@@ -54,6 +54,12 @@ try {
     tools: [],
     hostedTools: [{ type: 'web_search' }]
   });
+  const configuredHostedWebSearchRequest = buildCodexResponsesRequest({
+    ...base,
+    compatibilityEnabled: false,
+    tools: [],
+    hostedTools: [{ type: 'web_search', external_web_access: false, search_context_size: 'high' }]
+  });
   const continuationInput = [
     { type: 'message', id: '', role: 'assistant', content: 'empty id' },
     { type: 'message', id: 'legacy-message-id', role: 'assistant', content: 'legacy id' },
@@ -96,6 +102,11 @@ try {
     areCodexRequestsIncrementallyCompatible(standardRequest, hostedWebSearchRequest),
     false,
     'hosted tool selection invalidates continuation reuse'
+  );
+  assertEqual(
+    areCodexRequestsIncrementallyCompatible(hostedWebSearchRequest, configuredHostedWebSearchRequest),
+    false,
+    'Web Search configuration changes invalidate continuation reuse'
   );
   assertEqual('id' in sanitizedHttpRequest.input[0], false, 'HTTP continuation omits empty response item id');
   assertEqual('id' in sanitizedHttpRequest.input[1], false, 'HTTP continuation omits legacy response item id');

--- a/test/smokeCodexRequestBuilder.mjs
+++ b/test/smokeCodexRequestBuilder.mjs
@@ -48,12 +48,19 @@ try {
     reasoning: undefined,
     tools: []
   });
+  const hostedWebSearchRequest = buildCodexResponsesRequest({
+    ...base,
+    compatibilityEnabled: false,
+    tools: [],
+    hostedTools: [{ type: 'web_search' }]
+  });
   const continuationInput = [
     { type: 'message', id: '', role: 'assistant', content: 'empty id' },
     { type: 'message', id: 'legacy-message-id', role: 'assistant', content: 'legacy id' },
     { type: 'message', id: 'msg_valid123', role: 'assistant', content: 'valid message id' },
     { type: 'function_call', id: 'fc_valid123', call_id: 'call_valid', name: 'read', arguments: '{}' },
-    { type: 'function_call_output', id: 'legacy-output-id', call_id: 'call_valid', output: 'result' }
+    { type: 'function_call_output', id: 'legacy-output-id', call_id: 'call_valid', output: 'result' },
+    { type: 'web_search_call', id: 'ws_valid123', status: 'completed', action: { type: 'search', query: 'test' } }
   ];
   const sanitizedHttpRequest = buildCodexResponsesRequest({
     ...base,
@@ -82,6 +89,14 @@ try {
   assertEqual(compatibilityDefaultReasoningRequest.include[0], 'reasoning.encrypted_content', 'compatibility default reasoning requests encrypted content');
   assertEqual('reasoning' in standardRequest, false, 'standard request does not add default reasoning');
   assertEqual('include' in standardRequest, false, 'standard request does not request encrypted reasoning');
+  assertEqual(hostedWebSearchRequest.tools[0].type, 'web_search', 'OpenAI hosted web search tool is preserved');
+  assertEqual(hostedWebSearchRequest.include[0], 'web_search_call.action.sources', 'web search sources are requested');
+  assertEqual(hostedWebSearchRequest.tools.some((tool) => tool.type === 'function'), false, 'hosted web search does not become a function tool');
+  assertEqual(
+    areCodexRequestsIncrementallyCompatible(standardRequest, hostedWebSearchRequest),
+    false,
+    'hosted tool selection invalidates continuation reuse'
+  );
   assertEqual('id' in sanitizedHttpRequest.input[0], false, 'HTTP continuation omits empty response item id');
   assertEqual('id' in sanitizedHttpRequest.input[1], false, 'HTTP continuation omits legacy response item id');
   assertEqual(sanitizedHttpRequest.input[2].id, 'msg_valid123', 'HTTP continuation preserves valid response item id');
@@ -92,6 +107,8 @@ try {
   assertEqual('id' in sanitizedWebSocketEvent.input[1], false, 'WebSocket continuation omits legacy response item id');
   assertEqual(sanitizedWebSocketEvent.input[2].id, 'msg_valid123', 'WebSocket continuation preserves valid response item id');
   assertEqual(sanitizedWebSocketEvent.input[4].call_id, 'call_valid', 'WebSocket continuation preserves tool output call id');
+  assertEqual(sanitizedHttpRequest.input[5].id, 'ws_valid123', 'HTTP continuation preserves web search item id');
+  assertEqual(sanitizedWebSocketEvent.input[5].id, 'ws_valid123', 'WebSocket continuation preserves web search item id');
   assertEqual(event.generate, false, 'prewarm generate flag');
   assertEqual('stream' in event, false, 'WebSocket stream omitted');
   assertEqual(areCodexRequestsIncrementallyCompatible(request, appended), true, 'input ignored by request fingerprint');

--- a/test/smokeHostedWebSearch.mjs
+++ b/test/smokeHostedWebSearch.mjs
@@ -1,0 +1,91 @@
+import { loadBundled, assertEqual } from './testBundleHelper.mjs';
+
+const planModule = await loadBundled('src/hostedTools/hostedToolPlan.ts');
+const eventModule = await loadBundled('src/hostedTools/hostedToolEvents.ts');
+
+try {
+  const {
+    CODEX_WEB_SEARCH_TOOL_NAME,
+    resolveHostedToolPlan
+  } = planModule.exports;
+  const {
+    extractWebSearchSources,
+    formatWebSearchSources,
+    projectHostedToolLifecycleEvent,
+    projectWebSearchReplayItem
+  } = eventModule.exports;
+
+  const clientTool = { name: 'read_file', description: 'Read a file', inputSchema: { type: 'object' } };
+  const markerTool = { name: CODEX_WEB_SEARCH_TOOL_NAME, description: 'Search the web', inputSchema: { type: 'object' } };
+  const plan = resolveHostedToolPlan([clientTool, markerTool]);
+
+  assertEqual(plan.clientTools.length, 1, 'marker is removed from client tools');
+  assertEqual(plan.clientTools[0].name, 'read_file', 'ordinary VS Code tool is preserved');
+  assertEqual(plan.responseTools.length, 1, 'one hosted tool is planned');
+  assertEqual(plan.responseTools[0].type, 'web_search', 'hosted tool uses OpenAI SDK web search shape');
+  assertEqual(plan.responseTools[0].external_web_access, true, 'hosted tool explicitly enables live web access');
+  assertEqual(plan.webSearchEnabled, true, 'web search selection is recorded');
+
+  const lifecycle = projectHostedToolLifecycleEvent({
+    type: 'response.web_search_call.searching',
+    item_id: 'ws_test',
+    output_index: 1,
+    sequence_number: 4
+  });
+  assertEqual(lifecycle.phase, 'searching', 'web search lifecycle is normalized');
+  assertEqual(lifecycle.itemId, 'ws_test', 'web search lifecycle keeps item identity');
+
+  const callSources = extractWebSearchSources({
+    type: 'web_search_call',
+    action: {
+      type: 'search',
+      sources: [
+        { type: 'url', url: 'https://example.com/one' },
+        { type: 'url', url: 'file:///not-allowed' }
+      ]
+    }
+  });
+  const citationSources = extractWebSearchSources({
+    type: 'message',
+    content: [{
+      type: 'output_text',
+      annotations: [{
+        type: 'url_citation',
+        url: 'https://example.com/one',
+        title: 'Example [One]',
+        start_index: 0,
+        end_index: 1
+      }]
+    }]
+  });
+  assertEqual(callSources.length, 1, 'unsafe web search source URLs are discarded');
+  assertEqual(citationSources[0].title, 'Example [One]', 'citation title is retained');
+  assertEqual(
+    formatWebSearchSources([...callSources, ...citationSources]),
+    '\n\nSources:\n- [Example \\[One\\]](<https://example.com/one>)',
+    'sources are deduplicated, titled, escaped, and clickable'
+  );
+
+  const replay = projectWebSearchReplayItem({
+    type: 'web_search_call',
+    id: 'ws_test',
+    status: 'completed',
+    action: { type: 'search', queries: ['OpenAI SDK'] }
+  });
+  assertEqual(replay?.id, 'ws_test', 'completed web search call is safe to replay');
+  assertEqual(
+    projectWebSearchReplayItem({
+      type: 'web_search_call',
+      id: 'ws_bad',
+      status: 'completed',
+      action: { type: 'open_page', url: 'javascript:alert(1)' }
+    }),
+    undefined,
+    'unsafe replay URLs are rejected'
+  );
+
+  console.log('Smoke test passed: hosted Web Search remains independent from client and Native Tool Search tools.');
+} finally {
+  await planModule.dispose();
+  await eventModule.dispose();
+}

--- a/test/smokeHostedWebSearch.mjs
+++ b/test/smokeHostedWebSearch.mjs
@@ -10,20 +10,28 @@ try {
   } = planModule.exports;
   const {
     extractWebSearchSources,
-    formatWebSearchSources,
+    formatWebSearchActivity,
     projectHostedToolLifecycleEvent,
-    projectWebSearchReplayItem
+    projectWebSearchActivity,
+    projectWebSearchReplayItem,
+    WebSearchStatusPresenter
   } = eventModule.exports;
 
   const clientTool = { name: 'read_file', description: 'Read a file', inputSchema: { type: 'object' } };
   const markerTool = { name: CODEX_WEB_SEARCH_TOOL_NAME, description: 'Search the web', inputSchema: { type: 'object' } };
-  const plan = resolveHostedToolPlan([clientTool, markerTool]);
+  const plan = resolveHostedToolPlan([clientTool, markerTool], {
+    externalWebAccess: false,
+    contextSize: 'high',
+    allowedDomains: ['example.com']
+  });
 
   assertEqual(plan.clientTools.length, 1, 'marker is removed from client tools');
   assertEqual(plan.clientTools[0].name, 'read_file', 'ordinary VS Code tool is preserved');
   assertEqual(plan.responseTools.length, 1, 'one hosted tool is planned');
   assertEqual(plan.responseTools[0].type, 'web_search', 'hosted tool uses OpenAI SDK web search shape');
-  assertEqual(plan.responseTools[0].external_web_access, true, 'hosted tool explicitly enables live web access');
+  assertEqual(plan.responseTools[0].external_web_access, false, 'hosted tool respects live-access configuration');
+  assertEqual(plan.responseTools[0].search_context_size, 'high', 'hosted tool respects search context size');
+  assertEqual(plan.responseTools[0].filters.allowed_domains[0], 'example.com', 'hosted tool applies allowed domains');
   assertEqual(plan.webSearchEnabled, true, 'web search selection is recorded');
 
   const lifecycle = projectHostedToolLifecycleEvent({
@@ -34,6 +42,55 @@ try {
   });
   assertEqual(lifecycle.phase, 'searching', 'web search lifecycle is normalized');
   assertEqual(lifecycle.itemId, 'ws_test', 'web search lifecycle keeps item identity');
+  const completedItems = [
+    {
+      type: 'web_search_call', id: 'ws_first', status: 'completed',
+      action: { type: 'search', queries: ['OpenAI web search'], sources: [{ type: 'url', url: 'https://example.com/one' }] }
+    },
+    {
+      type: 'web_search_call', id: 'ws_second', status: 'completed',
+      action: { type: 'open_page', url: 'https://example.com/article' }
+    },
+    {
+      type: 'web_search_call', id: 'ws_third', status: 'completed',
+      action: { type: 'find_in_page', pattern: 'pricing', url: 'https://example.com/article' }
+    }
+  ];
+  const firstActivity = projectWebSearchActivity(completedItems[0]);
+  assertEqual(firstActivity.action.queries[0], 'OpenAI web search', 'completed activity retains search queries');
+  assertEqual(
+    formatWebSearchActivity(firstActivity, { statusDetail: 'actionsAndSources', statusMaxSources: 3 }),
+    '**Searched the web** · “OpenAI web search” · [example\\.com/one](<https://example.com/one>)',
+    'detailed status displays the query and clickable source page on one line'
+  );
+  const statusPresenter = new WebSearchStatusPresenter({ statusDetail: 'actions', statusMaxSources: 3 });
+  assertEqual(
+    JSON.stringify([...completedItems, completedItems[0]].flatMap((item) => statusPresenter.present(item)?.value ?? [])),
+    JSON.stringify([
+      '**Searched the web** · “OpenAI web search”',
+      '**Opened a web page** · [example\\.com/article](<https://example.com/article>)',
+      '**Searched within a web page** · “pricing” · [example\\.com/article](<https://example.com/article>)'
+    ]),
+    'search, open-page, and find-in-page calls each produce one informative deduplicated status'
+  );
+  const lifecycleFallbackPresenter = new WebSearchStatusPresenter({ statusDetail: 'actionsAndSources', statusMaxSources: 3 });
+  assertEqual(lifecycleFallbackPresenter.noteCompletedLifecycle({
+    tool: 'web_search', phase: 'completed', itemId: 'ws_lifecycle_only', outputIndex: 2, sequenceNumber: 70
+  }), true, 'a completed lifecycle event schedules one fallback status');
+  assertEqual(lifecycleFallbackPresenter.noteCompletedLifecycle({
+    tool: 'web_search', phase: 'completed', itemId: 'ws_first', outputIndex: 3, sequenceNumber: 71
+  }), true, 'a second completed lifecycle event has its own status identity');
+  lifecycleFallbackPresenter.present(completedItems[0]);
+  assertEqual(
+    lifecycleFallbackPresenter.presentLifecycleFallback('ws_lifecycle_only')?.value,
+    '**Searched the web**',
+    'a completed lifecycle event immediately falls back to one compact status when no detailed raw item arrives'
+  );
+  assertEqual(
+    lifecycleFallbackPresenter.presentLifecycleFallback('ws_first'),
+    undefined,
+    'a detailed raw item cancels only its matching lifecycle fallback'
+  );
 
   const callSources = extractWebSearchSources({
     type: 'web_search_call',
@@ -60,11 +117,6 @@ try {
   });
   assertEqual(callSources.length, 1, 'unsafe web search source URLs are discarded');
   assertEqual(citationSources[0].title, 'Example [One]', 'citation title is retained');
-  assertEqual(
-    formatWebSearchSources([...callSources, ...citationSources]),
-    '\n\nSources:\n- [Example \\[One\\]](<https://example.com/one>)',
-    'sources are deduplicated, titled, escaped, and clickable'
-  );
 
   const replay = projectWebSearchReplayItem({
     type: 'web_search_call',

--- a/test/smokeNativeToolOptIn.mjs
+++ b/test/smokeNativeToolOptIn.mjs
@@ -7,10 +7,18 @@ assertEqual(
   'disabled',
   'the extension manifest leaves tool discovery to VS Code by default'
 );
+assertEqual(
+  manifest.contributes.configuration.properties['codexModelProvider.webSearchStatusDetail'].default,
+  'actionsAndSources',
+  'the extension manifest shows Web Search actions and sources by default'
+);
 
+const configValues = {};
 const loaded = await loadBundled('src/config.ts', {
   workspace: {
-    getConfiguration: () => ({ get: (_setting, defaultValue) => defaultValue })
+    getConfiguration: () => ({
+      get: (setting, defaultValue) => setting in configValues ? configValues[setting] : defaultValue
+    })
   }
 });
 try {
@@ -19,5 +27,23 @@ try {
     'disabled',
     'the runtime configuration keeps Native Tool Search disabled until the user opts in'
   );
+  assertEqual(
+    loaded.exports.getProviderConfig().webSearch.statusDetail,
+    'actionsAndSources',
+    'the runtime shows detailed Web Search activity by default'
+  );
+  Object.assign(configValues, {
+    webSearchExternalAccess: false,
+    webSearchContextSize: 'high',
+    webSearchAllowedDomains: ['OpenAI.com', 'https://invalid.example/path', 'openai.com'],
+    webSearchStatusDetail: 'actions',
+    webSearchStatusMaxSources: 99
+  });
+  const webSearch = loaded.exports.getProviderConfig().webSearch;
+  assertEqual(webSearch.externalWebAccess, false, 'Web Search live access is configurable');
+  assertEqual(webSearch.contextSize, 'high', 'Web Search context size is normalized');
+  assertEqual(JSON.stringify(webSearch.allowedDomains), JSON.stringify(['openai.com']), 'Web Search domains are normalized and validated');
+  assertEqual(webSearch.statusDetail, 'actions', 'Web Search status detail is configurable');
+  assertEqual(webSearch.statusMaxSources, 10, 'Web Search status source count is bounded');
   console.log('Smoke test passed: Native Tool Search is disabled by default in the manifest and runtime.');
 } finally { await loaded.dispose(); }

--- a/test/smokeResponsesClient.mjs
+++ b/test/smokeResponsesClient.mjs
@@ -35,6 +35,7 @@ Module._load = function patchedLoad(request, parent, isMain) {
 };
 
 const {
+  createResponsesServerEventHandler,
   disposeReusableResponsesWebSockets,
   isResponsesContinuationMissError,
   isResponsesContinuationMissPayload,
@@ -44,6 +45,7 @@ const {
 
 try {
   runContinuationMissClassifierSmokeTest(isResponsesContinuationMissPayload);
+  runHostedWebSearchEventSmokeTest(createResponsesServerEventHandler);
   await runNestedConnectionCauseSmokeTest(streamResponseText);
   await runHttpTransportSmokeTest(streamResponseText);
   await runHttpContinuationMissSmokeTest(streamResponseText, isResponsesContinuationMissError);
@@ -65,6 +67,56 @@ try {
   disposeReusableResponsesWebSockets();
   Module._load = moduleLoad;
   await rm(tempDir, { recursive: true, force: true });
+}
+
+function runHostedWebSearchEventSmokeTest(createEventHandler) {
+  const lifecycleEvents = [];
+  const sources = [];
+  const handler = createEventHandler({
+    model: 'gpt-5.5',
+    transport: 'http',
+    onTextDelta() {},
+    onHostedToolLifecycleEvent(event) {
+      lifecycleEvents.push(event);
+    },
+    onWebSearchSources(items) {
+      sources.push(...items);
+    }
+  });
+
+  handler({
+    type: 'response.web_search_call.searching',
+    item_id: 'ws_transport',
+    output_index: 0,
+    sequence_number: 2
+  });
+  handler({
+    type: 'response.output_item.done',
+    output_index: 1,
+    sequence_number: 3,
+    item: {
+      type: 'message',
+      id: 'msg_transport',
+      role: 'assistant',
+      status: 'completed',
+      content: [{
+        type: 'output_text',
+        text: 'Result',
+        annotations: [{
+          type: 'url_citation',
+          url: 'https://example.com/source',
+          title: 'Source',
+          start_index: 0,
+          end_index: 6
+        }]
+      }]
+    }
+  });
+
+  assertEqual(lifecycleEvents.length, 1, 'hosted lifecycle event is delivered once');
+  assertEqual(lifecycleEvents[0].phase, 'searching', 'hosted lifecycle phase is preserved');
+  assertEqual(sources.length, 1, 'web citation source is delivered once');
+  assertEqual(sources[0].title, 'Source', 'web citation source title is preserved');
 }
 
 async function runNestedConnectionCauseSmokeTest(streamResponseText) {

--- a/test/smokeResponsesClient.mjs
+++ b/test/smokeResponsesClient.mjs
@@ -71,6 +71,7 @@ try {
 
 function runHostedWebSearchEventSmokeTest(createEventHandler) {
   const lifecycleEvents = [];
+  const rawItems = [];
   const sources = [];
   const handler = createEventHandler({
     model: 'gpt-5.5',
@@ -78,6 +79,9 @@ function runHostedWebSearchEventSmokeTest(createEventHandler) {
     onTextDelta() {},
     onHostedToolLifecycleEvent(event) {
       lifecycleEvents.push(event);
+    },
+    onRawResponseItem(item) {
+      rawItems.push(item);
     },
     onWebSearchSources(items) {
       sources.push(...items);
@@ -91,9 +95,26 @@ function runHostedWebSearchEventSmokeTest(createEventHandler) {
     sequence_number: 2
   });
   handler({
+    type: 'response.web_search_call.completed',
+    item_id: 'ws_transport',
+    output_index: 0,
+    sequence_number: 3
+  });
+  handler({
     type: 'response.output_item.done',
     output_index: 1,
-    sequence_number: 3,
+    sequence_number: 4,
+    item: {
+      type: 'web_search_call',
+      id: 'ws_transport',
+      status: 'completed',
+      action: { type: 'search', query: 'OpenAI web search' }
+    }
+  });
+  handler({
+    type: 'response.output_item.done',
+    output_index: 2,
+    sequence_number: 5,
     item: {
       type: 'message',
       id: 'msg_transport',
@@ -113,8 +134,10 @@ function runHostedWebSearchEventSmokeTest(createEventHandler) {
     }
   });
 
-  assertEqual(lifecycleEvents.length, 1, 'hosted lifecycle event is delivered once');
-  assertEqual(lifecycleEvents[0].phase, 'searching', 'hosted lifecycle phase is preserved');
+  assertEqual(lifecycleEvents.length, 2, 'hosted lifecycle events are delivered once per phase');
+  assertEqual(lifecycleEvents[0].phase, 'searching', 'hosted searching lifecycle phase is preserved');
+  assertEqual(lifecycleEvents[1].phase, 'completed', 'hosted completed lifecycle phase is preserved');
+  assertEqual(rawItems[0].type, 'web_search_call', 'completed Web Search raw items are delivered for detailed status projection');
   assertEqual(sources.length, 1, 'web citation source is delivered once');
   assertEqual(sources[0].title, 'Source', 'web citation source title is preserved');
 }


### PR DESCRIPTION
## Summary

- add a VS Code **Web Search** tool-picker entry and `#webSearch` reference
- keep Web Search independent from Native Tool Search by separating its marker before client tool planning
- send OpenAI's hosted `{ type: "web_search", external_web_access: true }` tool through the shared HTTP/WebSocket Responses request builder
- surface hosted search lifecycle in the thinking UI and append deduplicated, clickable citation sources
- preserve safe `web_search_call` items for continuation recovery and invalidate reuse when hosted-tool selection changes
- upgrade the OpenAI Node SDK from 6.44.0 to 7.8.0 so the implementation uses the current SDK Web Search types and events

## Verification

- `npm run check`
- `npm run test:smoke`
- `npm run compile`
- `npm run package:vsix -- --out /tmp/codex-for-copilot-web-search.vsix`
- `git diff --check`
- GitHub Actions **Pull Request CI**, including the Extension Host smoke test
- GitHub Actions **Pull Request Title**

A live ChatGPT Codex backend probe was not run because this environment does not have a test account credential.