### PR TITLE
feat(protocol): add configurable Codex request identity profiles

### DIFF
--- a/docs/codex-cli-parity.md
+++ b/docs/codex-cli-parity.md
@@ -3,7 +3,8 @@
 Protocol baseline:
 
 - Codex For Copilot: `2987db25dc15b79cd22dc2ccc08f4c44b7db1351`
-- `openai/codex`: `711a5f8b3a6eb40134146ae9ec22fdcdda5e3170`
+- `openai/codex`: `3c837e568c24e4281bba4abdf3bc3c398f3fff13`
+- Codex CLI compatibility identity package version: `0.153.2`
 - WebSocket beta: `responses_websockets=2026-02-06`
 
 ## Baseline checklist
@@ -52,12 +53,42 @@ projections. The direct turn-metadata header deliberately excludes
   remain protected. `Codex: Show Effective Protocol` writes a redacted view of
   the most recent effective projection to the extension log.
 
-## Protocol profiles and overrides
+## Protocol profiles, client identity, and overrides
+
+Protocol compatibility, client identity, and authentication identity are three
+separate concerns. `protocolProfile` controls whether Codex session, thread,
+turn, Turn State, cache-routing, metadata, and transport semantics are emitted.
+`requestIdentityProfile` controls only what the client declares about itself.
+Neither setting creates credentials or official Codex attestation.
 
 `codexModelProvider.protocolProfile` defaults to `auto`. `auto` and
 `codexCompatible` enable the Codex projection only for the official ChatGPT Codex
 endpoint with Codex credentials; `minimal` disables it. `custom` is an explicit
 opt-in for HTTPS-compatible gateways.
+
+`codexModelProvider.requestIdentityProfile` defaults to `extension`, preserving
+the existing `codex-for-copilot` originator, extension User-Agent/version,
+`agent_name`, and source. `neutral` removes those branding fields without
+removing protocol identity or Turn State. `codexCliCompatible` projects the
+pinned upstream declaration (`originator=codex_cli_rs` and an upstream-shaped
+User-Agent containing Codex `0.153.2`, OS, architecture, and detected terminal),
+but sends no invented `version`, `source`, or `agent_name`. `custom` uses only
+validated configured identity fields. Its values are printable ASCII and are
+bounded to 128 bytes, except User-Agent, which is bounded to 512 bytes.
+
+Useful orthogonal combinations include:
+
+| Protocol + identity | Meaning |
+| --- | --- |
+| `auto + extension` | Current default behavior |
+| `auto + neutral` | Codex protocol without extension branding |
+| `auto + codexCliCompatible` | Codex protocol with the pinned CLI-compatible declaration |
+| `custom + custom` | Explicit HTTPS gateway with a custom declaration |
+| `minimal + neutral` | Minimal Responses protocol without branding |
+
+Contradictory-looking combinations are allowed. For example,
+`minimal + codexCliCompatible` does not turn Codex protocol fields back on; the
+identity selection has no authority over protocol semantics.
 
 Overrides are applied to the canonical snapshot before the body/header
 projections are created. Safe mode accepts extra metadata and non-protected
@@ -66,6 +97,13 @@ fields to be replaced for protocol testing, but it never permits settings to
 replace authentication, account identity, `x-codex-turn-state`, HTTP transport
 invariants, or `Sec-WebSocket-*` fields. Extra client metadata follows upstream's
 16-entry, 64-byte key, and 128-byte string-value limits.
+
+The fixed precedence is: generated protocol semantics, resolved request
+identity, safe protocol overrides, opted-in unsafe protocol overrides, then
+restoration of credentials, Turn State, WebSocket security, and transport
+invariants. Attestation and internal agent-authentication headers are always
+rejected. Thus CLI compatibility is a client declaration only; it does not
+provide Codex attestation or represent an authenticated official Codex CLI.
 
 ## Latency and continuation behavior
 
@@ -110,7 +148,7 @@ Model discovery uses a bounded stale-while-revalidate cache:
 
 For compatible ChatGPT Codex WebSocket sessions, model discovery may schedule one
 45-second idle preconnection per endpoint/account/auth scope. The empty handshake
-contains authentication, account, extension origin, and the WebSocket beta header,
+contains authentication, account, the resolved client identity, and the WebSocket beta header,
 but deliberately omits synthetic installation, session, thread, and turn identity.
 The next formal request claims that socket and supplies its actual identity. A
 `generate:false` prewarm remains an explicit experimental option with a 400ms

--- a/docs/codex-cli-parity.md
+++ b/docs/codex-cli-parity.md
@@ -3,8 +3,8 @@
 Protocol baseline:
 
 - Codex For Copilot: `2987db25dc15b79cd22dc2ccc08f4c44b7db1351`
-- `openai/codex`: `3c837e568c24e4281bba4abdf3bc3c398f3fff13`
-- Codex CLI compatibility identity package version: `0.153.2`
+- Protocol `openai/codex`: `711a5f8b3a6eb40134146ae9ec22fdcdda5e3170`
+- Identity `openai/codex` release commit: `657a993cbee87acf52d14b758ce49dbd46d1b8eb` (`rust-v0.153.2`)
 - WebSocket beta: `responses_websockets=2026-02-06`
 
 ## Baseline checklist
@@ -72,7 +72,8 @@ the existing `codex-for-copilot` originator, extension User-Agent/version,
 removing protocol identity or Turn State. `codexCliCompatible` projects the
 pinned upstream declaration (`originator=codex_cli_rs` and an upstream-shaped
 User-Agent containing Codex `0.153.2`, OS, architecture, and detected terminal),
-but sends no invented `version`, `source`, or `agent_name`. `custom` uses only
+and the root CLI agent path (`agent_name=/root`), but sends no invented `version`
+or `source`. `custom` uses only
 validated configured identity fields. Its values are printable ASCII and are
 bounded to 128 bytes, except User-Agent, which is bounded to 512 bytes.
 

--- a/package.json
+++ b/package.json
@@ -313,6 +313,36 @@
             "advanced"
           ]
         },
+        "codexModelProvider.requestIdentityProfile": {
+          "type": "string",
+          "default": "extension",
+          "enum": [
+            "extension",
+            "codexCliCompatible",
+            "neutral",
+            "custom"
+          ],
+          "enumDescriptions": [
+            "Identify requests as Codex For Copilot.",
+            "Use a client identity compatible with the pinned Codex CLI protocol baseline.",
+            "Do not add Codex For Copilot branding while preserving required Codex protocol fields.",
+            "Use the configured custom client identity."
+          ],
+          "description": "Controls the client-declared identity independently of Codex protocol compatibility."
+        },
+        "codexModelProvider.customRequestIdentity": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "originator": { "type": "string", "maxLength": 128 },
+            "userAgent": { "type": "string", "maxLength": 512 },
+            "version": { "type": "string", "maxLength": 128 },
+            "agentName": { "type": "string", "maxLength": 128 },
+            "source": { "type": "string", "maxLength": 128 }
+          },
+          "additionalProperties": false,
+          "description": "Validated client identity fields used only by the custom request identity profile."
+        },
         "codexModelProvider.headerOverrides": {
           "type": "object",
           "default": {},

--- a/src/codexProtocol.ts
+++ b/src/codexProtocol.ts
@@ -1,8 +1,13 @@
 import type { ApiCredentials } from './secrets';
 import type { CodexToolPlan } from './nativeToolSearch/nativeToolTypes';
+import {
+  CODEX_CLI_COMPATIBLE_VERSION,
+  CODEX_IDENTITY_UPSTREAM_COMMIT,
+  type ResolvedRequestIdentity
+} from './codexRequestIdentity';
 
 // Protocol baseline: openai/codex@711a5f8b3a6eb40134146ae9ec22fdcdda5e3170.
-export const CODEX_PROTOCOL_UPSTREAM_COMMIT = '711a5f8b3a6eb40134146ae9ec22fdcdda5e3170';
+export const CODEX_PROTOCOL_UPSTREAM_COMMIT = '3c837e568c24e4281bba4abdf3bc3c398f3fff13';
 export const CODEX_RESPONSES_WEBSOCKET_BETA = 'responses_websockets=2026-02-06';
 
 export const CodexHeader = {
@@ -65,11 +70,11 @@ export interface CodexTurnMetadata extends Record<string, unknown> {
   parent_thread_id: string | null;
   parent_turn_id?: string;
   root_turn_id?: string;
-  agent_name: string;
+  agent_name?: string;
   turn_started_at_unix_ms: number;
   tool_namespaces_info?: Record<string, CodexToolNamespaceMetadata>;
   request_kind: 'turn' | 'prewarm';
-  source: 'vscode-language-model-provider';
+  source?: string;
 }
 
 export type CodexProtocolProfileName = 'auto' | 'codexCompatible' | 'minimal' | 'custom';
@@ -90,10 +95,16 @@ export interface CodexProtocolSnapshot {
   clientMetadata: Record<string, string>;
   compatibilityTurnMetadata: string;
   settings: CodexProtocolSettings;
+  clientIdentity: ResolvedRequestIdentity;
 }
 
 export interface CodexEffectiveProtocolDiagnostic {
   profile: CodexProtocolProfileName;
+  requestIdentityProfile: ResolvedRequestIdentity['profile'];
+  identityBaseline: { upstreamCommit: string; compatibleCodexVersion: string };
+  clientIdentity: ResolvedRequestIdentity;
+  compatibilityIdentityOnly: boolean;
+  compatibilityNotice?: string;
   headers?: Record<string, string>;
   clientMetadata: Record<string, string>;
   turnMetadata: Record<string, unknown>;
@@ -108,14 +119,12 @@ export interface CodexDynamicHeaderContext {
   turnMetadata: string;
   snapshot?: CodexProtocolSnapshot;
   turnState?: string;
-  extensionVersion: string;
-  userAgent: string;
+  clientIdentity: ResolvedRequestIdentity;
 }
 
 export interface CodexWebSocketPreconnectHeaderContext {
   credentialsHeaders?: Record<string, string>;
-  extensionVersion: string;
-  userAgent: string;
+  clientIdentity: ResolvedRequestIdentity;
   settings?: CodexProtocolSettings;
 }
 
@@ -156,9 +165,6 @@ export function buildCodexRequestHeaders(
   const snapshot = context.snapshot;
   const headers: Record<string, string> = {
     ...context.credentialsHeaders,
-    'User-Agent': context.userAgent,
-    originator: 'codex-for-copilot',
-    version: context.extensionVersion,
     [CodexHeader.requestId]: context.identity.threadId,
     [CodexHeader.sessionId]: context.identity.sessionId,
     [CodexHeader.threadId]: context.identity.threadId,
@@ -166,6 +172,7 @@ export function buildCodexRequestHeaders(
     [CodexHeader.windowId]: context.identity.windowId,
     [CodexHeader.turnMetadata]: snapshot?.compatibilityTurnMetadata ?? context.turnMetadata
   };
+  applyClientIdentityHeaders(headers, context.clientIdentity);
 
   if (context.identity.parentThreadId) {
     headers[CodexHeader.parentThreadId] = context.identity.parentThreadId;
@@ -205,11 +212,9 @@ export function buildCodexWebSocketPreconnectHeaders(
 ): Record<string, string> {
   const headers = {
     ...context.credentialsHeaders,
-    'User-Agent': context.userAgent,
-    originator: 'codex-for-copilot',
-    version: context.extensionVersion,
     [CodexHeader.beta]: CODEX_RESPONSES_WEBSOCKET_BETA
   };
+  applyClientIdentityHeaders(headers, context.clientIdentity);
   if (context.settings) {
     applyGeneratedHeaderOmissions(headers, context.settings);
     applyHeaderOverrides(headers, context.settings);
@@ -223,7 +228,8 @@ export function createCodexTurnMetadata(
   identity: CodexRequestIdentity,
   requestKind: CodexTurnMetadata['request_kind'] = 'turn',
   turnStartedAtUnixMs = Date.now(),
-  toolPlan?: CodexToolPlan
+  toolPlan?: CodexToolPlan,
+  clientIdentity: ResolvedRequestIdentity = { profile: 'extension', agentName: 'codex-for-copilot', source: 'vscode-language-model-provider' }
 ): CodexTurnMetadata {
   return {
     installation_id: identity.installationId,
@@ -234,11 +240,11 @@ export function createCodexTurnMetadata(
     parent_thread_id: identity.parentThreadId ?? null,
     ...(identity.parentTurnId ? { parent_turn_id: identity.parentTurnId } : {}),
     ...(identity.rootTurnId ? { root_turn_id: identity.rootTurnId } : {}),
-    agent_name: 'codex-for-copilot',
+    ...(clientIdentity.agentName ? { agent_name: clientIdentity.agentName } : {}),
     turn_started_at_unix_ms: turnStartedAtUnixMs,
     ...buildToolNamespacesMetadata(toolPlan),
     request_kind: requestKind,
-    source: 'vscode-language-model-provider'
+    ...(clientIdentity.source ? { source: clientIdentity.source } : {})
   };
 }
 
@@ -248,14 +254,21 @@ export function buildCodexProtocolSnapshot(options: {
   turnStartedAtUnixMs?: number;
   toolPlan?: CodexToolPlan;
   settings?: Partial<CodexProtocolSettings>;
+  clientIdentity?: ResolvedRequestIdentity;
 }): CodexProtocolSnapshot {
   const requestKind = options.requestKind ?? 'turn';
   const settings = normalizeCodexProtocolSettings(options.settings);
+  const clientIdentity = options.clientIdentity ?? {
+    profile: 'extension' as const,
+    agentName: 'codex-for-copilot',
+    source: 'vscode-language-model-provider'
+  };
   const generated = createCodexTurnMetadata(
     options.identity,
     requestKind,
     options.turnStartedAtUnixMs,
-    options.toolPlan
+    options.toolPlan,
+    clientIdentity
   );
   const turnMetadata = mergeMetadataOverrides(generated, settings.turnMetadataOverrides, settings.allowUnsafeProtocolOverrides);
   const fullTurnMetadata = stableSerializeCodexMetadata(turnMetadata);
@@ -281,7 +294,7 @@ export function buildCodexProtocolSnapshot(options: {
     settings.clientMetadataOverrides,
     settings.allowUnsafeProtocolOverrides
   );
-  const snapshot = { identity: options.identity, requestKind, turnMetadata, clientMetadata, compatibilityTurnMetadata, settings };
+  const snapshot = { identity: options.identity, requestKind, turnMetadata, clientMetadata, compatibilityTurnMetadata, settings, clientIdentity };
   const previousHeaders = lastEffectiveProtocolIdentityKey === getSnapshotIdentityKey(snapshot)
     ? lastEffectiveProtocol?.headers
     : undefined;
@@ -331,7 +344,8 @@ const RESERVED_METADATA_KEYS = new Set([
 
 const ALWAYS_PROTECTED_HEADERS = new Set([
   'authorization', 'chatgpt-account-id', 'host', 'content-length', 'connection', 'upgrade',
-  'openai-beta', 'accept', 'content-type', CodexHeader.turnState
+  'openai-beta', 'accept', 'content-type', CodexHeader.turnState, 'x-oai-attestation',
+  'x-openai-subagent', 'x-openai-agent-identity'
 ].map((value) => value.toLowerCase()));
 
 const SAFE_PROTECTED_HEADERS = new Set([
@@ -422,6 +436,12 @@ function applyGeneratedHeaderOmissions(headers: Record<string, string>, settings
   }
 }
 
+function applyClientIdentityHeaders(headers: Record<string, string>, identity: ResolvedRequestIdentity): void {
+  if (identity.userAgent) headers['User-Agent'] = identity.userAgent;
+  if (identity.originator) headers.originator = identity.originator;
+  if (identity.version) headers.version = identity.version;
+}
+
 function applyHeaderOverrides(headers: Record<string, string>, settings: CodexProtocolSettings): void {
   for (const [name, value] of Object.entries(settings.headerOverrides).slice(0, 32)) {
     const normalized = name.toLowerCase();
@@ -466,6 +486,16 @@ function isValidHeaderValue(value: string): boolean {
 function createProtocolDiagnostic(snapshot: CodexProtocolSnapshot): CodexEffectiveProtocolDiagnostic {
   return {
     profile: snapshot.settings.profile,
+    requestIdentityProfile: snapshot.clientIdentity.profile,
+    identityBaseline: {
+      upstreamCommit: CODEX_IDENTITY_UPSTREAM_COMMIT,
+      compatibleCodexVersion: CODEX_CLI_COMPATIBLE_VERSION
+    },
+    clientIdentity: { ...snapshot.clientIdentity },
+    compatibilityIdentityOnly: snapshot.clientIdentity.profile === 'codexCliCompatible',
+    ...(snapshot.clientIdentity.profile === 'codexCliCompatible'
+      ? { compatibilityNotice: 'Compatibility identity only; does not provide Codex attestation.' }
+      : {}),
     clientMetadata: redactMetadataRecord(snapshot.clientMetadata),
     turnMetadata: redactObject(snapshot.turnMetadata) as Record<string, unknown>
   };

--- a/src/codexProtocol.ts
+++ b/src/codexProtocol.ts
@@ -7,7 +7,7 @@ import {
 } from './codexRequestIdentity';
 
 // Protocol baseline: openai/codex@711a5f8b3a6eb40134146ae9ec22fdcdda5e3170.
-export const CODEX_PROTOCOL_UPSTREAM_COMMIT = '3c837e568c24e4281bba4abdf3bc3c398f3fff13';
+export const CODEX_PROTOCOL_UPSTREAM_COMMIT = '711a5f8b3a6eb40134146ae9ec22fdcdda5e3170';
 export const CODEX_RESPONSES_WEBSOCKET_BETA = 'responses_websockets=2026-02-06';
 
 export const CodexHeader = {
@@ -436,7 +436,7 @@ function applyGeneratedHeaderOmissions(headers: Record<string, string>, settings
   }
 }
 
-function applyClientIdentityHeaders(headers: Record<string, string>, identity: ResolvedRequestIdentity): void {
+export function applyClientIdentityHeaders(headers: Record<string, string>, identity: ResolvedRequestIdentity): void {
   if (identity.userAgent) headers['User-Agent'] = identity.userAgent;
   if (identity.originator) headers.originator = identity.originator;
   if (identity.version) headers.version = identity.version;

--- a/src/codexRequestBuilder.ts
+++ b/src/codexRequestBuilder.ts
@@ -193,13 +193,16 @@ export function fingerprintCodexRequestEnvelope(options: CodexRequestEnvelopeOpt
     ...options,
     input: []
   }));
-  return stableSerialize({
+  const envelope = {
     requestFingerprint,
     protocolSettings: options.protocolSettings ?? null,
-    // Preserve the legacy/default extension envelope while still invalidating
-    // continuation reuse when callers switch to a non-default declaration.
-    clientIdentity: options.clientIdentity?.profile === 'extension' ? null : options.clientIdentity ?? null
-  });
+    // Omit (rather than serialize as null) to preserve the byte-for-byte legacy
+    // envelope used by already-recorded default-extension continuation markers.
+    ...(options.clientIdentity && options.clientIdentity.profile !== 'extension'
+      ? { clientIdentity: options.clientIdentity }
+      : {})
+  };
+  return stableSerialize(envelope);
 }
 
 export function areCodexRequestsIncrementallyCompatible(

--- a/src/codexRequestBuilder.ts
+++ b/src/codexRequestBuilder.ts
@@ -17,6 +17,7 @@ import {
   type CodexProtocolSettings,
   type CodexRequestIdentity
 } from './codexProtocol';
+import type { ResolvedRequestIdentity } from './codexRequestIdentity';
 
 export type CodexResponsesRequest = ResponseCreateParamsStreaming & {
   client_metadata?: Record<string, string>;
@@ -50,6 +51,7 @@ export interface CodexRequestBuilderOptions {
   websocketRequestStartedAt?: number;
   turnStartedAtUnixMs?: number;
   protocolSettings?: CodexProtocolSettings;
+  clientIdentity?: ResolvedRequestIdentity;
 }
 
 export type CodexRequestEnvelopeOptions = Omit<
@@ -88,7 +90,8 @@ export function buildCodexResponsesRequestWithMetrics(
         requestKind: options.requestKind ?? 'turn',
         turnStartedAtUnixMs: options.turnStartedAtUnixMs,
         toolPlan: options.toolPlan,
-        settings: options.protocolSettings
+        settings: options.protocolSettings,
+        clientIdentity: options.clientIdentity
       })
     : undefined;
   const metadata = protocolSnapshot
@@ -190,7 +193,13 @@ export function fingerprintCodexRequestEnvelope(options: CodexRequestEnvelopeOpt
     ...options,
     input: []
   }));
-  return stableSerialize({ requestFingerprint, protocolSettings: options.protocolSettings ?? null });
+  return stableSerialize({
+    requestFingerprint,
+    protocolSettings: options.protocolSettings ?? null,
+    // Preserve the legacy/default extension envelope while still invalidating
+    // continuation reuse when callers switch to a non-default declaration.
+    clientIdentity: options.clientIdentity?.profile === 'extension' ? null : options.clientIdentity ?? null
+  });
 }
 
 export function areCodexRequestsIncrementallyCompatible(

--- a/src/codexRequestIdentity.ts
+++ b/src/codexRequestIdentity.ts
@@ -1,0 +1,98 @@
+import os from 'node:os';
+
+export const CODEX_IDENTITY_UPSTREAM_COMMIT = '3c837e568c24e4281bba4abdf3bc3c398f3fff13';
+export const CODEX_CLI_COMPATIBLE_VERSION = '0.153.2';
+
+export type CodexRequestIdentityProfile = 'extension' | 'codexCliCompatible' | 'neutral' | 'custom';
+
+export interface CustomRequestIdentity {
+  originator?: string;
+  userAgent?: string;
+  version?: string;
+  agentName?: string;
+  source?: string;
+}
+
+export interface ResolvedRequestIdentity {
+  profile: CodexRequestIdentityProfile;
+  originator?: string;
+  userAgent?: string;
+  version?: string;
+  agentName?: string;
+  source?: string;
+}
+
+export interface RequestIdentitySettings {
+  profile: CodexRequestIdentityProfile;
+  custom: CustomRequestIdentity;
+}
+
+export interface ResolveRequestIdentityOptions {
+  profile?: CodexRequestIdentityProfile;
+  custom?: CustomRequestIdentity;
+  extensionVersion: string;
+  extensionUserAgent: string;
+  platform?: { osType: string; osVersion: string; architecture: string; terminalUserAgent: string };
+}
+
+/** Resolve client declaration once; protocol and transports only project this value. */
+export function resolveRequestIdentity(options: ResolveRequestIdentityOptions): ResolvedRequestIdentity {
+  const profile = options.profile ?? 'extension';
+  if (profile === 'neutral') {
+    return { profile };
+  }
+  if (profile === 'custom') {
+    return { profile, ...normalizeCustomRequestIdentity(options.custom) };
+  }
+  if (profile === 'codexCliCompatible') {
+    const platform = options.platform ?? currentPlatformIdentity();
+    return {
+      profile,
+      originator: 'codex_cli_rs',
+      userAgent: `codex_cli_rs/${CODEX_CLI_COMPATIBLE_VERSION} (${platform.osType} ${platform.osVersion}; ${platform.architecture}) ${platform.terminalUserAgent}`
+    };
+  }
+  return {
+    profile: 'extension',
+    originator: 'codex-for-copilot',
+    userAgent: options.extensionUserAgent,
+    version: options.extensionVersion,
+    agentName: 'codex-for-copilot',
+    source: 'vscode-language-model-provider'
+  };
+}
+
+export function normalizeCustomRequestIdentity(value: unknown): CustomRequestIdentity {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  const input = value as Record<string, unknown>;
+  return Object.fromEntries(['originator', 'userAgent', 'version', 'agentName', 'source'].flatMap((key) => {
+    const normalized = normalizeIdentityValue(input[key], key === 'userAgent' ? 512 : 128);
+    return normalized === undefined ? [] : [[key, normalized]];
+  })) as CustomRequestIdentity;
+}
+
+function normalizeIdentityValue(value: unknown, maxBytes: number): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed && Buffer.byteLength(trimmed) <= maxBytes && /^[\x20-\x7e]+$/.test(trimmed)
+    ? trimmed
+    : undefined;
+}
+
+function currentPlatformIdentity(): ResolveRequestIdentityOptions['platform'] & {} {
+  const terminal = process.env.TERM_PROGRAM?.trim();
+  const terminalVersion = process.env.TERM_PROGRAM_VERSION?.trim();
+  const terminalUserAgent = terminal
+    ? `${terminal}${terminalVersion ? `/${terminalVersion}` : ''}`
+    : process.env.TERM?.trim() || 'unknown';
+  return {
+    osType: os.type(),
+    osVersion: os.release(),
+    architecture: os.arch(),
+    terminalUserAgent: terminalUserAgent.replace(/[^\x21-\x7e]/g, '_')
+  };
+}

--- a/src/codexRequestIdentity.ts
+++ b/src/codexRequestIdentity.ts
@@ -1,6 +1,7 @@
 import os from 'node:os';
+import { readFileSync } from 'node:fs';
 
-export const CODEX_IDENTITY_UPSTREAM_COMMIT = '3c837e568c24e4281bba4abdf3bc3c398f3fff13';
+export const CODEX_IDENTITY_UPSTREAM_COMMIT = '657a993cbee87acf52d14b758ce49dbd46d1b8eb';
 export const CODEX_CLI_COMPATIBLE_VERSION = '0.153.2';
 
 export type CodexRequestIdentityProfile = 'extension' | 'codexCliCompatible' | 'neutral' | 'custom';
@@ -49,7 +50,8 @@ export function resolveRequestIdentity(options: ResolveRequestIdentityOptions): 
     return {
       profile,
       originator: 'codex_cli_rs',
-      userAgent: `codex_cli_rs/${CODEX_CLI_COMPATIBLE_VERSION} (${platform.osType} ${platform.osVersion}; ${platform.architecture}) ${platform.terminalUserAgent}`
+      userAgent: `codex_cli_rs/${CODEX_CLI_COMPATIBLE_VERSION} (${platform.osType} ${platform.osVersion}; ${platform.architecture}) ${platform.terminalUserAgent}`,
+      agentName: '/root'
     };
   }
   return {
@@ -84,15 +86,57 @@ function normalizeIdentityValue(value: unknown, maxBytes: number): string | unde
 }
 
 function currentPlatformIdentity(): ResolveRequestIdentityOptions['platform'] & {} {
-  const terminal = process.env.TERM_PROGRAM?.trim();
-  const terminalVersion = process.env.TERM_PROGRAM_VERSION?.trim();
-  const terminalUserAgent = terminal
-    ? `${terminal}${terminalVersion ? `/${terminalVersion}` : ''}`
-    : process.env.TERM?.trim() || 'unknown';
+  const platform = upstreamPlatform();
   return {
-    osType: os.type(),
-    osVersion: os.release(),
-    architecture: os.arch(),
-    terminalUserAgent: terminalUserAgent.replace(/[^\x21-\x7e]/g, '_')
+    ...platform,
+    architecture: normalizeArchitecture(os.arch()),
+    terminalUserAgent: detectTerminalUserAgent(process.env)
   };
+}
+
+/** Pinned subset of codex-terminal-detection's ordered probes and token normalization. */
+export function detectTerminalUserAgent(environment: NodeJS.ProcessEnv): string {
+  const value = (name: string) => environment[name]?.trim() || undefined;
+  const termProgram = value('TERM_PROGRAM');
+  if (termProgram) {
+    return sanitizeToken(`${termProgram}${value('TERM_PROGRAM_VERSION') ? `/${value('TERM_PROGRAM_VERSION')}` : ''}`);
+  }
+  const detected: [boolean, string, string?][] = [
+    [Boolean(value('WEZTERM_VERSION')), 'WezTerm', value('WEZTERM_VERSION')],
+    [Boolean(value('ITERM_SESSION_ID') || value('ITERM_PROFILE') || value('ITERM_PROFILE_NAME')), 'iTerm.app'],
+    [Boolean(value('TERM_SESSION_ID')), 'Apple_Terminal'],
+    [Boolean(value('KITTY_WINDOW_ID') || value('TERM')?.includes('kitty')), 'kitty'],
+    [Boolean(value('ALACRITTY_SOCKET') || value('TERM') === 'alacritty'), 'Alacritty'],
+    [Boolean(value('KONSOLE_VERSION')), 'Konsole', value('KONSOLE_VERSION')],
+    [Boolean(value('GNOME_TERMINAL_SCREEN')), 'gnome-terminal'],
+    [Boolean(value('VTE_VERSION')), 'VTE', value('VTE_VERSION')],
+    [Boolean(value('WT_SESSION')), 'WindowsTerminal']
+  ];
+  const match = detected.find(([present]) => present);
+  if (match) return sanitizeToken(`${match[1]}${match[2] ? `/${match[2]}` : ''}`);
+  return sanitizeToken(value('TERM') ?? 'unknown');
+}
+
+function sanitizeToken(value: string): string {
+  return value.replace(/[^A-Za-z0-9._/-]/g, '_');
+}
+
+function normalizeArchitecture(value: string): string {
+  return value === 'x64' ? 'x86_64' : value === 'arm64' ? 'aarch64' : value;
+}
+
+function upstreamPlatform(): Pick<NonNullable<ResolveRequestIdentityOptions['platform']>, 'osType' | 'osVersion'> {
+  if (process.platform === 'win32') return { osType: 'Windows', osVersion: os.release() };
+  if (process.platform === 'darwin') return { osType: 'Mac OS', osVersion: os.release() };
+  if (process.platform !== 'linux') return { osType: os.type(), osVersion: os.release() };
+  try {
+    const fields = Object.fromEntries(readFileSync('/etc/os-release', 'utf8').split('\n').flatMap((line) => {
+      const separator = line.indexOf('=');
+      if (separator < 1) return [];
+      return [[line.slice(0, separator), line.slice(separator + 1).replace(/^"|"$/g, '')]];
+    }));
+    return { osType: fields.NAME || 'Linux', osVersion: fields.VERSION_ID || os.release() };
+  } catch {
+    return { osType: 'Linux', osVersion: os.release() };
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,11 @@ import * as vscode from 'vscode';
 import { normalizeKnownReasoningEffort, type KnownReasoningEffort } from './reasoningEffort';
 import { MAX_NAMESPACE_FUNCTIONS } from './nativeToolSearch/nativeToolPolicy';
 import type { CodexProtocolProfileName, CodexProtocolSettings } from './codexProtocol';
+import {
+  normalizeCustomRequestIdentity,
+  type CodexRequestIdentityProfile,
+  type RequestIdentitySettings
+} from './codexRequestIdentity';
 
 export interface ModelPricing {
   input?: number;
@@ -25,6 +30,7 @@ export interface ProviderConfig {
   websocketPrewarm: 'auto' | 'enabled' | 'disabled';
   requestCompression: 'auto' | 'enabled' | 'disabled';
   protocol: CodexProtocolSettings;
+  requestIdentity: RequestIdentitySettings;
   nativeToolSearch: 'auto' | 'enabled' | 'disabled';
   nativeToolSearchMaxToolsPerNamespace: number;
   webSearch: WebSearchConfig;
@@ -57,6 +63,10 @@ export function getProviderConfig(): ProviderConfig {
       omitGeneratedHeaders: normalizeStringList(config.get('omitGeneratedHeaders', [])),
       allowUnsafeProtocolOverrides: config.get('allowUnsafeProtocolOverrides', false)
     },
+    requestIdentity: {
+      profile: normalizeRequestIdentityProfile(config.get('requestIdentityProfile', 'extension')),
+      custom: normalizeCustomRequestIdentity(config.get('customRequestIdentity', {}))
+    },
     nativeToolSearch: normalizeTriState(config.get('nativeToolSearch', 'disabled'), 'disabled'),
     nativeToolSearchMaxToolsPerNamespace: normalizeNativeToolSearchMaxToolsPerNamespace(
       config.get('nativeToolSearchMaxToolsPerNamespace', MAX_NAMESPACE_FUNCTIONS)
@@ -78,6 +88,10 @@ export function getProviderConfig(): ProviderConfig {
     maxOutputTokens: config.get('maxOutputTokens', 8192),
     modelPricingUsdPerMTok: normalizeModelPricing(config.get('modelPricingUsdPerMTok', {}))
   };
+}
+
+function normalizeRequestIdentityProfile(value: unknown): CodexRequestIdentityProfile {
+  return value === 'codexCliCompatible' || value === 'neutral' || value === 'custom' ? value : 'extension';
 }
 
 function normalizeProtocolProfile(value: unknown): CodexProtocolProfileName {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -37,6 +37,7 @@ import { getApiCredentials } from './secrets';
 import type { CodexAuthManager } from './auth/codexAuthManager';
 import { CodexIdentityManager, inputStartsNewTurn } from './codexIdentity';
 import { getCodexCompatibilityProfile, type CodexRequestIdentity } from './codexProtocol';
+import { resolveRequestIdentity } from './codexRequestIdentity';
 import { resetCodexFetchCapabilities } from './codexFetchAdapter';
 import {
   buildCodexResponsesRequest,
@@ -423,6 +424,11 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         })
       });
     }
+    const clientIdentity = resolveRequestIdentity({
+      ...config.requestIdentity,
+      extensionVersion: getExtensionVersion(this.context),
+      extensionUserAgent: buildCodexUserAgent(getExtensionVersion(this.context))
+    });
     let requestOptions: CodexRequestEnvelopeOptions = {
       compatibilityEnabled: compatibilityProfile.enabled,
       model: selectedModel.requestModel,
@@ -438,7 +444,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       maxOutputTokens: config.maxOutputTokens,
       textVerbosity: 'medium',
       includeEncryptedReasoning: true,
-      protocolSettings: config.protocol
+      protocolSettings: config.protocol,
+      clientIdentity
     };
     const toolSchemas = toolPlan;
     latency.recordContext({
@@ -897,6 +904,7 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
         extensionVersion: getExtensionVersion(this.context),
         userAgent: buildCodexUserAgent(getExtensionVersion(this.context)),
         protocolSettings: config.protocol,
+        clientIdentity,
         turnStartedAtUnixMs: branchState.turn.startedAt,
         websocketPrewarm: config.websocketPrewarm,
         requestCompression: config.requestCompression,
@@ -1503,6 +1511,11 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
     }
     this.handleConnectionConfiguration(config, authIdentity);
     const compatibilityProfile = getCodexCompatibilityProfile(config.baseURL, credentials, config.protocol.profile);
+    const clientIdentity = resolveRequestIdentity({
+      ...config.requestIdentity,
+      extensionVersion: getExtensionVersion(this.context),
+      extensionUserAgent: buildCodexUserAgent(getExtensionVersion(this.context))
+    });
     const started = compatibilityProfile.enabled && preconnectCodexResponsesWebSocket({
       baseURL: config.baseURL,
       apiKey: credentials.apiKey,
@@ -1511,7 +1524,8 @@ export class CodexModelProvider implements vscode.LanguageModelChatProvider {
       authIdentity,
       extensionVersion: getExtensionVersion(this.context),
       userAgent: buildCodexUserAgent(getExtensionVersion(this.context)),
-      protocolSettings: config.protocol
+      protocolSettings: config.protocol,
+      clientIdentity
     });
     if (started) {
       this.outputChannel.debug('response WebSocket preconnection started', {

--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -25,6 +25,7 @@ import {
   buildCodexWebSocketPreconnectHeaders,
   buildCodexRequestHeaders,
   buildCodexProtocolSnapshot,
+  applyClientIdentityHeaders,
   type CodexCompatibilityProfile,
   type CodexProtocolSettings,
   type CodexRequestIdentity
@@ -240,11 +241,7 @@ export function preconnectCodexResponsesWebSocket(options: PreconnectCodexRespon
 
   const headers = buildCodexWebSocketPreconnectHeaders({
     credentialsHeaders: options.headers,
-    clientIdentity: options.clientIdentity ?? {
-      profile: 'extension', originator: 'codex-for-copilot',
-      userAgent: options.userAgent ?? `codex-for-copilot/${options.extensionVersion ?? '0.0.0'}`,
-      version: options.extensionVersion ?? '0.0.0', agentName: 'codex-for-copilot', source: 'vscode-language-model-provider'
-    },
+    clientIdentity: resolveClientIdentity(options),
     settings: options.protocolSettings
   });
 
@@ -961,7 +958,9 @@ function createRequestBuilderOptions(options: StreamResponseTextOptions): CodexR
 
 function buildDynamicHeaders(options: StreamResponseTextOptions, transport: 'http' | 'websocket'): Record<string, string> {
   if (!options.compatibilityProfile?.enabled || !options.identity) {
-    return { ...options.headers };
+    const headers = { ...options.headers };
+    applyClientIdentityHeaders(headers, resolveClientIdentity(options));
+    return headers;
   }
   const snapshot = buildCodexProtocolSnapshot({
     identity: options.identity,
@@ -977,12 +976,17 @@ function buildDynamicHeaders(options: StreamResponseTextOptions, transport: 'htt
     turnMetadata: metadata,
     snapshot,
     turnState: options.turnState,
-    clientIdentity: options.clientIdentity ?? {
-      profile: 'extension', originator: 'codex-for-copilot',
-      userAgent: options.userAgent ?? `codex-for-copilot/${options.extensionVersion ?? '0.0.0'}`,
-      version: options.extensionVersion ?? '0.0.0', agentName: 'codex-for-copilot', source: 'vscode-language-model-provider'
-    }
+    clientIdentity: resolveClientIdentity(options)
   }, transport);
+}
+
+function resolveClientIdentity(options: Pick<StreamResponseTextOptions, 'clientIdentity' | 'extensionVersion' | 'userAgent' | 'headers'>): ResolvedRequestIdentity {
+  return options.clientIdentity ?? resolveRequestIdentity({
+    extensionVersion: options.extensionVersion ?? '0.0.0',
+    extensionUserAgent: options.userAgent
+      ?? getHeader(options.headers, 'User-Agent')
+      ?? `codex-for-copilot/${options.extensionVersion ?? '0.0.0'}`
+  });
 }
 
 function getHeader(headers: Record<string, string> | undefined, name: string): string | undefined {

--- a/src/responsesClient.ts
+++ b/src/responsesClient.ts
@@ -42,6 +42,7 @@ import {
   type CodexConnectionScopeBase
 } from './codexConnectionManager';
 import type { CodexWebSocketHandshake, CodexWebSocketPreconnectionObserver } from './codexWebSocketSession';
+import { resolveRequestIdentity, type ResolvedRequestIdentity } from './codexRequestIdentity';
 import type { CodexFunctionCallEvent, CodexToolPlan } from './nativeToolSearch/nativeToolTypes';
 import {
   extractWebSearchSources,
@@ -127,6 +128,7 @@ export interface StreamResponseTextOptions {
   extensionVersion?: string;
   userAgent?: string;
   protocolSettings?: CodexProtocolSettings;
+  clientIdentity?: ResolvedRequestIdentity;
   turnStartedAtUnixMs?: number;
   websocketPrewarm?: 'auto' | 'enabled' | 'disabled';
   requestCompression?: RequestCompressionPolicy;
@@ -188,6 +190,7 @@ export interface PreconnectCodexResponsesWebSocketOptions {
   extensionVersion?: string;
   userAgent?: string;
   protocolSettings?: CodexProtocolSettings;
+  clientIdentity?: ResolvedRequestIdentity;
   onConnected?: CodexWebSocketPreconnectionObserver['onConnected'];
   onError?: CodexWebSocketPreconnectionObserver['onError'];
 }
@@ -237,8 +240,11 @@ export function preconnectCodexResponsesWebSocket(options: PreconnectCodexRespon
 
   const headers = buildCodexWebSocketPreconnectHeaders({
     credentialsHeaders: options.headers,
-    extensionVersion: options.extensionVersion ?? '0.0.0',
-    userAgent: options.userAgent ?? `codex-for-copilot/${options.extensionVersion ?? '0.0.0'}`,
+    clientIdentity: options.clientIdentity ?? {
+      profile: 'extension', originator: 'codex-for-copilot',
+      userAgent: options.userAgent ?? `codex-for-copilot/${options.extensionVersion ?? '0.0.0'}`,
+      version: options.extensionVersion ?? '0.0.0', agentName: 'codex-for-copilot', source: 'vscode-language-model-provider'
+    },
     settings: options.protocolSettings
   });
 
@@ -948,6 +954,7 @@ function createRequestBuilderOptions(options: StreamResponseTextOptions): CodexR
     textVerbosity: 'medium',
     includeEncryptedReasoning: true,
     protocolSettings: options.protocolSettings,
+    clientIdentity: options.clientIdentity,
     turnStartedAtUnixMs: options.turnStartedAtUnixMs
   };
 }
@@ -960,7 +967,8 @@ function buildDynamicHeaders(options: StreamResponseTextOptions, transport: 'htt
     identity: options.identity,
     turnStartedAtUnixMs: options.turnStartedAtUnixMs,
     toolPlan: options.toolPlan,
-    settings: options.protocolSettings
+    settings: options.protocolSettings,
+    clientIdentity: options.clientIdentity
   });
   const metadata = snapshot.compatibilityTurnMetadata;
   return buildCodexRequestHeaders({
@@ -969,8 +977,11 @@ function buildDynamicHeaders(options: StreamResponseTextOptions, transport: 'htt
     turnMetadata: metadata,
     snapshot,
     turnState: options.turnState,
-    extensionVersion: options.extensionVersion ?? '0.0.0',
-    userAgent: options.userAgent ?? `codex-for-copilot/${options.extensionVersion ?? '0.0.0'}`
+    clientIdentity: options.clientIdentity ?? {
+      profile: 'extension', originator: 'codex-for-copilot',
+      userAgent: options.userAgent ?? `codex-for-copilot/${options.extensionVersion ?? '0.0.0'}`,
+      version: options.extensionVersion ?? '0.0.0', agentName: 'codex-for-copilot', source: 'vscode-language-model-provider'
+    }
   }, transport);
 }
 
@@ -988,6 +999,7 @@ function createResponsesWsOptions(headers?: Record<string, string>, baseURL?: st
 }
 
 export { shouldBypassProxy } from './proxy';
+export { resolveRequestIdentity };
 
 function getManagedConnectionScope(options: StreamResponseTextOptions): CodexConnectionScope | undefined {
   if (!options.compatibilityProfile?.enabled || !options.identity || !options.authIdentity) {

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -39,6 +39,7 @@
 - Reasoning-option tests must prove recognized `modelOptions.thinking` shapes override the model's default effort, and request diagnostics must identify tool-output full replay separately from ordinary prior-response reuse.
 - A model-generated tool-loop test must verify the first tool call is emitted once and the following tool result is replayed with its matching call.
 - The Extension Development Host smoke must exercise `vscode.lm.selectChatModels()` and a complete tool-call/result loop, so the provider-facing VS Code API boundary is covered separately from direct provider tests.
+- The Extension Development Host smoke pins the `extension` request-identity profile and asserts its generated `User-Agent`, `originator`, and `version` headers; restore that setting after each run.
 - Repeated reasoning deltas for one Responses item must retain one thinking-part ID, and reasoning that arrives after visible text must not interrupt the text sequence.
 - Complete function calls must be reported from `response.function_call_arguments.done` before later text, using the non-empty `output_item.added` name when the early event omits it; `response.output_item.done` must not duplicate the tool call.
 - Malformed historical function calls and their matched outputs must be excluded, while valid standalone tool outputs remain available for continuation.

--- a/test/extensionHostSmoke.cjs
+++ b/test/extensionHostSmoke.cjs
@@ -60,7 +60,7 @@ async function run() {
 
     if (request.method === 'GET' && request.url === '/backend-api/wham/usage') {
       assert.strictEqual(request.headers.authorization, 'Bearer extension-host-smoke-token');
-      assert.strictEqual(request.headers['user-agent'], 'local.codex-for-copilot Codex for Copilot');
+      assert.strictEqual(request.headers['user-agent'], expectedExtensionUserAgent());
       response.writeHead(200, { 'content-type': 'application/json' });
       response.end('{}');
       return;
@@ -85,7 +85,9 @@ async function run() {
     assert.strictEqual(request.method, 'POST');
     assert.strictEqual(request.url, '/backend-api/codex/responses');
     assert(request.headers.authorization?.startsWith('Bearer '), 'Missing bearer authorization header.');
-    assert.strictEqual(request.headers['user-agent'], 'local.codex-for-copilot Codex for Copilot');
+    assert.strictEqual(request.headers['user-agent'], expectedExtensionUserAgent());
+    assert.strictEqual(request.headers.originator, 'codex-for-copilot');
+    assert.strictEqual(request.headers.version, manifest.version);
     assert.strictEqual(body.instructions, 'Extension host smoke instructions');
     assert.strictEqual(body.stream, true);
     assert.strictEqual(body.store, false);
@@ -171,6 +173,7 @@ async function run() {
   let originalInstructions;
   let originalTransport;
   let originalIncludeHiddenModels;
+  let originalRequestIdentityProfile;
   let configCleanupFailure;
   let serverCleanupFailure;
   try {
@@ -181,10 +184,12 @@ async function run() {
     originalInstructions = config.inspect('instructions')?.globalValue;
     originalTransport = config.inspect('transport')?.globalValue;
     originalIncludeHiddenModels = config.inspect('includeHiddenModels')?.globalValue;
+    originalRequestIdentityProfile = config.inspect('requestIdentityProfile')?.globalValue;
     await config.update('baseURL', `http://127.0.0.1:${address.port}/backend-api/codex/responses`, vscode.ConfigurationTarget.Global);
     await config.update('instructions', 'Extension host smoke instructions', vscode.ConfigurationTarget.Global);
     await config.update('transport', 'http', vscode.ConfigurationTarget.Global);
     await config.update('includeHiddenModels', true, vscode.ConfigurationTarget.Global);
+    await config.update('requestIdentityProfile', 'extension', vscode.ConfigurationTarget.Global);
     assert.strictEqual(config.get('includeHiddenModels'), true, 'Hidden-model opt-in was not effective before activation.');
 
     await extension.activate();
@@ -263,6 +268,7 @@ async function run() {
         await config.update('instructions', originalInstructions, vscode.ConfigurationTarget.Global);
         await config.update('transport', originalTransport, vscode.ConfigurationTarget.Global);
         await config.update('includeHiddenModels', originalIncludeHiddenModels, vscode.ConfigurationTarget.Global);
+        await config.update('requestIdentityProfile', originalRequestIdentityProfile, vscode.ConfigurationTarget.Global);
       }
     } catch (error) {
       configCleanupFailure = error;
@@ -301,6 +307,10 @@ function writeTextResponse(response, text, responseId) {
   response.write(`data: ${JSON.stringify({ type: 'response.completed', response: { id: responseId, object: 'response', status: 'completed' } })}\n\n`);
   response.write('data: [DONE]\n\n');
   response.end();
+}
+
+function expectedExtensionUserAgent() {
+  return `codex-for-copilot/${manifest.version} (${process.platform}; ${process.arch}; vscode/${vscode.version})`;
 }
 
 function listen(server) {

--- a/test/fixtures/codex-cli-identity.json
+++ b/test/fixtures/codex-cli-identity.json
@@ -1,5 +1,5 @@
 {
-  "upstreamCommit": "3c837e568c24e4281bba4abdf3bc3c398f3fff13",
+  "upstreamCommit": "657a993cbee87acf52d14b758ce49dbd46d1b8eb",
   "codexVersion": "0.153.2",
   "platform": {
     "osType": "Linux",
@@ -10,6 +10,7 @@
   "identity": {
     "profile": "codexCliCompatible",
     "originator": "codex_cli_rs",
-    "userAgent": "codex_cli_rs/0.153.2 (Linux 6.8.0-test; x86_64) vscode/1.104.0"
+    "userAgent": "codex_cli_rs/0.153.2 (Linux 6.8.0-test; x86_64) vscode/1.104.0",
+    "agentName": "/root"
   }
 }

--- a/test/fixtures/codex-cli-identity.json
+++ b/test/fixtures/codex-cli-identity.json
@@ -1,0 +1,15 @@
+{
+  "upstreamCommit": "3c837e568c24e4281bba4abdf3bc3c398f3fff13",
+  "codexVersion": "0.153.2",
+  "platform": {
+    "osType": "Linux",
+    "osVersion": "6.8.0-test",
+    "architecture": "x86_64",
+    "terminalUserAgent": "vscode/1.104.0"
+  },
+  "identity": {
+    "profile": "codexCliCompatible",
+    "originator": "codex_cli_rs",
+    "userAgent": "codex_cli_rs/0.153.2 (Linux 6.8.0-test; x86_64) vscode/1.104.0"
+  }
+}

--- a/test/realBackendProbe.mjs
+++ b/test/realBackendProbe.mjs
@@ -15,6 +15,9 @@ const requestedTransport = process.env.CODEX_TEST_TRANSPORT === 'websocket'
   : process.env.CODEX_TEST_TRANSPORT === 'auto'
     ? 'auto'
     : 'http';
+const requestedIdentityProfile = ['extension', 'codexCliCompatible', 'neutral', 'custom'].includes(process.env.CODEX_TEST_REQUEST_IDENTITY)
+  ? process.env.CODEX_TEST_REQUEST_IDENTITY
+  : 'extension';
 const runContinuationProbe = process.env.CODEX_TEST_CONTINUATION === '1';
 const runPreconnectionProbe = process.env.CODEX_TEST_PRECONNECT === '1';
 const shouldRunToolContinuationProbe = process.env.CODEX_TEST_TOOL_CONTINUATION === '1';
@@ -100,6 +103,7 @@ try {
     disposeReusableResponsesWebSockets,
     isResponsesContinuationMissError,
     preconnectCodexResponsesWebSocket,
+    resolveRequestIdentity,
     streamResponseText
   } = require(responsesBundlePath);
   const auth = JSON.parse(await readFile(process.env.CODEX_AUTH_FILE ?? join(homedir(), '.codex', 'auth.json'), 'utf8'));
@@ -163,6 +167,12 @@ try {
     turnId: randomUUID(),
     windowId: randomUUID()
   };
+  const clientIdentity = resolveRequestIdentity({
+    profile: requestedIdentityProfile,
+    custom: requestedIdentityProfile === 'custom' ? { originator: 'codex-real-backend-probe', userAgent: 'codex-real-backend-probe/1', agentName: 'codex-real-backend-probe', source: 'real-backend-probe' } : undefined,
+    extensionVersion: 'real-backend-probe',
+    extensionUserAgent: 'codex-for-copilot/real-backend-probe'
+  });
   let preconnection = null;
   if (runPreconnectionProbe) {
     if (requestedTransport === 'http') {
@@ -186,6 +196,7 @@ try {
       authIdentity: `real-probe:${auth.tokens.account_id ?? 'default'}`,
       extensionVersion: 'real-backend-probe',
       userAgent: 'codex-for-copilot/real-backend-probe',
+      clientIdentity,
       onConnected: resolveHandshake,
       onError: rejectHandshake
     });
@@ -206,6 +217,7 @@ try {
     authIdentity: `real-probe:${auth.tokens.account_id ?? 'default'}`,
     extensionVersion: 'real-backend-probe',
     userAgent: 'codex-for-copilot/real-backend-probe',
+    clientIdentity,
     websocketPrewarm: requestedPrewarm,
     requestCompression: process.env.CODEX_TEST_COMPRESSION === '1' ? 'enabled' : 'auto',
     store: requestStore,
@@ -270,6 +282,7 @@ try {
       authIdentity: `real-probe:${auth.tokens.account_id ?? 'default'}`,
       extensionVersion: 'real-backend-probe',
       userAgent: 'codex-for-copilot/real-backend-probe',
+      clientIdentity,
       websocketPrewarm: requestedPrewarm,
       requestCompression: process.env.CODEX_TEST_COMPRESSION === '1' ? 'enabled' : 'auto',
       store: requestStore,

--- a/test/smokeCodexProtocol.mjs
+++ b/test/smokeCodexProtocol.mjs
@@ -9,11 +9,12 @@ try {
     buildCodexProtocolSnapshot,
     buildCodexRequestHeaders,
     buildCodexWebSocketPreconnectHeaders,
+    applyClientIdentityHeaders,
     createCodexTurnMetadata,
     getCodexCompatibilityProfile,
     stableSerializeCodexMetadata
   } = loaded.exports;
-  const { resolveRequestIdentity, normalizeCustomRequestIdentity, CODEX_IDENTITY_UPSTREAM_COMMIT, CODEX_CLI_COMPATIBLE_VERSION } = loadedIdentity.exports;
+  const { resolveRequestIdentity, normalizeCustomRequestIdentity, detectTerminalUserAgent, CODEX_IDENTITY_UPSTREAM_COMMIT, CODEX_CLI_COMPATIBLE_VERSION } = loadedIdentity.exports;
   const fixture = JSON.parse(await readFile(new URL('./fixtures/codex-cli-identity.json', import.meta.url), 'utf8'));
   const identity = {
     installationId: '11111111-1111-4111-8111-111111111111',
@@ -68,6 +69,13 @@ try {
   assertEqual(JSON.stringify(cliIdentity), JSON.stringify(fixture.identity), 'pinned CLI identity fixture');
   assertEqual(CODEX_IDENTITY_UPSTREAM_COMMIT, fixture.upstreamCommit, 'identity upstream commit');
   assertEqual(CODEX_CLI_COMPATIBLE_VERSION, fixture.codexVersion, 'compatible Codex version');
+  assertEqual(cliIdentity.agentName, '/root', 'CLI root turn agent path');
+  assertEqual(cliIdentity.source, undefined, 'CLI root turn does not invent a source');
+  assertEqual(detectTerminalUserAgent({ WT_SESSION: '1' }), 'WindowsTerminal', 'Windows Terminal probe');
+  assertEqual(detectTerminalUserAgent({ ITERM_SESSION_ID: '1' }), 'iTerm.app', 'macOS iTerm probe');
+  assertEqual(detectTerminalUserAgent({ WEZTERM_VERSION: '20240203' }), 'WezTerm/20240203', 'Linux WezTerm probe');
+  assertEqual(detectTerminalUserAgent({ KITTY_WINDOW_ID: '1' }), 'kitty', 'kitty probe');
+  assertEqual(detectTerminalUserAgent({ TERM_PROGRAM: 'tmux', TERM_PROGRAM_VERSION: '3.4', TERM: 'screen' }), 'tmux/3.4', 'tmux declaration is normalized');
   for (const profile of ['extension', 'codexCliCompatible', 'neutral', 'custom']) {
     const clientIdentity = resolveRequestIdentity({ profile, extensionVersion: '1.2.3', extensionUserAgent: 'codex-for-copilot/1.2.3 (test)', custom: { originator: 'third-party', userAgent: 'third-party/4', version: '4', agentName: 'third-party', source: 'gateway' }, platform: fixture.platform });
     const snapshot = buildCodexProtocolSnapshot({ identity, turnStartedAtUnixMs, clientIdentity });
@@ -82,6 +90,14 @@ try {
       assertEqual(JSON.stringify({ http, metadata: snapshot.turnMetadata }).includes('codex-for-copilot'), false, 'neutral has no extension branding');
       assertEqual(http['session-id'], identity.sessionId, 'neutral retains protocol identity');
     }
+  }
+  for (const profile of ['extension', 'codexCliCompatible', 'neutral', 'custom']) {
+    const clientIdentity = resolveRequestIdentity({ profile, extensionVersion: '1.2.3', extensionUserAgent: 'codex-for-copilot/1.2.3', custom: { originator: 'custom-origin', userAgent: 'custom/1' }, platform: fixture.platform });
+    const minimalHeaders = { Authorization: 'Bearer real' };
+    applyClientIdentityHeaders(minimalHeaders, clientIdentity);
+    assertEqual(minimalHeaders.originator, clientIdentity.originator, `minimal + ${profile} originator`);
+    assertEqual(minimalHeaders['User-Agent'], clientIdentity.userAgent, `minimal + ${profile} User-Agent`);
+    assertEqual(minimalHeaders['session-id'], undefined, `minimal + ${profile} omits protocol session`);
   }
   const malformed = normalizeCustomRequestIdentity({ originator: 'bad\r\nvalue', userAgent: '\u0000bad', source: 'ok', version: 'x'.repeat(129) });
   assertEqual(JSON.stringify(malformed), JSON.stringify({ source: 'ok' }), 'malformed custom identity is removed');

--- a/test/smokeCodexProtocol.mjs
+++ b/test/smokeCodexProtocol.mjs
@@ -1,15 +1,20 @@
 import { loadBundled, assertEqual } from './testBundleHelper.mjs';
+import { readFile } from 'node:fs/promises';
 
 const loaded = await loadBundled('src/codexProtocol.ts');
+const loadedIdentity = await loadBundled('src/codexRequestIdentity.ts');
 try {
   const {
     CODEX_RESPONSES_WEBSOCKET_BETA,
     buildCodexProtocolSnapshot,
     buildCodexRequestHeaders,
+    buildCodexWebSocketPreconnectHeaders,
     createCodexTurnMetadata,
     getCodexCompatibilityProfile,
     stableSerializeCodexMetadata
   } = loaded.exports;
+  const { resolveRequestIdentity, normalizeCustomRequestIdentity, CODEX_IDENTITY_UPSTREAM_COMMIT, CODEX_CLI_COMPATIBLE_VERSION } = loadedIdentity.exports;
+  const fixture = JSON.parse(await readFile(new URL('./fixtures/codex-cli-identity.json', import.meta.url), 'utf8'));
   const identity = {
     installationId: '11111111-1111-4111-8111-111111111111',
     sessionId: '22222222-2222-4222-8222-222222222222',
@@ -18,13 +23,13 @@ try {
     windowId: '55555555-5555-4555-8555-555555555555'
   };
   const turnStartedAtUnixMs = 1_787_000_000_000;
-  const metadata = stableSerializeCodexMetadata(createCodexTurnMetadata(identity, 'turn', turnStartedAtUnixMs));
+  const extensionIdentity = { profile: 'extension', originator: 'codex-for-copilot', userAgent: 'codex-for-copilot/1.2.3 (test)', version: '1.2.3', agentName: 'codex-for-copilot', source: 'vscode-language-model-provider' };
+  const metadata = stableSerializeCodexMetadata(createCodexTurnMetadata(identity, 'turn', turnStartedAtUnixMs, undefined, extensionIdentity));
   const headers = buildCodexRequestHeaders({
     credentialsHeaders: { 'ChatGPT-Account-ID': 'acct-test' },
     identity,
     turnMetadata: metadata,
-    extensionVersion: '1.2.3',
-    userAgent: 'codex-for-copilot/1.2.3 (test)'
+    clientIdentity: extensionIdentity
   }, 'websocket');
   assertEqual(CODEX_RESPONSES_WEBSOCKET_BETA, 'responses_websockets=2026-02-06', 'beta baseline');
   assertEqual(headers['OpenAI-Beta'], CODEX_RESPONSES_WEBSOCKET_BETA, 'beta header');
@@ -35,6 +40,7 @@ try {
   const safeSnapshot = buildCodexProtocolSnapshot({
     identity,
     turnStartedAtUnixMs,
+    clientIdentity: extensionIdentity,
     settings: {
       headerOverrides: { originator: 'custom-client', Authorization: 'must-not-win', 'x-extra': 'yes', 'x-codex-routing-hint': 'route-a' },
       clientMetadataOverrides: { custom_surface: 'vscode', thread_id: 'must-not-win' },
@@ -47,8 +53,7 @@ try {
     turnMetadata: safeSnapshot.compatibilityTurnMetadata,
     snapshot: safeSnapshot,
     turnState: 'sticky-secret',
-    extensionVersion: '1.2.3',
-    userAgent: 'codex-for-copilot/1.2.3 (test)'
+    clientIdentity: extensionIdentity
   }, 'http');
   assertEqual(safeHeaders.originator, 'custom-client', 'safe header override');
   assertEqual(safeHeaders['x-extra'], 'yes', 'extra header override');
@@ -59,6 +64,34 @@ try {
   assertEqual(safeSnapshot.clientMetadata.thread_id, identity.threadId, 'reserved client metadata is protected');
   assertEqual(safeSnapshot.turnMetadata.custom_surface, 'vscode', 'extra turn metadata is accepted');
   assertEqual(safeSnapshot.clientMetadata.custom_surface, 'vscode', 'extra client metadata is accepted');
+  const cliIdentity = resolveRequestIdentity({ profile: 'codexCliCompatible', extensionVersion: '1.2.3', extensionUserAgent: 'unused', platform: fixture.platform });
+  assertEqual(JSON.stringify(cliIdentity), JSON.stringify(fixture.identity), 'pinned CLI identity fixture');
+  assertEqual(CODEX_IDENTITY_UPSTREAM_COMMIT, fixture.upstreamCommit, 'identity upstream commit');
+  assertEqual(CODEX_CLI_COMPATIBLE_VERSION, fixture.codexVersion, 'compatible Codex version');
+  for (const profile of ['extension', 'codexCliCompatible', 'neutral', 'custom']) {
+    const clientIdentity = resolveRequestIdentity({ profile, extensionVersion: '1.2.3', extensionUserAgent: 'codex-for-copilot/1.2.3 (test)', custom: { originator: 'third-party', userAgent: 'third-party/4', version: '4', agentName: 'third-party', source: 'gateway' }, platform: fixture.platform });
+    const snapshot = buildCodexProtocolSnapshot({ identity, turnStartedAtUnixMs, clientIdentity });
+    const http = buildCodexRequestHeaders({ credentialsHeaders: { Authorization: 'Bearer real' }, identity, turnMetadata: snapshot.compatibilityTurnMetadata, snapshot, turnState: 'real-state', clientIdentity }, 'http');
+    const websocket = buildCodexRequestHeaders({ credentialsHeaders: { Authorization: 'Bearer real' }, identity, turnMetadata: snapshot.compatibilityTurnMetadata, snapshot, turnState: 'real-state', clientIdentity }, 'websocket');
+    const preconnect = buildCodexWebSocketPreconnectHeaders({ credentialsHeaders: { Authorization: 'Bearer real' }, clientIdentity });
+    assertEqual(http.originator, websocket.originator, `${profile} transport originator parity`);
+    assertEqual(http['User-Agent'], websocket['User-Agent'], `${profile} transport UA parity`);
+    assertEqual(preconnect.originator, websocket.originator, `${profile} preconnect originator parity`);
+    assertEqual(preconnect['User-Agent'], websocket['User-Agent'], `${profile} preconnect UA parity`);
+    if (profile === 'neutral') {
+      assertEqual(JSON.stringify({ http, metadata: snapshot.turnMetadata }).includes('codex-for-copilot'), false, 'neutral has no extension branding');
+      assertEqual(http['session-id'], identity.sessionId, 'neutral retains protocol identity');
+    }
+  }
+  const malformed = normalizeCustomRequestIdentity({ originator: 'bad\r\nvalue', userAgent: '\u0000bad', source: 'ok', version: 'x'.repeat(129) });
+  assertEqual(JSON.stringify(malformed), JSON.stringify({ source: 'ok' }), 'malformed custom identity is removed');
+  const unsafeSnapshot = buildCodexProtocolSnapshot({ identity, clientIdentity: extensionIdentity, settings: { allowUnsafeProtocolOverrides: true, headerOverrides: { Authorization: 'fake', 'x-codex-turn-state': 'fake', 'OpenAI-Beta': 'fake', 'Sec-WebSocket-Key': 'fake', 'x-oai-attestation': 'fake' } } });
+  const protectedHeaders = buildCodexRequestHeaders({ credentialsHeaders: { Authorization: 'Bearer real' }, identity, snapshot: unsafeSnapshot, turnMetadata: unsafeSnapshot.compatibilityTurnMetadata, turnState: 'real-state', clientIdentity: extensionIdentity }, 'websocket');
+  assertEqual(protectedHeaders.Authorization, 'Bearer real', 'unsafe cannot replace credentials');
+  assertEqual(protectedHeaders['x-codex-turn-state'], 'real-state', 'unsafe cannot replace Turn State');
+  assertEqual(protectedHeaders['OpenAI-Beta'], CODEX_RESPONSES_WEBSOCKET_BETA, 'unsafe cannot replace WebSocket beta');
+  assertEqual(protectedHeaders['Sec-WebSocket-Key'], undefined, 'unsafe cannot forge WebSocket security');
+  assertEqual(protectedHeaders['x-oai-attestation'], undefined, 'unsafe cannot forge attestation');
   const toolSnapshot = buildCodexProtocolSnapshot({
     identity,
     turnStartedAtUnixMs,
@@ -89,5 +122,6 @@ try {
   assertEqual(getCodexCompatibilityProfile('https://chatgpt.com/backend-api/codex/responses', { kind: 'codexAccessToken' }, 'minimal').enabled, false, 'minimal profile disabled');
   console.log('Smoke test passed: Codex protocol constants, headers, gating, and metadata are stable.');
 } finally {
+  await loadedIdentity.dispose();
   await loaded.dispose();
 }

--- a/test/smokeCodexRequestBuilder.mjs
+++ b/test/smokeCodexRequestBuilder.mjs
@@ -9,6 +9,7 @@ try {
     buildCodexResponsesRequest,
     buildCodexResponsesRequestWithMetrics,
     buildCodexResponsesWebSocketEvent,
+    fingerprintCodexRequestEnvelope,
     resetCodexToolSchemaCache
   } = loaded.exports;
   const identity = {
@@ -31,6 +32,13 @@ try {
     textVerbosity: 'medium',
     turnStartedAtUnixMs: 1_787_000_000_000
   };
+  const legacyEnvelope = fingerprintCodexRequestEnvelope(base);
+  const defaultIdentityEnvelope = fingerprintCodexRequestEnvelope({
+    ...base,
+    clientIdentity: { profile: 'extension', originator: 'codex-for-copilot', userAgent: 'codex-for-copilot/1.8.1' }
+  });
+  assertEqual(defaultIdentityEnvelope, legacyEnvelope, 'default extension identity preserves legacy envelope fingerprint');
+  assertEqual(fingerprintCodexRequestEnvelope({ ...base, clientIdentity: { profile: 'neutral' } }) === legacyEnvelope, false, 'effective identity change invalidates envelope fingerprint');
   const request = buildCodexResponsesRequest(base);
   const compatibilityDefaultReasoningRequest = buildCodexResponsesRequest({
     ...base,

--- a/test/smokeCodexRequestBuilder.mjs
+++ b/test/smokeCodexRequestBuilder.mjs
@@ -33,6 +33,8 @@ try {
     turnStartedAtUnixMs: 1_787_000_000_000
   };
   const legacyEnvelope = fingerprintCodexRequestEnvelope(base);
+  const expectedLegacyEnvelope = '{"protocolSettings":null,"requestFingerprint":"{\\"include\\":[\\"reasoning.encrypted_content\\"],\\"instructions\\":\\"instructions\\",\\"model\\":\\"gpt-test\\",\\"parallel_tool_calls\\":true,\\"reasoning\\":{\\"effort\\":\\"high\\",\\"summary\\":\\"auto\\"},\\"store\\":false,\\"stream\\":true,\\"text\\":{\\"verbosity\\":\\"medium\\"},\\"tool_choice\\":\\"auto\\",\\"tools\\":[{\\"description\\":\\"Read\\",\\"name\\":\\"read\\",\\"parameters\\":{\\"type\\":\\"object\\"},\\"strict\\":false,\\"type\\":\\"function\\"}]}"}';
+  assertEqual(legacyEnvelope, expectedLegacyEnvelope, 'legacy envelope fingerprint remains byte-for-byte stable');
   const defaultIdentityEnvelope = fingerprintCodexRequestEnvelope({
     ...base,
     clientIdentity: { profile: 'extension', originator: 'codex-for-copilot', userAgent: 'codex-for-copilot/1.8.1' }


### PR DESCRIPTION
### Motivation

- Decouple client-declared identity from existing Codex protocol semantics so the extension can declare who it is (branding) without changing protocol/session/turn identity or forging attestation. 
- Provide a reproducible, pinned CLI-compatible declaration baseline instead of guessing an upstream CLI package string. 
- Make HTTP, WebSocket, and WebSocket preconnect use one resolved identity projection so preconnect and formal requests never disagree. 

### Description

- Add a new client-identity layer in `src/codexRequestIdentity.ts` that defines `CodexRequestIdentityProfile` (`extension`, `codexCliCompatible`, `neutral`, `custom`) and a single resolver `resolveRequestIdentity(...)` that yields a `ResolvedRequestIdentity`. 
- Pin the CLI-compatible baseline (`CODEX_IDENTITY_UPSTREAM_COMMIT = '3c837e568c...'` and `CODEX_CLI_COMPATIBLE_VERSION = '0.153.2'`) and generate the CLI-shaped User-Agent from originator/version/OS/arch/terminal tokens without creating attestation fields. 
- Refactor protocol header and metadata projections so they consume a `ResolvedRequestIdentity` (changes to `src/codexProtocol.ts`, `src/responsesClient.ts`, `src/codexRequestBuilder.ts`, and `src/provider.ts`) and add helpers to apply client identity headers/metadata. 
- Preserve and strengthen protected headers and invariants so credentials, `x-codex-turn-state`, WebSocket security/`Sec-WebSocket-*`, transport invariants, and attestation/internal agent headers cannot be forged by identity profiles or user overrides. 
- Add VS Code settings in `package.json`: `codexModelProvider.requestIdentityProfile` and `codexModelProvider.customRequestIdentity` with validation limits and UI text for each profile. 
- Extend diagnostics and parity documentation so `Codex: Show Effective Protocol` reports the effective request identity, pinned upstream baseline, and a compatibility notice for `codexCliCompatible`; update `docs/codex-cli-parity.md`. 
- Add deterministic test fixtures and extend smoke tests to cover identity profiles, preconnect/request parity, neutral profile de-branding, malformed custom identity, and protected-header behavior (`test/fixtures/codex-cli-identity.json`, updates to `test/smokeCodexProtocol.mjs` and `test/realBackendProbe.mjs`). 

### Testing

- Ran type check with `npm run check` which succeeded. 
- Ran the deterministic parity suite with `npm run test:codex-parity` which completed successfully. 
- Built the bundle with `npm run compile` which succeeded. 
- Ran the smoke suites (`npm run test:smoke`) and most smoke tests (protocol, HTTP, WebSocket, preconnect, compression, native tool-search, request-building and many provider fallbacks) passed in this environment, but a full smoke run was intermittently impacted by the environment's forced HTTP proxy (caused a proxy-403 on a local mock path) so one provider fallback assertion required an environment proxy workaround; this is an environmental test flake rather than a functional regression. 
- Real-backend probe (`npm run test:real-backend`) was not executed here because `~/.codex/auth.json` was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9aad22e68c83249caf31a432e8439f)